### PR TITLE
Fix mix command names in README for llmdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,10 @@ Snapshot is shipped with the library. To rebuild with fresh data:
 
 ```bash
 # Fetch upstream data (optional)
-mix llm_db.pull
+mix llmdb.pull
 
 # Run ETL and write snapshot.json
-mix llm_db.build
+mix llmdb.build
 ```
 
 See the [Sources & Engine](guides/sources-and-engine.md) guide for details.


### PR DESCRIPTION
## Type of Change

- [ ] Code (bug fix, feature, refactor)
- [ ] Model metadata (TOML updates)
- [X] Documentation
- [ ] CI/build

## Description

Fix mix command names.

## Changes Made

- `mix llm_db.*` -> `mix llmdb.*` 

## Checklist

- [ ] Code formatted (`mix format`)
- [ ] Tests pass locally
- [ ] No compiler warnings
- [ ] Updated relevant documentation
- [ ] CHANGELOG.md updated (if user-facing)
