### PR TITLE
feat: add flexible lifecycle extension for models

### DIFF
--- a/lib/llm_db/engine/normalize.ex
+++ b/lib/llm_db/engine/normalize.ex
@@ -283,6 +283,7 @@ defmodule LLMDB.Normalize do
 
   defp normalize_lifecycle(model) do
     lifecycle = Map.get(model, :lifecycle)
+    lifecycle = if is_map(lifecycle), do: lifecycle, else: nil
     status = lifecycle_status_from_map(lifecycle)
     deprecated_flag = Map.get(model, :deprecated) == true
     retired_flag = Map.get(model, :retired) == true
@@ -304,12 +305,7 @@ defmodule LLMDB.Normalize do
         |> Map.put(:retired, false)
 
       is_nil(status) and (retired_flag or deprecated_flag) ->
-        derived_status =
-          cond do
-            retired_flag -> "retired"
-            deprecated_flag -> "deprecated"
-            true -> nil
-          end
+        derived_status = if retired_flag, do: "retired", else: "deprecated"
 
         updated_lifecycle =
           (lifecycle || %{})
@@ -317,7 +313,7 @@ defmodule LLMDB.Normalize do
 
         model
         |> Map.put(:lifecycle, updated_lifecycle)
-        |> Map.put(:deprecated, deprecated_flag or retired_flag)
+        |> Map.put(:deprecated, true)
         |> Map.put(:retired, retired_flag)
 
       true ->


### PR DESCRIPTION
## Summary

Fixes #99 - deprecated flag now matches lifecycle status

## Changes

### Schema additions
- Added `retired` boolean field to Model schema (symmetric with `deprecated`)
- Added `retired_at` field to lifecycle schema for actual retirement date

### Lifecycle normalization (in Engine)
- Lifecycle fields are now normalized during ingestion in `LLMDB.Normalize`
- `lifecycle.status` is the source of truth; boolean flags derived from it:
  - `retired` → `deprecated: true, retired: true`
  - `deprecated` → `deprecated: true, retired: false`
  - `active` → `deprecated: false, retired: false`
- If only boolean flags are set, `lifecycle.status` is derived from them for backward compatibility

### New computed functions
- `lifecycle_status/1` - returns declared status from lifecycle field
- `effective_status/2` - respects `deprecated_at`/`retired_at` dates
- `deprecated?/2` - true if deprecated or retired (considers dates)
- `retired?/2` - true if retired (considers dates)

### Documentation
- Updated Model moduledoc with lifecycle documentation and examples

## Example Usage

```elixir
# After this change, lifecycle.status: "deprecated" will sync deprecated: true
{:ok, model} = LLMDB.model("openai:dall-e-3")
model.lifecycle.status  # => "deprecated"
model.deprecated        # => true (was false before this fix)

# Temporal lifecycle queries
model = LLMDB.Model.new!(%{
  id: "old-model",
  provider: :openai,
  lifecycle: %{deprecated_at: "2025-01-01", retired_at: "2025-06-01"}
})

LLMDB.Model.effective_status(model, ~U[2025-03-01 00:00:00Z])  # => "deprecated"
LLMDB.Model.retired?(model, ~U[2025-07-01 00:00:00Z])         # => true
```