### PR TITLE
fix: preserve sparse overlay intent across merges

### DIFF
--- a/lib/llm_db/engine.ex
+++ b/lib/llm_db/engine.ex
@@ -80,7 +80,8 @@ defmodule LLMDB.Engine do
          {:ok, normalized} <- normalize_layers(layers_data),
          {:ok, validated} <- validate_layers(normalized),
          {:ok, merged} <- merge_layers(validated),
-         {:ok, snapshot} <- finalize(merged),
+         {:ok, merged_validated} <- validate_merged(merged),
+         {:ok, snapshot} <- finalize(merged_validated),
          :ok <- validate_runtime_contract(snapshot),
          :ok <- ensure_viable(snapshot) do
       {:ok, snapshot}
@@ -95,6 +96,7 @@ defmodule LLMDB.Engine do
         nil -> Config.sources!()
         sources when is_list(sources) -> sources
       end
+      |> prioritize_source_precedence()
 
     # Warn if no sources provided
     if sources_list == [] do
@@ -145,12 +147,14 @@ defmodule LLMDB.Engine do
     {:ok, %{layers: normalized_layers}}
   end
 
-  # Stage 3: Validate - apply to each layer and log results
+  # Stage 3: Validate - apply to each layer and preserve sparse overlay intent
   defp validate_layers(normalized) do
     validated_layers =
       Enum.map(normalized.layers, fn layer ->
-        {:ok, providers, providers_dropped} = Validate.validate_providers(layer.providers)
-        {:ok, models, models_dropped} = Validate.validate_models(layer.models)
+        {:ok, providers, providers_dropped} =
+          Validate.validate_providers_for_merge(layer.providers)
+
+        {:ok, models, models_dropped} = Validate.validate_models_for_merge(layer.models)
 
         if providers_dropped > 0 do
           Logger.warning(
@@ -196,6 +200,21 @@ defmodule LLMDB.Engine do
     filtered_models = Merge.merge_models(models, [], excludes)
 
     {:ok, %{providers: providers, models: filtered_models}}
+  end
+
+  defp validate_merged(merged) do
+    {:ok, providers, providers_dropped} = Validate.validate_providers(merged.providers)
+    {:ok, models, models_dropped} = Validate.validate_models(merged.models)
+
+    if providers_dropped > 0 do
+      Logger.warning("Dropped #{providers_dropped} invalid provider(s) after merge")
+    end
+
+    if models_dropped > 0 do
+      Logger.warning("Dropped #{models_dropped} invalid model(s) after merge")
+    end
+
+    {:ok, %{providers: providers, models: models}}
   end
 
   # Stage 5: Finalize (Enrich → Nest)
@@ -362,5 +381,16 @@ defmodule LLMDB.Engine do
 
       {[provider | provs_acc], models ++ mods_acc}
     end)
+  end
+
+  # Local TOML overlays are the highest-precedence source regardless of config order.
+  defp prioritize_source_precedence(sources) when is_list(sources) do
+    {locals, non_locals} =
+      Enum.split_with(sources, fn
+        {LLMDB.Sources.Local, _opts} -> true
+        _other -> false
+      end)
+
+    non_locals ++ locals
   end
 end

--- a/lib/llm_db/engine/validate.ex
+++ b/lib/llm_db/engine/validate.ex
@@ -86,22 +86,16 @@ defmodule LLMDB.Validate do
   explicitly supplied fields plus required identity.
   """
   @spec validate_provider_overlay(map()) :: {:ok, map()} | {:error, validation_error()}
-  def validate_provider_overlay(map) when is_map(map) do
-    with {:ok, provider} <- validate_provider(map) do
-      {:ok, sparse_overlay(provider, map, [:id])}
-    end
-  end
+  def validate_provider_overlay(map) when is_map(map),
+    do: validate_overlay(map, &validate_provider/1, [:id])
 
   @doc """
   Validates a model map and returns a sparse overlay that preserves only the
   explicitly supplied fields plus required identity.
   """
   @spec validate_model_overlay(map()) :: {:ok, map()} | {:error, validation_error()}
-  def validate_model_overlay(map) when is_map(map) do
-    with {:ok, model} <- validate_model(map) do
-      {:ok, sparse_overlay(model, map, [:id, :provider])}
-    end
-  end
+  def validate_model_overlay(map) when is_map(map),
+    do: validate_overlay(map, &validate_model/1, [:id, :provider])
 
   @doc """
   Validates a list of provider maps, collecting valid ones and counting invalid.
@@ -115,33 +109,14 @@ defmodule LLMDB.Validate do
       {:ok, [%{id: :openai}, %{id: :anthropic}], 1}
   """
   @spec validate_providers([map()]) :: {:ok, [Provider.t()], non_neg_integer()}
-  def validate_providers(maps) when is_list(maps) do
-    {valid, invalid_count} =
-      Enum.reduce(maps, {[], 0}, fn map, {valid_acc, invalid_acc} ->
-        case validate_provider(map) do
-          {:ok, provider} -> {[provider | valid_acc], invalid_acc}
-          {:error, _} -> {valid_acc, invalid_acc + 1}
-        end
-      end)
-
-    {:ok, Enum.reverse(valid), invalid_count}
-  end
+  def validate_providers(maps) when is_list(maps), do: validate_many(maps, &validate_provider/1)
 
   @doc """
   Validates a list of provider maps and returns sparse overlays suitable for merge.
   """
   @spec validate_providers_for_merge([map()]) :: {:ok, [map()], non_neg_integer()}
-  def validate_providers_for_merge(maps) when is_list(maps) do
-    {valid, invalid_count} =
-      Enum.reduce(maps, {[], 0}, fn map, {valid_acc, invalid_acc} ->
-        case validate_provider_overlay(map) do
-          {:ok, provider} -> {[provider | valid_acc], invalid_acc}
-          {:error, _} -> {valid_acc, invalid_acc + 1}
-        end
-      end)
-
-    {:ok, Enum.reverse(valid), invalid_count}
-  end
+  def validate_providers_for_merge(maps) when is_list(maps),
+    do: validate_many(maps, &validate_provider_overlay/1)
 
   @doc """
   Validates a list of model maps, collecting valid ones and counting invalid.
@@ -159,53 +134,15 @@ defmodule LLMDB.Validate do
       {:ok, [%{id: "gpt-4o", ...}, %{id: "claude-3", ...}], 1}
   """
   @spec validate_models([map()]) :: {:ok, [Model.t()], non_neg_integer()}
-  def validate_models(maps) when is_list(maps) do
-    {valid, invalid_count} =
-      Enum.reduce(maps, {[], 0}, fn map, {valid_acc, invalid_acc} ->
-        case validate_model(map) do
-          {:ok, model} ->
-            {[model | valid_acc], invalid_acc}
-
-          {:error, error} ->
-            model_id = Map.get(map, :id, Map.get(map, "id", "unknown"))
-            provider = Map.get(map, :provider, Map.get(map, "provider", "unknown"))
-
-            Logger.warning(
-              "Validation failed for model #{inspect(provider)}:#{inspect(model_id)}: #{inspect(error)}"
-            )
-
-            {valid_acc, invalid_acc + 1}
-        end
-      end)
-
-    {:ok, Enum.reverse(valid), invalid_count}
-  end
+  def validate_models(maps) when is_list(maps),
+    do: validate_many(maps, &validate_model/1, &log_model_validation_error/2)
 
   @doc """
   Validates a list of model maps and returns sparse overlays suitable for merge.
   """
   @spec validate_models_for_merge([map()]) :: {:ok, [map()], non_neg_integer()}
-  def validate_models_for_merge(maps) when is_list(maps) do
-    {valid, invalid_count} =
-      Enum.reduce(maps, {[], 0}, fn map, {valid_acc, invalid_acc} ->
-        case validate_model_overlay(map) do
-          {:ok, model} ->
-            {[model | valid_acc], invalid_acc}
-
-          {:error, error} ->
-            model_id = Map.get(map, :id, Map.get(map, "id", "unknown"))
-            provider = Map.get(map, :provider, Map.get(map, "provider", "unknown"))
-
-            Logger.warning(
-              "Validation failed for model #{inspect(provider)}:#{inspect(model_id)}: #{inspect(error)}"
-            )
-
-            {valid_acc, invalid_acc + 1}
-        end
-      end)
-
-    {:ok, Enum.reverse(valid), invalid_count}
-  end
+  def validate_models_for_merge(maps) when is_list(maps),
+    do: validate_many(maps, &validate_model_overlay/1, &log_model_validation_error/2)
 
   @doc """
   Validates typed provider runtime and model execution metadata after merge/enrichment.
@@ -557,6 +494,37 @@ defmodule LLMDB.Validate do
 
   defp maybe_add_operation(operations, true, operation), do: [operation | operations]
   defp maybe_add_operation(operations, false, _operation), do: operations
+
+  defp validate_overlay(map, validator, required_keys) when is_map(map) do
+    with {:ok, parsed} <- validator.(map) do
+      {:ok, sparse_overlay(parsed, map, required_keys)}
+    end
+  end
+
+  defp validate_many(maps, validator, on_error \\ fn _, _ -> :ok end) when is_list(maps) do
+    {valid, invalid_count} =
+      Enum.reduce(maps, {[], 0}, fn map, {valid_acc, invalid_acc} ->
+        case validator.(map) do
+          {:ok, item} ->
+            {[item | valid_acc], invalid_acc}
+
+          {:error, error} ->
+            on_error.(map, error)
+            {valid_acc, invalid_acc + 1}
+        end
+      end)
+
+    {:ok, Enum.reverse(valid), invalid_count}
+  end
+
+  defp log_model_validation_error(map, error) do
+    model_id = Map.get(map, :id, Map.get(map, "id", "unknown"))
+    provider = Map.get(map, :provider, Map.get(map, "provider", "unknown"))
+
+    Logger.warning(
+      "Validation failed for model #{inspect(provider)}:#{inspect(model_id)}: #{inspect(error)}"
+    )
+  end
 
   defp sparse_overlay(parsed, raw, required_keys) when is_map(raw) do
     parsed_map =

--- a/lib/llm_db/engine/validate.ex
+++ b/lib/llm_db/engine/validate.ex
@@ -616,10 +616,10 @@ defmodule LLMDB.Validate do
 
       is_binary(raw_key) ->
         case maybe_existing_atom(raw_key) do
-          atom_key when is_atom(atom_key) ->
+          {:ok, atom_key} ->
             if Map.has_key?(parsed_map, atom_key), do: atom_key
 
-          _ ->
+          :error ->
             nil
         end
 
@@ -637,9 +637,9 @@ defmodule LLMDB.Validate do
 
   defp maybe_existing_atom(key) when is_binary(key) do
     try do
-      String.to_existing_atom(key)
+      {:ok, String.to_existing_atom(key)}
     rescue
-      ArgumentError -> nil
+      ArgumentError -> :error
     end
   end
 end

--- a/lib/llm_db/engine/validate.ex
+++ b/lib/llm_db/engine/validate.ex
@@ -82,6 +82,28 @@ defmodule LLMDB.Validate do
   end
 
   @doc """
+  Validates a provider map and returns a sparse overlay that preserves only the
+  explicitly supplied fields plus required identity.
+  """
+  @spec validate_provider_overlay(map()) :: {:ok, map()} | {:error, validation_error()}
+  def validate_provider_overlay(map) when is_map(map) do
+    with {:ok, provider} <- validate_provider(map) do
+      {:ok, sparse_overlay(provider, map, [:id])}
+    end
+  end
+
+  @doc """
+  Validates a model map and returns a sparse overlay that preserves only the
+  explicitly supplied fields plus required identity.
+  """
+  @spec validate_model_overlay(map()) :: {:ok, map()} | {:error, validation_error()}
+  def validate_model_overlay(map) when is_map(map) do
+    with {:ok, model} <- validate_model(map) do
+      {:ok, sparse_overlay(model, map, [:id, :provider])}
+    end
+  end
+
+  @doc """
   Validates a list of provider maps, collecting valid ones and counting invalid.
 
   Returns all valid providers and the count of invalid ones that were dropped.
@@ -97,6 +119,22 @@ defmodule LLMDB.Validate do
     {valid, invalid_count} =
       Enum.reduce(maps, {[], 0}, fn map, {valid_acc, invalid_acc} ->
         case validate_provider(map) do
+          {:ok, provider} -> {[provider | valid_acc], invalid_acc}
+          {:error, _} -> {valid_acc, invalid_acc + 1}
+        end
+      end)
+
+    {:ok, Enum.reverse(valid), invalid_count}
+  end
+
+  @doc """
+  Validates a list of provider maps and returns sparse overlays suitable for merge.
+  """
+  @spec validate_providers_for_merge([map()]) :: {:ok, [map()], non_neg_integer()}
+  def validate_providers_for_merge(maps) when is_list(maps) do
+    {valid, invalid_count} =
+      Enum.reduce(maps, {[], 0}, fn map, {valid_acc, invalid_acc} ->
+        case validate_provider_overlay(map) do
           {:ok, provider} -> {[provider | valid_acc], invalid_acc}
           {:error, _} -> {valid_acc, invalid_acc + 1}
         end
@@ -125,6 +163,32 @@ defmodule LLMDB.Validate do
     {valid, invalid_count} =
       Enum.reduce(maps, {[], 0}, fn map, {valid_acc, invalid_acc} ->
         case validate_model(map) do
+          {:ok, model} ->
+            {[model | valid_acc], invalid_acc}
+
+          {:error, error} ->
+            model_id = Map.get(map, :id, Map.get(map, "id", "unknown"))
+            provider = Map.get(map, :provider, Map.get(map, "provider", "unknown"))
+
+            Logger.warning(
+              "Validation failed for model #{inspect(provider)}:#{inspect(model_id)}: #{inspect(error)}"
+            )
+
+            {valid_acc, invalid_acc + 1}
+        end
+      end)
+
+    {:ok, Enum.reverse(valid), invalid_count}
+  end
+
+  @doc """
+  Validates a list of model maps and returns sparse overlays suitable for merge.
+  """
+  @spec validate_models_for_merge([map()]) :: {:ok, [map()], non_neg_integer()}
+  def validate_models_for_merge(maps) when is_list(maps) do
+    {valid, invalid_count} =
+      Enum.reduce(maps, {[], 0}, fn map, {valid_acc, invalid_acc} ->
+        case validate_model_overlay(map) do
           {:ok, model} ->
             {[model | valid_acc], invalid_acc}
 
@@ -493,4 +557,89 @@ defmodule LLMDB.Validate do
 
   defp maybe_add_operation(operations, true, operation), do: [operation | operations]
   defp maybe_add_operation(operations, false, _operation), do: operations
+
+  defp sparse_overlay(parsed, raw, required_keys) when is_map(raw) do
+    parsed_map =
+      case parsed do
+        struct when is_struct(struct) -> Map.from_struct(struct)
+        map when is_map(map) -> map
+      end
+
+    explicit =
+      Enum.reduce(raw, %{}, fn {raw_key, raw_value}, acc ->
+        case overlay_key(raw_key, parsed_map) do
+          nil ->
+            acc
+
+          key ->
+            parsed_value = Map.get(parsed_map, key)
+            Map.put(acc, key, sparse_overlay_value(parsed_value, raw_value))
+        end
+      end)
+
+    Enum.reduce(required_keys, explicit, fn key, acc ->
+      if Map.has_key?(acc, key) or not Map.has_key?(parsed_map, key) do
+        acc
+      else
+        Map.put(acc, key, Map.get(parsed_map, key))
+      end
+    end)
+  end
+
+  defp sparse_overlay_value(parsed_value, raw_value)
+
+  defp sparse_overlay_value(parsed_value, raw_value)
+       when is_map(parsed_value) and is_map(raw_value) do
+    sparse_overlay(parsed_value, raw_value, [])
+  end
+
+  defp sparse_overlay_value(parsed_value, raw_value)
+       when is_list(parsed_value) and is_list(raw_value) do
+    if length(parsed_value) == length(raw_value) and
+         Enum.all?(raw_value, &is_map/1) and
+         Enum.all?(parsed_value, &(is_map(&1) or is_struct(&1))) do
+      Enum.zip(parsed_value, raw_value)
+      |> Enum.map(fn {parsed_item, raw_item} ->
+        sparse_overlay(parsed_item, raw_item, [])
+      end)
+    else
+      parsed_value
+    end
+  end
+
+  defp sparse_overlay_value(parsed_value, _raw_value), do: parsed_value
+
+  defp overlay_key(raw_key, parsed_map) when is_map(parsed_map) do
+    cond do
+      Map.has_key?(parsed_map, raw_key) ->
+        raw_key
+
+      is_binary(raw_key) ->
+        case maybe_existing_atom(raw_key) do
+          atom_key when is_atom(atom_key) ->
+            if Map.has_key?(parsed_map, atom_key), do: atom_key
+
+          _ ->
+            nil
+        end
+
+      is_atom(raw_key) ->
+        string_key = Atom.to_string(raw_key)
+
+        if Map.has_key?(parsed_map, string_key) do
+          string_key
+        end
+
+      true ->
+        nil
+    end
+  end
+
+  defp maybe_existing_atom(key) when is_binary(key) do
+    try do
+      String.to_existing_atom(key)
+    rescue
+      ArgumentError -> nil
+    end
+  end
 end

--- a/lib/llm_db/loader.ex
+++ b/lib/llm_db/loader.ex
@@ -9,7 +9,7 @@ defmodule LLMDB.Loader do
   LLMDB module focused on the query API.
   """
 
-  alias LLMDB.{Engine, Merge, Model, Packaged, Pricing, Provider, Runtime, Snapshot}
+  alias LLMDB.{Engine, Merge, Model, Packaged, Pricing, Provider, Runtime, Snapshot, Validate}
   alias LLMDB.Snapshot.ReleaseStore
 
   require Logger
@@ -301,27 +301,51 @@ defmodule LLMDB.Loader do
   end
 
   defp merge_custom({providers, models}, custom) do
-    # Deserialize custom providers and models (convert JSON strings to atoms)
-    custom_providers = deserialize_json_atoms(custom.providers, :provider)
-    custom_models = deserialize_json_atoms(custom.models, :model)
+    custom_providers =
+      Enum.map(custom.providers, fn provider ->
+        case Validate.validate_provider_overlay(provider) do
+          {:ok, overlay} ->
+            overlay
 
-    # Merge providers (last wins by ID)
-    merged_providers = Merge.merge_providers(providers, custom_providers)
+          {:error, reason} ->
+            raise ArgumentError, "Invalid custom provider: #{inspect(reason)}"
+        end
+      end)
 
-    # Merge models (last wins by provider + id)
-    merged_models = merge_models(models, custom_models)
+    custom_models =
+      Enum.map(custom.models, fn model ->
+        case Validate.validate_model_overlay(model) do
+          {:ok, overlay} ->
+            overlay
+
+          {:error, reason} ->
+            raise ArgumentError, "Invalid custom model: #{inspect(reason)}"
+        end
+      end)
+
+    merged_providers =
+      providers
+      |> Merge.merge_providers(custom_providers)
+      |> revalidate_merged!(&Validate.validate_provider/1, "custom provider")
+
+    merged_models =
+      models
+      |> Merge.merge_models(custom_models, %{})
+      |> revalidate_merged!(&Validate.validate_model/1, "custom model")
 
     {merged_providers, merged_models}
   end
 
-  defp merge_models(base_models, custom_models) do
-    # Build map by {provider, id} for efficient merging
-    base_map = Map.new(base_models, fn m -> {{m.provider, m.id}, m} end)
-    custom_map = Map.new(custom_models, fn m -> {{m.provider, m.id}, m} end)
+  defp revalidate_merged!(items, validator, label) when is_list(items) do
+    Enum.map(items, fn item ->
+      case validator.(item) do
+        {:ok, validated} ->
+          validated
 
-    # Merge with custom winning
-    Map.merge(base_map, custom_map)
-    |> Map.values()
+        {:error, reason} ->
+          raise ArgumentError, "Invalid #{label} after merge: #{inspect(reason)}"
+      end
+    end)
   end
 
   defp warn_unknown_providers([], _providers), do: :ok

--- a/lib/llm_db/loader.ex
+++ b/lib/llm_db/loader.ex
@@ -225,21 +225,11 @@ defmodule LLMDB.Loader do
 
   defp deserialize_json_atoms(items, :provider) do
     Enum.map(items, fn provider ->
-      # Convert provider ID from JSON string to existing atom
-      normalized_id =
-        case get_value(provider, :id) do
-          id when is_atom(id) -> id
-          id when is_binary(id) -> provider_atom(id)
-        end
-
-      provider_map =
-        provider
-        |> deep_atomize_keys()
-        |> Map.put(:id, normalized_id)
+      provider_map = normalize_provider_item(provider)
 
       # Validate and create Provider struct
-      case provider do
-        %Provider{} -> %{provider | id: normalized_id}
+      case provider_map do
+        %Provider{} = normalized -> normalized
         _ -> Provider.new!(provider_map)
       end
     end)
@@ -247,40 +237,11 @@ defmodule LLMDB.Loader do
 
   defp deserialize_json_atoms(items, :model) do
     Enum.map(items, fn model ->
-      # Convert provider from JSON string to existing atom
-      normalized_provider =
-        case get_value(model, :provider) do
-          p when is_atom(p) -> p
-          p when is_binary(p) -> provider_atom(p)
-        end
-
-      # Convert modality strings to existing atoms
-      model_map =
-        case get_value(model, :modalities) do
-          %{input: input, output: output} ->
-            put_value(model, :modalities, %{
-              input: deserialize_modality_list(input),
-              output: deserialize_modality_list(output)
-            })
-
-          %{"input" => input, "output" => output} ->
-            put_value(model, :modalities, %{
-              input: deserialize_modality_list(input),
-              output: deserialize_modality_list(output)
-            })
-
-          _ ->
-            model
-        end
-
-      model_map =
-        model_map
-        |> put_value(:provider, normalized_provider)
-        |> deep_atomize_keys()
+      model_map = normalize_model_item(model)
 
       # Validate and create Model struct
-      case model do
-        %Model{} -> model_map
+      case model_map do
+        %Model{} = normalized -> normalized
         _ -> Model.new!(model_map)
       end
     end)
@@ -301,27 +262,8 @@ defmodule LLMDB.Loader do
   end
 
   defp merge_custom({providers, models}, custom) do
-    custom_providers =
-      Enum.map(custom.providers, fn provider ->
-        case Validate.validate_provider_overlay(provider) do
-          {:ok, overlay} ->
-            overlay
-
-          {:error, reason} ->
-            raise ArgumentError, "Invalid custom provider: #{inspect(reason)}"
-        end
-      end)
-
-    custom_models =
-      Enum.map(custom.models, fn model ->
-        case Validate.validate_model_overlay(model) do
-          {:ok, overlay} ->
-            overlay
-
-          {:error, reason} ->
-            raise ArgumentError, "Invalid custom model: #{inspect(reason)}"
-        end
-      end)
+    custom_providers = validate_custom_overlays!(custom.providers, :provider)
+    custom_models = validate_custom_overlays!(custom.models, :model)
 
     merged_providers =
       providers
@@ -334,6 +276,32 @@ defmodule LLMDB.Loader do
       |> revalidate_merged!(&Validate.validate_model/1, "custom model")
 
     {merged_providers, merged_models}
+  end
+
+  defp validate_custom_overlays!(items, :provider) when is_list(items) do
+    Enum.map(items, fn provider ->
+      provider
+      |> normalize_provider_item()
+      |> validate_custom_overlay!(&Validate.validate_provider_overlay/1, "custom provider")
+    end)
+  end
+
+  defp validate_custom_overlays!(items, :model) when is_list(items) do
+    Enum.map(items, fn model ->
+      model
+      |> normalize_model_item()
+      |> validate_custom_overlay!(&Validate.validate_model_overlay/1, "custom model")
+    end)
+  end
+
+  defp validate_custom_overlay!(item, validator, label) do
+    case validator.(item) do
+      {:ok, overlay} ->
+        overlay
+
+      {:error, reason} ->
+        raise ArgumentError, "Invalid #{label}: #{inspect(reason)}"
+    end
   end
 
   defp revalidate_merged!(items, validator, label) when is_list(items) do
@@ -519,6 +487,53 @@ defmodule LLMDB.Loader do
 
   defp provider_atom(provider) when is_binary(provider) do
     safe_existing_atom(provider, true)
+  end
+
+  defp normalize_provider_item(provider) do
+    normalized_id =
+      case get_value(provider, :id) do
+        id when is_atom(id) -> id
+        id when is_binary(id) -> provider_atom(id)
+      end
+
+    provider
+    |> deep_atomize_keys()
+    |> Map.put(:id, normalized_id)
+  end
+
+  defp normalize_model_item(model) do
+    normalized_provider =
+      case get_value(model, :provider) do
+        provider when is_atom(provider) -> provider
+        provider when is_binary(provider) -> provider_atom(provider)
+      end
+
+    model
+    |> normalize_model_modalities()
+    |> put_value(:provider, normalized_provider)
+    |> deep_atomize_keys()
+  end
+
+  defp normalize_model_modalities(model) do
+    case get_value(model, :modalities) do
+      modalities when is_map(modalities) ->
+        normalized =
+          modalities
+          |> maybe_normalize_modality(:input)
+          |> maybe_normalize_modality(:output)
+
+        put_value(model, :modalities, normalized)
+
+      _other ->
+        model
+    end
+  end
+
+  defp maybe_normalize_modality(modalities, key) do
+    case get_value(modalities, key) do
+      list when is_list(list) -> put_value(modalities, key, deserialize_modality_list(list))
+      _other -> modalities
+    end
   end
 
   defp safe_existing_atom(value, allow_create \\ false)

--- a/test/llm_db/consumer_filtering_test.exs
+++ b/test/llm_db/consumer_filtering_test.exs
@@ -1,6 +1,7 @@
 defmodule LLMDB.ConsumerFilteringTest do
   use ExUnit.Case, async: false
 
+  alias LLMDB.{Engine, Snapshot}
   alias LLMDB.Sources.Config, as: ConfigSource
 
   setup do
@@ -246,9 +247,71 @@ defmodule LLMDB.ConsumerFilteringTest do
       local_models = LLMDB.models(:local_llm)
       assert length(local_models) == 2
     end
+
+    test "deep merges partial custom model overlays without losing packaged metadata" do
+      snapshot_path =
+        write_test_snapshot!(%{
+          providers: [%{id: :openai, name: "OpenAI"}],
+          models: [
+            %{
+              id: "gpt-5-mini",
+              provider: :openai,
+              name: "GPT-5 Mini",
+              cost: %{input: 0.25, output: 2.0},
+              capabilities: %{
+                chat: true,
+                reasoning: %{enabled: true},
+                tools: %{enabled: true, strict: true},
+                streaming: %{tool_calls: true}
+              }
+            }
+          ]
+        })
+
+      on_exit(fn ->
+        File.rm_rf!(snapshot_path)
+      end)
+
+      Application.put_env(:llm_db, :snapshot_path, snapshot_path)
+
+      {:ok, _snapshot} =
+        LLMDB.load(
+          custom: %{
+            openai: [
+              models: %{
+                "gpt-5-mini" => %{
+                  capabilities: %{
+                    json: %{schema: true}
+                  }
+                }
+              }
+            ]
+          }
+        )
+
+      assert {:ok, model} = LLMDB.model(:openai, "gpt-5-mini")
+      assert model.name == "GPT-5 Mini"
+      assert model.cost.input == 0.25
+      assert model.capabilities.reasoning.enabled == true
+      assert model.capabilities.tools.enabled == true
+      assert model.capabilities.tools.strict == true
+      assert model.capabilities.streaming.tool_calls == true
+      assert model.capabilities.json.schema == true
+    end
   end
 
   defp capture_log(fun) do
     ExUnit.CaptureLog.capture_log(fun)
+  end
+
+  defp write_test_snapshot!(overrides) do
+    {:ok, engine_snapshot} = Engine.run(sources: [{ConfigSource, %{overrides: overrides}}])
+
+    snapshot_path =
+      Path.join(System.tmp_dir!(), "llm_db-snapshot-#{System.unique_integer([:positive])}.json")
+
+    snapshot = Snapshot.from_engine_snapshot(engine_snapshot)
+    Snapshot.write!(snapshot_path, snapshot)
+    snapshot_path
   end
 end

--- a/test/llm_db/consumer_filtering_test.exs
+++ b/test/llm_db/consumer_filtering_test.exs
@@ -248,6 +248,28 @@ defmodule LLMDB.ConsumerFilteringTest do
       assert length(local_models) == 2
     end
 
+    test "normalizes string modality names in custom models before validation" do
+      Application.put_env(:llm_db, :custom, %{
+        local_llm: [
+          name: "Local LLM Server",
+          models: %{
+            "llama-3-8b" => %{
+              modalities: %{
+                input: ["text"],
+                output: ["text"]
+              }
+            }
+          }
+        ]
+      })
+
+      {:ok, _snapshot} = LLMDB.load()
+
+      assert {:ok, model} = LLMDB.model(:local_llm, "llama-3-8b")
+      assert model.modalities.input == [:text]
+      assert model.modalities.output == [:text]
+    end
+
     test "deep merges partial custom model overlays without losing packaged metadata" do
       snapshot_path =
         write_test_snapshot!(%{

--- a/test/llm_db/engine_override_test.exs
+++ b/test/llm_db/engine_override_test.exs
@@ -376,6 +376,52 @@ defmodule LLMDB.EngineOverrideTest do
       # Output should be preserved from base
       assert model.modalities.output == [:text]
     end
+
+    test "preserves lower-precedence capability groups when overlay only sets json schema" do
+      base = %{
+        providers: [%{id: :openai, name: "OpenAI"}],
+        models: [
+          %{
+            id: "gpt-5-mini",
+            provider: :openai,
+            name: "GPT-5 Mini",
+            capabilities: %{
+              chat: true,
+              reasoning: %{enabled: true},
+              tools: %{enabled: true, strict: true},
+              streaming: %{tool_calls: true}
+            }
+          }
+        ]
+      }
+
+      override = %{
+        providers: [],
+        models: [
+          %{
+            id: "gpt-5-mini",
+            provider: :openai,
+            capabilities: %{
+              json: %{schema: true}
+            }
+          }
+        ]
+      }
+
+      sources = [
+        {LLMDB.Sources.Config, %{overrides: base}},
+        {LLMDB.Sources.Config, %{overrides: override}}
+      ]
+
+      assert {:ok, _snapshot} = run_and_store(sources)
+
+      {:ok, model} = LLMDB.model(:openai, "gpt-5-mini")
+      assert model.capabilities.reasoning.enabled == true
+      assert model.capabilities.tools.enabled == true
+      assert model.capabilities.tools.strict == true
+      assert model.capabilities.streaming.tool_calls == true
+      assert model.capabilities.json.schema == true
+    end
   end
 
   describe "unknown field pass-through" do
@@ -789,6 +835,58 @@ defmodule LLMDB.EngineOverrideTest do
       assert model.limits.context == 128_000
       assert model.limits.output == 4096
     end
+
+    test "local TOML source keeps highest precedence regardless of source order" do
+      local_dir = tmp_local_source_dir!()
+
+      on_exit(fn ->
+        File.rm_rf!(local_dir)
+      end)
+
+      write_local_source!(
+        local_dir,
+        :openai,
+        """
+        id = "openai"
+        name = "OpenAI Local"
+        """,
+        %{
+          "gpt-4.toml" => """
+          id = "gpt-4"
+          name = "GPT-4 Local"
+
+          [capabilities]
+          chat = true
+          """
+        }
+      )
+
+      remote = %{
+        providers: [%{id: :openai, name: "OpenAI Remote"}],
+        models: [
+          %{
+            id: "gpt-4",
+            provider: :openai,
+            name: "GPT-4 Remote",
+            capabilities: %{chat: true}
+          }
+        ]
+      }
+
+      # Deliberately put Local first; engine should still treat it as highest precedence.
+      sources = [
+        {LLMDB.Sources.Local, %{dir: local_dir}},
+        {LLMDB.Sources.Config, %{overrides: remote}}
+      ]
+
+      assert {:ok, _snapshot} = run_and_store(sources)
+
+      {:ok, provider} = LLMDB.provider(:openai)
+      {:ok, model} = LLMDB.model(:openai, "gpt-4")
+
+      assert provider.name == "OpenAI Local"
+      assert model.name == "GPT-4 Local"
+    end
   end
 
   defp build_aliases_index(models) do
@@ -803,5 +901,21 @@ defmodule LLMDB.EngineOverrideTest do
       end)
     end)
     |> Map.new()
+  end
+
+  defp tmp_local_source_dir! do
+    dir = Path.join(System.tmp_dir!(), "llm_db-local-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  defp write_local_source!(root, provider_id, provider_toml, model_files) do
+    provider_dir = Path.join(root, Atom.to_string(provider_id))
+    File.mkdir_p!(provider_dir)
+    File.write!(Path.join(provider_dir, "provider.toml"), provider_toml)
+
+    Enum.each(model_files, fn {filename, contents} ->
+      File.write!(Path.join(provider_dir, filename), contents)
+    end)
   end
 end


### PR DESCRIPTION
## Summary
- preserve sparse build-time overlays until after merge so partial source records do not erase lower-precedence data
- force local TOML sources to the highest precedence tier regardless of configured source order
- deep-merge sparse runtime custom provider/model overlays and revalidate the merged result instead of replacing packaged records
- regenerate the installed snapshot and add regression coverage for sparse capability overlays, local precedence, and runtime custom overlays

## Callouts
- Build-time engine fix: source layers now stay sparse through merge, so overlay intent is preserved and local TOML overrides remain absolute.
- Runtime loader fix: `LLMDB.load(custom: ...)` now behaves like a sparse overlay instead of a full record replacement.

Closes #173