### PR TITLE
fix: restrict llm_db.build and llm_db.pull tasks to llm_db project only

### DIFF
--- a/lib/mix/tasks/llm_db.pull.ex
+++ b/lib/mix/tasks/llm_db.pull.ex
@@ -70,6 +70,8 @@ defmodule Mix.Tasks.LlmDb.Pull do
 
   @impl Mix.Task
   def run(args) do
+    ensure_llm_db_project!()
+
     # Load .env before starting app
     load_dotenv()
 
@@ -260,6 +262,27 @@ defmodule Mix.Tasks.LlmDb.Pull do
     if File.exists?(env_path) do
       vars = Dotenvy.source!(env_path)
       System.put_env(vars)
+    end
+  end
+
+  defp ensure_llm_db_project! do
+    app = Mix.Project.config()[:app]
+
+    if app != :llm_db do
+      Mix.raise("""
+      mix llm_db.pull can only be run inside the llm_db project itself.
+
+      This task fetches upstream data and writes to priv/llm_db/upstream/. Running
+      it from a downstream application would write files into your project that
+      belong in the :llm_db package.
+
+      If you need to pull fresh data (maintainers only):
+
+          cd path/to/llm_db
+          mix llm_db.pull
+
+      For downstream applications, use the data shipped with :llm_db.
+      """)
     end
   end
 end


### PR DESCRIPTION
## Summary

Prevents duplicate module errors when downstream projects accidentally run `mix llm_db.build` or `mix llm_db.pull`.

## Problem

When a downstream project (like `req_llm`) runs `mix llm_db.build`, it generates `lib/llm_db/generated/valid_providers.ex` in the consuming project's directory. This creates a duplicate `LLMDB.Generated.ValidProviders` module that conflicts with the one already shipped in the `:llm_db` Hex package, causing compilation errors.

## Solution

Both tasks now check `Mix.Project.config()[:app]` at startup. If not running inside the `:llm_db` project, they abort with a clear error message explaining:
1. Why the task can't run
2. What maintainers should do instead
3. That downstream users should rely on the shipped package

## Example error message

```
mix llm_db.build can only be run inside the llm_db project itself.

This task generates lib/llm_db/generated/valid_providers.ex. Running it from
a downstream application would create a duplicate LLMDB.Generated.ValidProviders
module that conflicts with the one shipped in the :llm_db Hex package.

If you need to regenerate the snapshot (maintainers only):

    cd path/to/llm_db
    mix llm_db.build

For downstream applications, use the data and modules shipped with :llm_db.
```

Fixes #44