### PR TITLE
feat: add wire.protocol and constraints metadata fields

### DIFF
--- a/priv/llm_db/local/README.md
+++ b/priv/llm_db/local/README.md
@@ -103,6 +103,17 @@ tool_calls = false                  # Optional: tool call streaming
 [extra]
 deployment_id = "prod-001"
 custom_metadata = "value"
+
+# Wire Protocol Selection (for API client libraries)
+[extra.wire]
+protocol = "openai_responses"    # openai_chat | openai_responses | anthropic
+
+# Parameter Constraints (for API client libraries)
+[extra.constraints]
+token_limit_key = "max_completion_tokens"  # max_tokens | max_completion_tokens
+temperature = "unsupported"                # any | unsupported | fixed_1
+reasoning_effort = "supported"             # unsupported | supported | required
+min_output_tokens = 16                     # integer minimum for output tokens
 ```
 
 ## Field Mapping Reference
@@ -151,6 +162,47 @@ See the example files in this directory:
 - `openai/` - OpenAI provider with GPT-4o models
 - `anthropic/` - Anthropic provider with Claude 3.5 Sonnet
 - `custom/` - Custom provider template
+
+## Wire Protocol & Constraints (API Client Integration)
+
+These `extra.*` fields enable metadata-driven API clients like ReqLlmNext to handle
+model-specific requirements without hardcoded model-name heuristics.
+
+### Wire Protocol
+
+Use `extra.wire.protocol` to specify which API format a model uses:
+
+| Value | Description |
+|-------|-------------|
+| `openai_chat` | Standard OpenAI Chat Completions API (default for OpenAI) |
+| `openai_responses` | OpenAI Responses API (o-series, GPT-5) |
+| `anthropic` | Anthropic Messages API (default for Anthropic) |
+
+When absent, clients should use provider defaults.
+
+### Constraints
+
+Use `extra.constraints.*` to specify parameter handling requirements:
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `token_limit_key` | `max_tokens`, `max_completion_tokens` | Which key to use for output tokens |
+| `temperature` | `any`, `unsupported`, `fixed_1` | Temperature parameter support |
+| `reasoning_effort` | `unsupported`, `supported`, `required` | Reasoning effort parameter handling |
+| `min_output_tokens` | integer | Minimum output tokens floor |
+
+Example for a reasoning model:
+```toml
+id = "o3-mini"
+
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "supported"
+```
 
 ## Notes
 

--- a/priv/llm_db/local/openai/gpt-5-chat-latest.toml
+++ b/priv/llm_db/local/openai/gpt-5-chat-latest.toml
@@ -9,6 +9,10 @@ enabled = false
 [capabilities.json]
 schema = false
 
-[extra]
-api = "responses"
-temperature = true
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "any"
+reasoning_effort = "unsupported"

--- a/priv/llm_db/local/openai/gpt-5-codex.toml
+++ b/priv/llm_db/local/openai/gpt-5-codex.toml
@@ -9,5 +9,10 @@ enabled = false
 [capabilities.json]
 schema = false
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "any"
+reasoning_effort = "unsupported"

--- a/priv/llm_db/local/openai/gpt-5-mini.toml
+++ b/priv/llm_db/local/openai/gpt-5-mini.toml
@@ -3,5 +3,10 @@ id = "gpt-5-mini"
 [capabilities.json]
 schema = true
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "required"

--- a/priv/llm_db/local/openai/gpt-5-nano.toml
+++ b/priv/llm_db/local/openai/gpt-5-nano.toml
@@ -3,5 +3,10 @@ id = "gpt-5-nano"
 [capabilities.json]
 schema = true
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "required"

--- a/priv/llm_db/local/openai/gpt-5-pro.toml
+++ b/priv/llm_db/local/openai/gpt-5-pro.toml
@@ -3,5 +3,10 @@ id = "gpt-5-pro"
 [capabilities.json]
 schema = true
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "required"

--- a/priv/llm_db/local/openai/gpt-5.toml
+++ b/priv/llm_db/local/openai/gpt-5.toml
@@ -3,5 +3,10 @@ id = "gpt-5"
 [capabilities.json]
 schema = true
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "required"

--- a/priv/llm_db/local/openai/o1.toml
+++ b/priv/llm_db/local/openai/o1.toml
@@ -1,4 +1,9 @@
 id = "o1"
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "supported"

--- a/priv/llm_db/local/openai/o3-mini.toml
+++ b/priv/llm_db/local/openai/o3-mini.toml
@@ -1,4 +1,9 @@
 id = "o3-mini"
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "supported"

--- a/priv/llm_db/local/openai/o3-pro.toml
+++ b/priv/llm_db/local/openai/o3-pro.toml
@@ -1,4 +1,9 @@
 id = "o3-pro"
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "supported"

--- a/priv/llm_db/local/openai/o3.toml
+++ b/priv/llm_db/local/openai/o3.toml
@@ -1,4 +1,9 @@
 id = "o3"
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "supported"

--- a/priv/llm_db/local/openai/o4-mini.toml
+++ b/priv/llm_db/local/openai/o4-mini.toml
@@ -1,4 +1,9 @@
 id = "o4-mini"
 
-[extra]
-api = "responses"
+[extra.wire]
+protocol = "openai_responses"
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "unsupported"
+reasoning_effort = "supported"

--- a/priv/llm_db/manifest.json
+++ b/priv/llm_db/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-12-17T18:40:22.225831Z",
+  "generated_at": "2025-12-18T15:06:16.136025Z",
   "providers": [
     "ai21",
     "aihubmix",

--- a/priv/llm_db/providers/openai.json
+++ b/priv/llm_db/providers/openai.json
@@ -2262,15 +2262,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": true,
+        "constraints": {
+          "reasoning_effort": "required",
+          "temperature": "unsupported",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1754425777,
         "family": "gpt-5",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "gpt-5",
@@ -2389,14 +2396,21 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": true,
+        "constraints": {
+          "reasoning_effort": "unsupported",
+          "temperature": "any",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1754073306,
         "family": "gpt-5-chat",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": true
+        "temperature": true,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "gpt-5-chat-latest",
@@ -2454,15 +2468,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": false,
+        "constraints": {
+          "reasoning_effort": "unsupported",
+          "temperature": "any",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1757527818,
         "family": "gpt-5-codex",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "gpt-5-codex",
@@ -2639,15 +2660,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": true,
+        "constraints": {
+          "reasoning_effort": "required",
+          "temperature": "unsupported",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1754425928,
         "family": "gpt-5-mini",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "gpt-5-mini",
@@ -2731,15 +2759,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": true,
+        "constraints": {
+          "reasoning_effort": "required",
+          "temperature": "unsupported",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1754426384,
         "family": "gpt-5-nano",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "gpt-5-nano",
@@ -2822,15 +2857,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": true,
+        "constraints": {
+          "reasoning_effort": "required",
+          "temperature": "unsupported",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1759469822,
         "family": "gpt-5-pro",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "gpt-5-pro",
@@ -4153,15 +4195,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": true,
+        "constraints": {
+          "reasoning_effort": "supported",
+          "temperature": "unsupported",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1734375816,
         "family": "o1",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "o1",
@@ -4265,15 +4314,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": true,
+        "constraints": {
+          "reasoning_effort": "supported",
+          "temperature": "unsupported",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1744225308,
         "family": "o3",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "o3",
@@ -4377,15 +4433,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": false,
+        "constraints": {
+          "reasoning_effort": "supported",
+          "temperature": "unsupported",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1737146383,
         "family": "o3-mini",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "o3-mini",
@@ -4520,15 +4583,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": true,
+        "constraints": {
+          "reasoning_effort": "supported",
+          "temperature": "unsupported",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1748475349,
         "family": "o3-pro",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "o3-pro",
@@ -4609,15 +4679,22 @@
       },
       "deprecated": false,
       "extra": {
-        "api": "responses",
         "attachment": true,
+        "constraints": {
+          "reasoning_effort": "supported",
+          "temperature": "unsupported",
+          "token_limit_key": "max_completion_tokens"
+        },
         "created": 1744225351,
         "family": "o4-mini",
         "hugging_face_id": "",
         "open_weights": false,
         "owned_by": "system",
         "structured_output": true,
-        "temperature": false
+        "temperature": false,
+        "wire": {
+          "protocol": "openai_responses"
+        }
       },
       "family": null,
       "id": "o4-mini",


### PR DESCRIPTION
## Summary

Add standardized metadata fields to enable metadata-driven API clients to eliminate model-ID heuristics for wire protocol selection and parameter handling.

## Changes

### New `extra.wire` fields
- `protocol`: Specifies which API format a model uses (`openai_chat`, `openai_responses`, `anthropic`)

### New `extra.constraints` fields
- `token_limit_key`: Which key to use for output tokens (`max_tokens` or `max_completion_tokens`)
- `temperature`: Temperature parameter support (`any`, `unsupported`, `fixed_1`)
- `reasoning_effort`: Reasoning effort parameter handling (`unsupported`, `supported`, `required`)
- `min_output_tokens`: Minimum output tokens floor (integer)

### Models Updated
- **o-series** (o1, o3, o3-mini, o3-pro, o4-mini): `openai_responses` + constraints
- **gpt-5 family** (gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-pro): `openai_responses` + reasoning required
- **gpt-5-codex, gpt-5-chat-latest**: `openai_responses` + temperature=any (non-reasoning variants)

### Documentation
- Updated `priv/llm_db/local/README.md` with new field documentation

## Motivation

This enables API clients like ReqLlmNext to determine wire protocol and parameter constraints from metadata alone, rather than pattern-matching on model IDs like `o1*`, `o3*`, etc.

See [LLMDB_EXTENSION_RECOMMENDATIONS.md](https://github.com/agentjido/req_llm/blob/main/vNext/LLMDB_EXTENSION_RECOMMENDATIONS.md) for the full design rationale.