### PR TITLE
Add tools.forced_choice capability field

### DIFF
--- a/lib/llm_db/model.ex
+++ b/lib/llm_db/model.ex
@@ -36,7 +36,8 @@ defmodule LLMDB.Model do
                   enabled: Zoi.boolean() |> Zoi.nullish(),
                   streaming: Zoi.boolean() |> Zoi.nullish(),
                   strict: Zoi.boolean() |> Zoi.nullish(),
-                  parallel: Zoi.boolean() |> Zoi.nullish()
+                  parallel: Zoi.boolean() |> Zoi.nullish(),
+                  forced_choice: Zoi.boolean() |> Zoi.nullish()
                 })
 
   @json_schema Zoi.object(%{

--- a/priv/llm_db/local/azure/deepseek_deepseek-r1-0528.toml
+++ b/priv/llm_db/local/azure/deepseek_deepseek-r1-0528.toml
@@ -1,0 +1,4 @@
+id = "deepseek-r1-0528"
+
+[capabilities.tools]
+forced_choice = false

--- a/priv/llm_db/local/azure/deepseek_deepseek-v3-0324.toml
+++ b/priv/llm_db/local/azure/deepseek_deepseek-v3-0324.toml
@@ -1,0 +1,4 @@
+id = "deepseek-v3-0324"
+
+[capabilities.tools]
+forced_choice = false

--- a/priv/llm_db/local/azure/deepseek_deepseek-v3.1.toml
+++ b/priv/llm_db/local/azure/deepseek_deepseek-v3.1.toml
@@ -1,0 +1,4 @@
+id = "deepseek-v3.1"
+
+[capabilities.tools]
+forced_choice = false


### PR DESCRIPTION
## Summary

Adds a new `capabilities.tools.forced_choice` boolean field to indicate whether a model supports object-style `tool_choice` (forcing a specific tool) versus only string values (`"auto"`, `"required"`, `"none"`).

### Background

Some providers like Azure's DeepSeek deployments only support string-style tool_choice:

```
Invalid tool_choice = {...}. Supported values are ["auto", "required", "none"]
```

This field allows clients to detect this limitation and adjust their `tool_choice` parameter accordingly.

### Changes

**Schema** (`lib/llm_db/model.ex`):
- Added `forced_choice: Zoi.boolean() |> Zoi.nullish()` to `@tools_schema`

**Local overrides** for Azure DeepSeek models (`forced_choice = false`):
- `deepseek_deepseek-v3.1.toml`
- `deepseek_deepseek-v3-0324.toml`
- `deepseek_deepseek-r1-0528.toml`

### Usage

```elixir
{:ok, model} = LLMDB.model(:azure, "deepseek-r1-0528")
model.capabilities.tools.forced_choice
# => false (only supports string tool_choice values)
```

**Depends on:** #29

## Test plan

- [x] `mix compile` succeeds
- [x] `mix test` passes (37 doctests, 541 tests, 0 failures)
- [x] Verified Azure DeepSeek models have `tools.forced_choice=false`