### PR TITLE
fix: add embedding capabilities to google_vertex gemini-embedding-001

### DIFF
--- a/priv/llm_db/providers/google_vertex.json
+++ b/priv/llm_db/providers/google_vertex.json
@@ -923,7 +923,32 @@
     "gemini-embedding-001": {
       "aliases": [],
       "base_url": null,
-      "capabilities": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "default_dimensions": 3072,
+          "max_dimensions": 3072,
+          "min_dimensions": 768
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false,
+          "parallel": false,
+          "streaming": false,
+          "strict": false
+        }
+      },
       "cost": {
         "input": 0.15,
         "output": 0


### PR DESCRIPTION
## Description

### `gemini-embedding-001` has null capabilities preventing embedding validation

The `gemini-embedding-001` model entry in the `google_vertex` provider JSON has `"capabilities": null`. This causes `ReqLLM.Embedding.validate_model/1` to reject the model since it checks `model.capabilities.embeddings`. A null capabilities map has no embeddings field, so validation fails even though the model is a dedicated embedding model.

This means `ReqLLM.embed("google_vertex:gemini-embedding-001", ...)` returns an error before ever reaching the provider, despite the model being a fully functional embedding model supporting 768, 1536, and 3072 dimensions via [Matryoshka Representation Learning](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#latest-models).

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
