### PR TITLE
feat: Use canonical costs for dated models

### DIFF
--- a/lib/llm_db/engine/enrich.ex
+++ b/lib/llm_db/engine/enrich.ex
@@ -91,8 +91,58 @@ defmodule LLMDB.Enrich do
   """
   @spec enrich_models([map()]) :: [map()]
   def enrich_models(models) when is_list(models) do
-    Enum.map(models, &enrich_model/1)
+    models
+    |> Enum.map(&enrich_model/1)
+    |> inherit_canonical_costs()
   end
+
+  @date_suffix ~r/-\d{4}-\d{2}-\d{2}$/
+
+  @doc """
+  Propagates cost from canonical models to their dated variants.
+
+  For models with a date suffix (e.g., `gpt-4o-mini-2024-07-18`), if the model
+  has no cost, looks up the canonical model (e.g., `gpt-4o-mini`) from the same
+  provider and copies its cost.
+
+  Models that already have a cost are left unchanged.
+
+  ## Examples
+
+      iex> models = [
+      ...>   %{id: "gpt-4o-mini", provider: :openai, cost: %{input: 0.15, output: 0.6}},
+      ...>   %{id: "gpt-4o-mini-2024-07-18", provider: :openai}
+      ...> ]
+      iex> [_, dated] = LLMDB.Enrich.inherit_canonical_costs(models)
+      iex> dated.cost
+      %{input: 0.15, output: 0.6}
+  """
+  @spec inherit_canonical_costs([map()]) :: [map()]
+  def inherit_canonical_costs(models) when is_list(models) do
+    canonicals_with_cost =
+      models
+      |> Enum.reject(&dated_model?/1)
+      |> Enum.filter(&has_cost?/1)
+      |> Map.new(&{{&1.provider, &1.id}, &1.cost})
+
+    Enum.map(models, fn model ->
+      if dated_model?(model) and not has_cost?(model) do
+        canonical_id = Regex.replace(@date_suffix, model.id, "")
+
+        case Map.get(canonicals_with_cost, {model.provider, canonical_id}) do
+          nil -> model
+          cost -> Map.put(model, :cost, cost)
+        end
+      else
+        model
+      end
+    end)
+  end
+
+  defp dated_model?(%{id: id}), do: Regex.match?(@date_suffix, id)
+
+  defp has_cost?(%{cost: cost}) when is_map(cost) and map_size(cost) > 0, do: true
+  defp has_cost?(_), do: false
 
   # Private helpers
 

--- a/priv/llm_db/manifest.json
+++ b/priv/llm_db/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-20T12:37:48.310893Z",
+  "generated_at": "2026-02-26T11:22:05.969815Z",
   "providers": [
     "302ai",
     "abacus",

--- a/priv/llm_db/providers/openai.json
+++ b/priv/llm_db/providers/openai.json
@@ -801,7 +801,10 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "input": 10,
+        "output": 30
+      },
       "deprecated": false,
       "extra": {
         "api": "chat",
@@ -928,7 +931,11 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "cache_read": 0.5,
+        "input": 2,
+        "output": 8
+      },
       "deprecated": false,
       "extra": {
         "api": "responses",
@@ -1025,7 +1032,11 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "cache_read": 0.1,
+        "input": 0.4,
+        "output": 1.6
+      },
       "deprecated": false,
       "extra": {
         "api": "responses",
@@ -1122,7 +1133,11 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "cache_read": 0.03,
+        "input": 0.1,
+        "output": 0.4
+      },
       "deprecated": false,
       "extra": {
         "api": "responses",
@@ -1574,7 +1589,11 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "cache_read": 0.08,
+        "input": 0.15,
+        "output": 0.6
+      },
       "deprecated": false,
       "extra": {
         "created": 1721172717,
@@ -2188,7 +2207,11 @@
           "strict": false
         }
       },
-      "cost": null,
+      "cost": {
+        "cache_read": 0.125,
+        "input": 1.25,
+        "output": 10
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -2462,7 +2485,11 @@
           "strict": false
         }
       },
-      "cost": null,
+      "cost": {
+        "cache_read": 0.025,
+        "input": 0.25,
+        "output": 2
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -2590,7 +2617,11 @@
           "strict": false
         }
       },
-      "cost": null,
+      "cost": {
+        "cache_read": 0.005,
+        "input": 0.05,
+        "output": 0.4
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -2717,7 +2748,10 @@
           "strict": false
         }
       },
-      "cost": null,
+      "cost": {
+        "input": 15,
+        "output": 120
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -2897,7 +2931,11 @@
           "strict": false
         }
       },
-      "cost": null,
+      "cost": {
+        "cache_read": 0.13,
+        "input": 1.25,
+        "output": 10
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -3316,7 +3354,11 @@
           "strict": false
         }
       },
-      "cost": null,
+      "cost": {
+        "cache_read": 0.175,
+        "input": 1.75,
+        "output": 14
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -3591,7 +3633,10 @@
           "strict": false
         }
       },
-      "cost": null,
+      "cost": {
+        "input": 21,
+        "output": 168
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -4473,7 +4518,11 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "cache_read": 7.5,
+        "input": 15,
+        "output": 60
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -4612,7 +4661,11 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "cache_read": 0.5,
+        "input": 2,
+        "output": 8
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -4742,7 +4795,11 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "cache_read": 0.55,
+        "input": 1.1,
+        "output": 4.4
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -4846,7 +4903,10 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "input": 20,
+        "output": 80
+      },
       "deprecated": false,
       "extra": {
         "constraints": {
@@ -4951,7 +5011,11 @@
       "aliases": [],
       "base_url": null,
       "capabilities": null,
-      "cost": null,
+      "cost": {
+        "cache_read": 0.28,
+        "input": 1.1,
+        "output": 4.4
+      },
       "deprecated": false,
       "extra": {
         "constraints": {

--- a/test/llm_db/engine/enrich_test.exs
+++ b/test/llm_db/engine/enrich_test.exs
@@ -210,6 +210,109 @@ defmodule LLMDB.Engine.EnrichTest do
     end
   end
 
+  describe "inherit_canonical_costs/1" do
+    test "dated model inherits cost from canonical" do
+      models = [
+        %{id: "gpt-4o-mini", provider: :openai, cost: %{input: 0.15, output: 0.6}},
+        %{id: "gpt-4o-mini-2024-07-18", provider: :openai}
+      ]
+
+      [_canonical, dated] = Enrich.inherit_canonical_costs(models)
+      assert dated.cost == %{input: 0.15, output: 0.6}
+    end
+
+    test "does not overwrite existing cost on dated model" do
+      models = [
+        %{id: "gpt-4o", provider: :openai, cost: %{input: 2.5, output: 10}},
+        %{id: "gpt-4o-2024-08-06", provider: :openai, cost: %{input: 1.25, output: 5}}
+      ]
+
+      [_canonical, dated] = Enrich.inherit_canonical_costs(models)
+      assert dated.cost == %{input: 1.25, output: 5}
+    end
+
+    test "does not inherit across providers" do
+      models = [
+        %{id: "model-v1", provider: :openai, cost: %{input: 1.0, output: 2.0}},
+        %{id: "model-v1-2024-07-18", provider: :anthropic}
+      ]
+
+      [_canonical, dated] = Enrich.inherit_canonical_costs(models)
+      refute Map.has_key?(dated, :cost)
+    end
+
+    test "leaves dated model unchanged when no canonical exists" do
+      models = [
+        %{id: "orphan-model-2024-07-18", provider: :openai}
+      ]
+
+      [dated] = Enrich.inherit_canonical_costs(models)
+      refute Map.has_key?(dated, :cost)
+    end
+
+    test "leaves dated model unchanged when canonical has no cost" do
+      models = [
+        %{id: "gpt-4o-mini", provider: :openai},
+        %{id: "gpt-4o-mini-2024-07-18", provider: :openai}
+      ]
+
+      [_canonical, dated] = Enrich.inherit_canonical_costs(models)
+      refute Map.has_key?(dated, :cost)
+    end
+
+    test "handles multiple dated variants of the same canonical" do
+      cost = %{input: 0.15, output: 0.6}
+
+      models = [
+        %{id: "gpt-4o-mini", provider: :openai, cost: cost},
+        %{id: "gpt-4o-mini-2024-07-18", provider: :openai},
+        %{id: "gpt-4o-mini-2025-01-15", provider: :openai}
+      ]
+
+      [_canonical, dated1, dated2] = Enrich.inherit_canonical_costs(models)
+      assert dated1.cost == cost
+      assert dated2.cost == cost
+    end
+
+    test "handles complex model IDs with date suffix" do
+      cost = %{input: 1.0, output: 4.0}
+
+      models = [
+        %{id: "gpt-4o-mini-realtime-preview", provider: :openai, cost: cost},
+        %{id: "gpt-4o-mini-realtime-preview-2024-12-17", provider: :openai}
+      ]
+
+      [_canonical, dated] = Enrich.inherit_canonical_costs(models)
+      assert dated.cost == cost
+    end
+
+    test "does not treat non-date suffixes as dated models" do
+      models = [
+        %{id: "gpt-3.5-turbo", provider: :openai, cost: %{input: 0.5, output: 1.5}},
+        %{id: "gpt-3.5-turbo-0125", provider: :openai}
+      ]
+
+      [_canonical, model] = Enrich.inherit_canonical_costs(models)
+      refute Map.has_key?(model, :cost)
+    end
+
+    test "empty list returns empty list" do
+      assert Enrich.inherit_canonical_costs([]) == []
+    end
+
+    test "integrates with enrich_models pipeline" do
+      models = [
+        %{id: "test-model-v1", provider: :test_provider_alpha, cost: %{input: 1.0, output: 2.0}},
+        %{id: "test-model-v1-2024-07-18", provider: :test_provider_alpha}
+      ]
+
+      [canonical, dated] = Enrich.enrich_models(models)
+      assert canonical.provider_model_id == "test-model-v1"
+      assert dated.cost == %{input: 1.0, output: 2.0}
+      assert dated.provider_model_id == "test-model-v1-2024-07-18"
+    end
+  end
+
   describe "integration with validation" do
     test "enrichment works before validation" do
       alias LLMDB.Validate


### PR DESCRIPTION
## Description

Inherit canonical model costs into dated models

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
- [ ] I have **NOT** directly edited files in `priv/llm_db/providers/` (they are generated by `mix llm_db.build`)

## Related Issues

Closes #131
