### PR TITLE
fix(spec): use amazon_bedrock provider and add missing inference profile prefixes

### DIFF
--- a/lib/llm_db/spec.ex
+++ b/lib/llm_db/spec.ex
@@ -19,12 +19,12 @@ defmodule LLMDB.Spec do
 
   ## Amazon Bedrock Inference Profiles
 
-  For Amazon Bedrock models, inference profile IDs with region prefixes (us., eu., ap., ca., global.)
-  are supported. The region prefix is stripped for catalog lookup but preserved in the returned
-  model ID. For example:
+  For Amazon Bedrock models, inference profile IDs with region prefixes (us., eu., ap., apac., ca.,
+  au., jp., us-gov., global.) are supported. The region prefix is stripped for catalog lookup but
+  preserved in the returned model ID. For example:
 
-      iex> LLMDB.Spec.resolve("bedrock:us.anthropic.claude-opus-4-1-20250805-v1:0")
-      {:ok, {:bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", %LLMDB.Model{}}}
+      iex> LLMDB.Spec.resolve("amazon_bedrock:us.anthropic.claude-opus-4-1-20250805-v1:0")
+      {:ok, {:amazon_bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", %LLMDB.Model{}}}
 
   The lookup uses "anthropic.claude-opus-4-1-20250805-v1:0" to find metadata, but the returned
   model ID retains the "us." prefix for API routing purposes.
@@ -33,8 +33,9 @@ defmodule LLMDB.Spec do
   alias LLMDB.{Normalize, Store}
   alias LLMDB.Model
 
-  # Valid Bedrock inference profile region prefixes
-  @bedrock_prefixes ~w(us. eu. ap. ca. global.)
+  # Valid Bedrock inference profile region prefixes.
+  # See: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+  @bedrock_prefixes ~w(us. eu. ap. apac. ca. au. jp. us-gov. global.)
 
   @doc """
   Parses and validates a provider identifier.
@@ -438,11 +439,22 @@ defmodule LLMDB.Spec do
     end
   end
 
-  # For Bedrock inference profiles, splits model_id into {base_id, prefix} where
-  # base_id is used for catalog lookup and prefix is preserved for the returned ID.
-  # For other providers or non-prefixed Bedrock IDs, returns {model_id, nil}.
+  @doc """
+  Strips any inference profile prefix from a model ID.
+
+  For Amazon Bedrock, splits prefixes like `"us."`, `"eu."`, `"au."` etc. from the model ID
+  so the base ID can be used for catalog lookup. Returns `{base_id, prefix}` where prefix
+  is `nil` if no prefix was found.
+
+  For other providers, returns `{model_id, nil}` unchanged.
+  """
+  @spec strip_prefix(atom(), String.t()) :: {String.t(), String.t() | nil}
+  def strip_prefix(provider, model_id) do
+    lookup_id_and_prefix(provider, model_id)
+  end
+
   defp lookup_id_and_prefix(provider, model_id) do
-    if provider == :bedrock do
+    if provider == :amazon_bedrock do
       case Enum.find_value(@bedrock_prefixes, fn prefix ->
              if String.starts_with?(model_id, prefix),
                do: {prefix, String.replace_prefix(model_id, prefix, "")}

--- a/lib/llm_db/store.ex
+++ b/lib/llm_db/store.ex
@@ -231,10 +231,13 @@ defmodule LLMDB.Store do
              end)
              |> Enum.map(fn {id, _} -> id end))
 
+        # Strip inference profile prefix for Bedrock lookups
+        {lookup_id, _prefix} = LLMDB.Spec.strip_prefix(provider_id, model_id)
+
         # Try each provider in the search list
         result =
           Enum.find_value(providers_to_search, fn search_provider_id ->
-            key = {search_provider_id, model_id}
+            key = {search_provider_id, lookup_id}
 
             # Try direct lookup first
             case Map.get(models_by_key, key) do

--- a/test/llm_db/spec_test.exs
+++ b/test/llm_db/spec_test.exs
@@ -10,7 +10,7 @@ defmodule LLMDB.SpecTest do
       %{id: :openai, name: "OpenAI"},
       %{id: :anthropic, name: "Anthropic"},
       %{id: :google_vertex, name: "Google Vertex AI"},
-      %{id: :bedrock, name: "Amazon Bedrock"}
+      %{id: :amazon_bedrock, name: "Amazon Bedrock"}
     ]
 
     models = [
@@ -58,13 +58,13 @@ defmodule LLMDB.SpecTest do
       },
       %{
         id: "anthropic.claude-opus-4-1-20250805-v1:0",
-        provider: :bedrock,
+        provider: :amazon_bedrock,
         name: "Claude Opus 4.1",
         aliases: ["anthropic.claude-opus"]
       },
       %{
         id: "meta.llama3-2-3b-instruct-v1:0",
-        provider: :bedrock,
+        provider: :amazon_bedrock,
         name: "Llama 3.2 3B",
         aliases: []
       }
@@ -419,7 +419,7 @@ defmodule LLMDB.SpecTest do
     end
 
     test "round-trips with complex Bedrock model IDs in colon format" do
-      original = "bedrock:anthropic.claude-opus-4-1-20250805-v1:0"
+      original = "amazon_bedrock:anthropic.claude-opus-4-1-20250805-v1:0"
       {:ok, spec} = Spec.parse_spec(original)
       formatted = Spec.format_spec(spec, :provider_colon_model)
       assert formatted == original
@@ -607,85 +607,113 @@ defmodule LLMDB.SpecTest do
 
   describe "resolve/2 with Bedrock inference profiles" do
     test "resolves inference profile with us. prefix" do
-      assert {:ok, {:bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
-               Spec.resolve("bedrock:us.anthropic.claude-opus-4-1-20250805-v1:0")
+      assert {:ok, {:amazon_bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:us.anthropic.claude-opus-4-1-20250805-v1:0")
 
       assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
       assert model.name == "Claude Opus 4.1"
     end
 
     test "resolves inference profile with global. prefix" do
-      assert {:ok, {:bedrock, "global.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
-               Spec.resolve("bedrock:global.anthropic.claude-opus-4-1-20250805-v1:0")
+      assert {:ok, {:amazon_bedrock, "global.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:global.anthropic.claude-opus-4-1-20250805-v1:0")
 
       assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
     end
 
     test "resolves inference profile with eu. prefix" do
-      assert {:ok, {:bedrock, "eu.meta.llama3-2-3b-instruct-v1:0", model}} =
-               Spec.resolve("bedrock:eu.meta.llama3-2-3b-instruct-v1:0")
+      assert {:ok, {:amazon_bedrock, "eu.meta.llama3-2-3b-instruct-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:eu.meta.llama3-2-3b-instruct-v1:0")
 
       assert model.id == "meta.llama3-2-3b-instruct-v1:0"
       assert model.name == "Llama 3.2 3B"
     end
 
     test "resolves inference profile with ap. prefix" do
-      assert {:ok, {:bedrock, "ap.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
-               Spec.resolve("bedrock:ap.anthropic.claude-opus-4-1-20250805-v1:0")
+      assert {:ok, {:amazon_bedrock, "ap.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:ap.anthropic.claude-opus-4-1-20250805-v1:0")
 
       assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
     end
 
     test "resolves inference profile with ca. prefix" do
-      assert {:ok, {:bedrock, "ca.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
-               Spec.resolve("bedrock:ca.anthropic.claude-opus-4-1-20250805-v1:0")
+      assert {:ok, {:amazon_bedrock, "ca.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:ca.anthropic.claude-opus-4-1-20250805-v1:0")
+
+      assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
+    end
+
+    test "resolves inference profile with au. prefix" do
+      assert {:ok, {:amazon_bedrock, "au.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:au.anthropic.claude-opus-4-1-20250805-v1:0")
+
+      assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
+    end
+
+    test "resolves inference profile with apac. prefix" do
+      assert {:ok, {:amazon_bedrock, "apac.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:apac.anthropic.claude-opus-4-1-20250805-v1:0")
+
+      assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
+    end
+
+    test "resolves inference profile with jp. prefix" do
+      assert {:ok, {:amazon_bedrock, "jp.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:jp.anthropic.claude-opus-4-1-20250805-v1:0")
+
+      assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
+    end
+
+    test "resolves inference profile with us-gov. prefix" do
+      assert {:ok, {:amazon_bedrock, "us-gov.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:us-gov.anthropic.claude-opus-4-1-20250805-v1:0")
 
       assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
     end
 
     test "resolves native Bedrock model without prefix" do
-      assert {:ok, {:bedrock, "anthropic.claude-opus-4-1-20250805-v1:0", model}} =
-               Spec.resolve("bedrock:anthropic.claude-opus-4-1-20250805-v1:0")
+      assert {:ok, {:amazon_bedrock, "anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:anthropic.claude-opus-4-1-20250805-v1:0")
 
       assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
     end
 
     test "resolves inference profile with tuple input" do
-      assert {:ok, {:bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
-               Spec.resolve({:bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0"})
+      assert {:ok, {:amazon_bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve({:amazon_bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0"})
 
       assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
     end
 
     test "resolves inference profile alias to canonical with prefix preserved" do
-      assert {:ok, {:bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
-               Spec.resolve("bedrock:us.anthropic.claude-opus")
+      assert {:ok, {:amazon_bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:us.anthropic.claude-opus")
 
       assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
       assert model.name == "Claude Opus 4.1"
     end
 
     test "resolves inference profile alias with different prefix" do
-      assert {:ok, {:bedrock, "global.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
-               Spec.resolve("bedrock:global.anthropic.claude-opus")
+      assert {:ok, {:amazon_bedrock, "global.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("amazon_bedrock:global.anthropic.claude-opus")
 
       assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
     end
 
     test "returns error for inference profile with nonexistent base model" do
-      assert {:error, :not_found} = Spec.resolve("bedrock:us.nonexistent.model")
+      assert {:error, :not_found} = Spec.resolve("amazon_bedrock:us.nonexistent.model")
     end
 
     test "preserves prefix for bare alias resolution with scope" do
-      assert {:ok, {:bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
-               Spec.resolve("us.anthropic.claude-opus", scope: :bedrock)
+      assert {:ok, {:amazon_bedrock, "us.anthropic.claude-opus-4-1-20250805-v1:0", model}} =
+               Spec.resolve("us.anthropic.claude-opus", scope: :amazon_bedrock)
 
       assert model.id == "anthropic.claude-opus-4-1-20250805-v1:0"
     end
 
     test "only strips known Bedrock prefixes, not arbitrary prefixes" do
       assert {:error, :not_found} =
-               Spec.resolve("bedrock:unknown.anthropic.claude-opus-4-1-20250805-v1:0")
+               Spec.resolve("amazon_bedrock:unknown.anthropic.claude-opus-4-1-20250805-v1:0")
     end
 
     test "does not affect non-Bedrock providers with similar prefixes" do

--- a/test/llm_db_test.exs
+++ b/test/llm_db_test.exs
@@ -622,6 +622,48 @@ defmodule LLMDBTest do
       assert {:error, :unknown_provider} = LLMDB.model("nonexistent:model")
     end
 
+    test "model/1 strips Bedrock inference profile prefixes" do
+      Store.clear!()
+
+      {:ok, _} =
+        load_with_test_data(%{
+          overrides: %{
+            providers: [%{id: :amazon_bedrock, name: "Amazon Bedrock"}],
+            models: [
+              %{
+                id: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+                provider: :amazon_bedrock,
+                capabilities: %{chat: true}
+              }
+            ]
+          }
+        })
+
+      # Without prefix
+      assert {:ok, model} =
+               LLMDB.model("amazon_bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0")
+
+      assert model.id == "anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+      # With au. prefix
+      assert {:ok, model} =
+               LLMDB.model("amazon_bedrock:au.anthropic.claude-sonnet-4-5-20250929-v1:0")
+
+      assert model.id == "anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+      # With us. prefix
+      assert {:ok, model} =
+               LLMDB.model("amazon_bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+
+      assert model.id == "anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+      # With eu. prefix
+      assert {:ok, model} =
+               LLMDB.model("amazon_bedrock:eu.anthropic.claude-sonnet-4-5-20250929-v1:0")
+
+      assert model.id == "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    end
+
     test "model/2 resolves model by provider and id" do
       providers = LLMDB.providers()
 


### PR DESCRIPTION
## Description

The inference profile prefix stripping was checking for `:bedrock` which doesn't exist in the catalog — the real provider is :amazon_bedrock. Also adds missing region prefixes (au, apac, jp, us-gov) per the AWS docs.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
- [x] I have **NOT** directly edited files in `priv/llm_db/providers/` (they are generated by `mix llm_db.build`)

## Related Issues

https://github.com/agentjido/req_llm/pull/449
