### PR TITLE
Add Model.reasoning_enabled?/1 helper function

### DIFF
--- a/lib/llm_db/model.ex
+++ b/lib/llm_db/model.ex
@@ -239,6 +239,32 @@ defmodule LLMDB.Model do
   def spec(%__MODULE__{provider: provider, id: id}, format \\ nil) do
     LLMDB.Spec.format_spec({provider, id}, format)
   end
+
+  @doc """
+  Checks if a model has reasoning capability enabled.
+
+  Encapsulates the knowledge of where reasoning.enabled lives in the capabilities structure.
+
+  ## Examples
+
+      iex> model = %LLMDB.Model{capabilities: %{reasoning: %{enabled: true}}}
+      iex> LLMDB.Model.reasoning_enabled?(model)
+      true
+
+      iex> model = %LLMDB.Model{capabilities: %{reasoning: %{enabled: false}}}
+      iex> LLMDB.Model.reasoning_enabled?(model)
+      false
+
+      iex> model = %LLMDB.Model{capabilities: %{}}
+      iex> LLMDB.Model.reasoning_enabled?(model)
+      false
+  """
+  @spec reasoning_enabled?(t()) :: boolean()
+  def reasoning_enabled?(%__MODULE__{capabilities: capabilities}) when is_map(capabilities) do
+    get_in(capabilities, [:reasoning, :enabled]) == true
+  end
+
+  def reasoning_enabled?(_model), do: false
 end
 
 defimpl DeepMerge.Resolver, for: LLMDB.Model do

--- a/test/llm_db/model_struct_api_test.exs
+++ b/test/llm_db/model_struct_api_test.exs
@@ -107,4 +107,72 @@ defmodule LLMDB.ModelStructAPITest do
       assert LLMDB.Model.spec(model, :filename_safe) == "gpt-4o-mini@openai"
     end
   end
+
+  describe "LLMDB.Model.reasoning_enabled?/1" do
+    test "returns true when reasoning is enabled" do
+      model = %LLMDB.Model{
+        id: "claude-sonnet",
+        provider: :anthropic,
+        capabilities: %{reasoning: %{enabled: true}}
+      }
+
+      assert LLMDB.Model.reasoning_enabled?(model) == true
+    end
+
+    test "returns false when reasoning is explicitly disabled" do
+      model = %LLMDB.Model{
+        id: "claude-sonnet",
+        provider: :anthropic,
+        capabilities: %{reasoning: %{enabled: false}}
+      }
+
+      assert LLMDB.Model.reasoning_enabled?(model) == false
+    end
+
+    test "returns false when capabilities is empty map" do
+      model = %LLMDB.Model{
+        id: "gpt-4",
+        provider: :openai,
+        capabilities: %{}
+      }
+
+      assert LLMDB.Model.reasoning_enabled?(model) == false
+    end
+
+    test "returns false when capabilities is nil" do
+      model = %LLMDB.Model{
+        id: "gpt-4",
+        provider: :openai,
+        capabilities: nil
+      }
+
+      assert LLMDB.Model.reasoning_enabled?(model) == false
+    end
+
+    test "returns false when reasoning key exists but enabled is missing" do
+      model = %LLMDB.Model{
+        id: "claude-sonnet",
+        provider: :anthropic,
+        capabilities: %{reasoning: %{}}
+      }
+
+      assert LLMDB.Model.reasoning_enabled?(model) == false
+    end
+
+    test "returns false when reasoning key exists but enabled is nil" do
+      model = %LLMDB.Model{
+        id: "claude-sonnet",
+        provider: :anthropic,
+        capabilities: %{reasoning: %{enabled: nil}}
+      }
+
+      assert LLMDB.Model.reasoning_enabled?(model) == false
+    end
+
+    test "returns false for non-Model struct" do
+      assert LLMDB.Model.reasoning_enabled?(%{}) == false
+      assert LLMDB.Model.reasoning_enabled?(nil) == false
+      assert LLMDB.Model.reasoning_enabled?("model") == false
+    end
+  end
 end


### PR DESCRIPTION
## Type of Change

- [x] Code (bug fix, feature, refactor)

## Description

Centralizes the check for whether a model has reasoning capability enabled. This eliminates duplicated get_in calls throughout dependent libraries like req_llm where this check was repeated with verbose Access.key syntax.

## Changes Made

- Added reasoning_enabled?/1 function to LLMDB.Model
- Function encapsulates knowledge of capabilities.reasoning.enabled structure
- Handles nil capabilities, empty maps, and non-Model structs gracefully
- Returns true only when capabilities.reasoning.enabled is explicitly true

## Testing

- [x] Tests added/updated - Added 7 comprehensive test cases covering all edge cases
- [x] `mix test` passes - All tests pass including new reasoning_enabled?/1 tests
- [x] Manual testing (describe): Verified helper works correctly for models with/without reasoning capability

## Checklist

- [x] Code formatted (`mix format`)
- [x] Tests pass locally
- [x] No compiler warnings
- [x] Updated relevant documentation - Added @doc with examples