### PR TITLE
fix: add grok-imagine-image pricing via local TOML override

### DIFF
--- a/priv/llm_db/local/xai/grok-imagine-image.toml
+++ b/priv/llm_db/local/xai/grok-imagine-image.toml
@@ -1,0 +1,47 @@
+id = "grok-imagine-image"
+name = "Grok Imagine Image"
+family = "grok-imagine"
+
+[modalities]
+input = ["text"]
+output = ["image"]
+
+[capabilities]
+chat = false
+embeddings = false
+
+[capabilities.json]
+native = false
+schema = false
+strict = false
+
+[capabilities.reasoning]
+enabled = false
+
+[capabilities.streaming]
+text = false
+tool_calls = false
+
+[capabilities.tools]
+enabled = false
+
+[pricing]
+currency = "USD"
+merge = "merge_by_id"
+
+[[pricing.components]]
+id = "image.input"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.002
+
+[[pricing.components]]
+id = "image.generated"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.02
+
+[extra]
+api = "images"

--- a/priv/llm_db/manifest.json
+++ b/priv/llm_db/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-01T19:46:04.615050Z",
+  "generated_at": "2026-02-02T02:27:37.800922Z",
   "providers": [
     "302ai",
     "abacus",

--- a/priv/llm_db/providers/xai.json
+++ b/priv/llm_db/providers/xai.json
@@ -1090,23 +1090,68 @@
     "grok-imagine-image": {
       "aliases": [],
       "base_url": null,
-      "capabilities": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": false,
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
       "cost": null,
       "deprecated": false,
       "extra": {
+        "api": "images",
         "created": 1769558400,
         "owned_by": "xai"
       },
-      "family": null,
+      "family": "grok-imagine",
       "id": "grok-imagine-image",
       "knowledge": null,
       "last_updated": null,
       "lifecycle": null,
       "limits": null,
-      "modalities": null,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "image"
+        ]
+      },
       "model": null,
-      "name": null,
-      "pricing": null,
+      "name": "Grok Imagine Image",
+      "pricing": {
+        "components": [
+          {
+            "id": "image.input",
+            "kind": "image",
+            "per": 1,
+            "rate": 0.002,
+            "unit": "image"
+          },
+          {
+            "id": "image.generated",
+            "kind": "image",
+            "per": 1,
+            "rate": 0.02,
+            "unit": "image"
+          }
+        ],
+        "currency": "USD",
+        "merge": "merge_by_id"
+      },
       "provider": "xai",
       "provider_model_id": null,
       "release_date": null,


### PR DESCRIPTION
Add pricing metadata for grok-imagine-image model using a local TOML file that persists across model_sync runs. The previous fix attempts (commits 0c173bb, 21985a6, 397bf3f) edited xai.json directly, which was overwritten by the automated model_sync in commit f59ba5a.

Pricing:
- image.input: $0.002 per image
- image.generated: $0.02 per image


## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
