### PR TITLE
fix: include OpenRouter in mix llm_db.pull sources

### DIFF
--- a/lib/mix/tasks/llm_db.pull.ex
+++ b/lib/mix/tasks/llm_db.pull.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.LlmDb.Pull do
 
   ## Switches
 
-  - `--source` - Pull from a specific source only (openai, anthropic, google, xai, models_dev)
+  - `--source` - Pull from a specific source only (openai, anthropic, google, xai, models_dev, openrouter, zenmux)
 
   ## Configuration
 
@@ -66,6 +66,7 @@ defmodule Mix.Tasks.LlmDb.Pull do
     "google" => LLMDB.Sources.Google,
     "xai" => LLMDB.Sources.XAI,
     "models_dev" => LLMDB.Sources.ModelsDev,
+    "openrouter" => LLMDB.Sources.OpenRouter,
     "zenmux" => LLMDB.Sources.Zenmux
   }
 


### PR DESCRIPTION
## Summary
- add `openrouter` to `@source_modules` in `Mix.Tasks.LlmDb.Pull`
- update `--source` task docs to include all currently supported named sources (`openrouter`, `zenmux`)

## Why
`mix llm_db.pull --source openrouter` failed with `Unknown source: openrouter` even though `LLMDB.Sources.OpenRouter` exists and is configured.

## Validation
- `mix llm_db.pull --source openrouter`
- `mix test test/llm_db/sources/openrouter_test.exs`
- pre-push hooks: `mix test` and `mix quality`

Closes #138
