### PR TITLE
fix: Don't load env files if .env is a directory

### DIFF
--- a/lib/llm_db/application.ex
+++ b/lib/llm_db/application.ex
@@ -36,7 +36,7 @@ defmodule LLMDB.Application do
   defp load_dotenv do
     env_path = Path.join(File.cwd!(), ".env")
 
-    if File.exists?(env_path) do
+    if File.exists?(env_path) and not File.dir?(env_path) do
       vars = Dotenvy.source!(env_path)
       System.put_env(vars)
     end


### PR DESCRIPTION
## Description

In my repo, `.env` is a directory, not a file, this makes llm_db fails to load since it tries to pass the directory to dotenvy.

## Type of Change

- x ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

Not a breaking change

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly <-- Not applicable
- [x] I have added tests that prove my fix/feature works <-- Not applicable
- [x] All new and existing tests pass <-- Not applicable
- [x] My commits follow conventional commit format