### PR TITLE
docs: clarify ReqLLM compatibility for custom providers

### DIFF
--- a/guides/using-the-data.md
+++ b/guides/using-the-data.md
@@ -20,38 +20,13 @@ Query, filter, and access LLM model metadata at runtime.
 # With custom providers
 {:ok, snapshot} = LLMDB.load(
   custom: %{
-    local: [
-      name: "Local Provider",
-      base_url: "http://localhost:8080",
+    vllm: [
+      name: "Local vLLM Provider",
+      base_url: "http://localhost:8000/v1",
       models: %{
         "llama-3" => %{
           capabilities: %{chat: true, tools: %{enabled: true}},
           limits: %{context: 8192, output: 2048}
-        }
-      }
-    ]
-  }
-)
-
-# With local providers that use a port per model
-{:ok, snapshot} = LLMDB.load(
-  custom: %{
-    vllm: [
-      name: "VLLM Provider",
-      models: %{
-        "llama-3" => %{
-          capabilities: %{chat: true, tools: %{enabled: true}},
-          limits: %{context: 8192, output: 2048},
-          base_url: "http://localhost:8000/v1"
-        ,
-        "SmolVLM-256M-Instruct" => %{
-          capabilities: %{chat: true},
-          modalities: %{
-            "input" => ["text","image"],
-            "output" => ["text"]
-          },
-          limits: %{context: 8192}
-          base_url: "http://localhost:8001/v1"
         }
       }
     ]
@@ -293,10 +268,10 @@ Add local or private models to the catalog at load time:
 ```elixir
 {:ok, _} = LLMDB.load(
   custom: %{
-    local: [
-      name: "Local LLM Server",
-      base_url: "http://localhost:8080",
-      env: ["LOCAL_API_KEY"],
+    vllm: [
+      name: "Local vLLM Server",
+      base_url: "http://localhost:8000/v1",
+      env: ["OPENAI_API_KEY"],
       models: %{
         "llama-3-8b" => %{
           name: "Llama 3 8B",
@@ -321,8 +296,8 @@ Add local or private models to the catalog at load time:
 )
 
 # Use custom models
-{:ok, model} = LLMDB.model("local:llama-3-8b")
-{:ok, {provider, id}} = LLMDB.select(require: [tools: true], prefer: [:local])
+{:ok, model} = LLMDB.model("vllm:llama-3-8b")
+{:ok, {provider, id}} = LLMDB.select(require: [tools: true], prefer: [:vllm])
 ```
 
 **Custom Provider Format:**
@@ -331,6 +306,7 @@ Add local or private models to the catalog at load time:
 - `:models` is required - a map where keys are model IDs and values are model configs
 - Models inherit the provider ID automatically
 - Custom providers/models merge with packaged data (last wins by ID)
+- ReqLLM users should pick a ReqLLM-supported provider ID (for local OpenAI-compatible servers, use `:vllm`) or register a custom ReqLLM provider module
 
 ## Load Options
 
@@ -341,7 +317,7 @@ All options passed to `LLMDB.load/1`:
   allow: %{openai: ["gpt-4*"]},
   deny: %{openai: ["*-preview"]},
   prefer: [:openai, :anthropic],
-  custom: %{local: [models: %{"llama-3" => %{capabilities: %{chat: true}}}]}
+  custom: %{vllm: [models: %{"llama-3" => %{capabilities: %{chat: true}}}]}
 )
 ```
 

--- a/lib/llm_db/config.ex
+++ b/lib/llm_db/config.ex
@@ -56,9 +56,9 @@ defmodule LLMDB.Config do
         deny: %{},    # or [:provider] or %{provider: ["pattern"]}
         prefer: [:openai, :anthropic],
         custom: %{
-          local: [
-            name: "Local Provider",
-            base_url: "http://localhost:8080",
+          vllm: [
+            name: "Local vLLM Provider",
+            base_url: "http://localhost:8000/v1",
             models: %{
               "llama-3" => %{capabilities: %{chat: true}},
               "mistral-7b" => %{capabilities: %{chat: true, tools: %{enabled: true}}}

--- a/lib/llm_db/runtime.ex
+++ b/lib/llm_db/runtime.ex
@@ -68,8 +68,8 @@ defmodule LLMDB.Runtime do
       # With custom providers
       runtime = Runtime.compile(
         custom: %{
-          local: [
-            name: "Local Provider",
+          vllm: [
+            name: "Local vLLM Provider",
             models: %{
               "llama-3" => %{capabilities: %{chat: true}}
             }


### PR DESCRIPTION
## Summary
- switch local custom-provider examples from `:local` to `:vllm` for ReqLLM-compatible local OpenAI servers
- document that arbitrary LLMDB provider IDs require registering a custom `ReqLLM.Provider`
- align README + guides + module docs with this behavior

## Validation
- mix format
- mix test
- pre-push hooks: mix quality

Fixes #91
