### PR TITLE
fix: keep OpenRouter models under :openrouter with full IDs

### DIFF
--- a/priv/llm_db/local/openrouter/openai_gpt-5.2-chat-latest.toml
+++ b/priv/llm_db/local/openrouter/openai_gpt-5.2-chat-latest.toml
@@ -1,0 +1,2 @@
+id = "openai/gpt-5.2-chat-latest"
+aliases = ["openai/gpt-5.2-chat"]


### PR DESCRIPTION
This fixes two issues:

- Fixes #68: Add alias for openai/gpt-5.2-chat -> openai/gpt-5.2-chat-latest
- Fixes #69: Add perplexity models to openrouter

## Changes

### OpenRouter Source Redesign

OpenRouter models are now kept exclusively under the `:openrouter` provider with their full IDs (e.g., `perplexity/sonar-pro`, `openai/gpt-4`).

Previously, the source would split model IDs like `perplexity/sonar-pro` into `{:perplexity, "sonar-pro"}`, which incorrectly mixed OpenRouter data with native provider data.

Now:
- `openrouter:perplexity/sonar-pro` is a distinct model from `perplexity:sonar-pro`
- Model IDs with `/` are treated as literal strings, not provider delimiters
- The `:` in specs remains the only provider delimiter

### Key Code Changes

- Removed `parse_model_id/1` - no longer splitting IDs on `/`
- Simplified `transform/1` - emits only a single "openrouter" provider
- Simplified `transform_model/1` - keeps full model ID, always sets `provider: :openrouter`
- Removed dual-registration/mirroring logic

### Issue #68 Fix

Added local TOML file to alias `openai/gpt-5.2-chat` to `openai/gpt-5.2-chat-latest` for the OpenRouter provider.

---

**Note:** This PR only includes code changes. A separate metadata update will be done after merging.