### PR TITLE
Bump zoi dependency to ~> 0.10.7 for Elixir 1.19 compatibility

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule LLMDB.MixProject do
 
   defp deps do
     [
-      {:zoi, "~> 0.10"},
+      {:zoi, "~> 0.10.7"},
       {:jason, "~> 1.4"},
       {:toml, "~> 0.7"},
       {:req, "~> 0.5"},


### PR DESCRIPTION
## Summary

- Bumps zoi dependency from `~> 0.10` to `~> 0.10.7`
- Fixes compilation error on Elixir 1.19 caused by string literals in typespecs

## Problem

Zoi 0.10.4 generates string literals in typespecs (e.g., `"active"` from `Zoi.enum(["active", "deprecated", "retired"])`), which Elixir 1.19 rejects with:

```
** (Kernel.TypespecError) lib/llm_db/model.ex:138: unexpected expression in typespec: "active"
```

Zoi 0.10.7 generates correct typespecs using `binary()` instead of string literals.

## Test plan

- [x] Verified error reproduces with Zoi 0.10.4 on Elixir 1.19
- [x] Verified compilation succeeds with Zoi 0.10.7 on Elixir 1.19
- [x] Clean rebuild passes: `rm -rf _build deps && mix deps.get && mix compile`

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)