### PR TITLE
Fix Opus 4.1 provider_model_id to use us. prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Claude Opus 4.1: Changed `provider_model_id` from `global.` to `us.` prefix - Opus 4.1 is only available with `us.` inference profile on AWS Bedrock, not `global.` like Haiku and Sonnet
 - Claude Haiku 4.5 and Sonnet 4.5: Override `tools.strict=false` to disable object generation hack - waiting for native Anthropic JSON support instead
 - Model spec parsing now handles ambiguous formats (specs with both `:` and `@` separators) by attempting provider validation to determine the correct format
 - Removed overly strict character validation that rejected `@` in model IDs when using colon format and `:` in model IDs when using @ format

--- a/priv/llm_db/local/amazon_bedrock/anthropic_claude-opus-4-1.toml
+++ b/priv/llm_db/local/amazon_bedrock/anthropic_claude-opus-4-1.toml
@@ -5,7 +5,8 @@ family = "claude"
 release_date = "2025-08-05"
 
 # Bedrock requires inference profile prefix for API calls
-provider_model_id = "global.anthropic.claude-opus-4-1-20250805-v1:0"
+# Note: Opus 4.1 only available with us. prefix, not global.
+provider_model_id = "us.anthropic.claude-opus-4-1-20250805-v1:0"
 
 # Inference profile aliases - allow routing across AWS regions
 aliases = [

--- a/priv/llm_db/snapshot.json
+++ b/priv/llm_db/snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-11-16T18:27:14.448342Z",
+  "generated_at": "2025-11-16T19:05:03.377532Z",
   "providers": {
     "z-ai": {
       "base_url": null,
@@ -13159,7 +13159,7 @@
           "model": null,
           "name": "Claude Opus 4.1",
           "provider": "amazon_bedrock",
-          "provider_model_id": "global.anthropic.claude-opus-4-1-20250805-v1:0",
+          "provider_model_id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
           "release_date": "2025-08-05",
           "tags": null
         },


### PR DESCRIPTION
## Summary

Claude Opus 4.1 is only available with `us.` inference profile on AWS Bedrock, not `global.` prefix like Haiku and Sonnet.

## Changes

- Updated `provider_model_id` from `global.anthropic.claude-opus-4-1-20250805-v1:0` to `us.anthropic.claude-opus-4-1-20250805-v1:0`
- Regenerated snapshot.json
- Updated CHANGELOG.md

## Testing

Verified with req_llm fixture recording - Opus 4.1 now records successfully with the `us.` prefix.