### PR TITLE
feat: deprecate deepseek-chat/reasoner, add v4-flash and v4-pro

### DIFF
--- a/priv/llm_db/providers/deepseek.json
+++ b/priv/llm_db/providers/deepseek.json
@@ -36,7 +36,7 @@
         "input": 0.28,
         "output": 0.42
       },
-      "deprecated": false,
+      "deprecated": true,
       "extra": {
         "attachment": true,
         "family": "deepseek",
@@ -46,8 +46,12 @@
       "family": null,
       "id": "deepseek-chat",
       "knowledge": "2025-09",
-      "last_updated": "2026-02-28",
-      "lifecycle": null,
+      "last_updated": "2026-04-28",
+      "lifecycle": {
+        "deprecated_at": "2026-04-28",
+        "replacement": "deepseek-v4-flash",
+        "status": "deprecated"
+      },
       "limits": {
         "context": 128000,
         "output": 8192
@@ -95,7 +99,7 @@
         "input": 0.28,
         "output": 0.42
       },
-      "deprecated": false,
+      "deprecated": true,
       "extra": {
         "attachment": true,
         "family": "deepseek-thinking",
@@ -108,8 +112,12 @@
       "family": null,
       "id": "deepseek-reasoner",
       "knowledge": "2025-09",
-      "last_updated": "2026-02-28",
-      "lifecycle": null,
+      "last_updated": "2026-04-28",
+      "lifecycle": {
+        "deprecated_at": "2026-04-28",
+        "replacement": "deepseek-v4-pro",
+        "status": "deprecated"
+      },
       "limits": {
         "context": 128000,
         "output": 64000
@@ -128,6 +136,130 @@
       "provider": "deepseek",
       "provider_model_id": null,
       "release_date": "2025-12-01",
+      "retired": false,
+      "tags": null
+    },
+    "deepseek-v4-flash": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": true,
+        "embeddings": false,
+        "json": {
+          "native": true,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": true
+        },
+        "streaming": {
+          "tool_calls": true
+        },
+        "tools": {
+          "enabled": true
+        }
+      },
+      "cost": {
+        "cache_read": 0.0028,
+        "input": 0.14,
+        "output": 0.28
+      },
+      "deprecated": false,
+      "extra": {
+        "attachment": true,
+        "family": "deepseek-v4",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "open_weights": true,
+        "temperature": true
+      },
+      "family": null,
+      "id": "deepseek-v4-flash",
+      "knowledge": null,
+      "last_updated": "2026-04-28",
+      "lifecycle": null,
+      "limits": {
+        "context": 1000000,
+        "output": 384000
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "model": null,
+      "name": "DeepSeek V4 Flash",
+      "pricing": null,
+      "provider": "deepseek",
+      "provider_model_id": null,
+      "release_date": "2026-04-28",
+      "retired": false,
+      "tags": null
+    },
+    "deepseek-v4-pro": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": true,
+        "embeddings": false,
+        "json": {
+          "native": true,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": true
+        },
+        "streaming": {
+          "tool_calls": true
+        },
+        "tools": {
+          "enabled": true
+        }
+      },
+      "cost": {
+        "cache_read": 0.0145,
+        "input": 1.74,
+        "output": 3.48
+      },
+      "deprecated": false,
+      "extra": {
+        "attachment": true,
+        "family": "deepseek-v4",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "open_weights": true,
+        "temperature": true
+      },
+      "family": null,
+      "id": "deepseek-v4-pro",
+      "knowledge": null,
+      "last_updated": "2026-04-28",
+      "lifecycle": null,
+      "limits": {
+        "context": 1000000,
+        "output": 384000
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "model": null,
+      "name": "DeepSeek V4 Pro",
+      "pricing": null,
+      "provider": "deepseek",
+      "provider_model_id": null,
+      "release_date": "2026-04-28",
       "retired": false,
       "tags": null
     }


### PR DESCRIPTION
DeepSeek has retired deepseek-chat and deepseek-reasoner in favor of the V4 family. Mark the old models as deprecated with replacement pointers, and add deepseek-v4-flash and deepseek-v4-pro with their 1M context, 384K max output limits and published per-million-token pricing.

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [ ] My commits follow conventional commit format
- [ ] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
- [ ] I have **NOT** directly edited generated snapshot/history artifacts unless this PR intentionally regenerates them (`priv/llm_db/snapshot.json`, `priv/llm_db/history/**`)

## Related Issues

Closes #
