### PR TITLE
chore(openai): codify 2026-04-22 deprecations

### DIFF
--- a/priv/llm_db/local/openai/computer-use-preview-2025-03-11.toml
+++ b/priv/llm_db/local/openai/computer-use-preview-2025-03-11.toml
@@ -1,0 +1,7 @@
+id = "computer-use-preview-2025-03-11"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.4-mini"

--- a/priv/llm_db/local/openai/computer-use-preview.toml
+++ b/priv/llm_db/local/openai/computer-use-preview.toml
@@ -1,0 +1,7 @@
+id = "computer-use-preview"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.4-mini"

--- a/priv/llm_db/local/openai/ft-babbage-002.toml
+++ b/priv/llm_db/local/openai/ft-babbage-002.toml
@@ -1,0 +1,7 @@
+id = "ft-babbage-002"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-5-mini"

--- a/priv/llm_db/local/openai/ft-davinci-002.toml
+++ b/priv/llm_db/local/openai/ft-davinci-002.toml
@@ -1,0 +1,7 @@
+id = "ft-davinci-002"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-5-mini"

--- a/priv/llm_db/local/openai/ft-gpt-3.5-turbo.toml
+++ b/priv/llm_db/local/openai/ft-gpt-3.5-turbo.toml
@@ -1,0 +1,7 @@
+id = "ft-gpt-3.5-turbo"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1-mini"

--- a/priv/llm_db/local/openai/ft-gpt-4.1-nano-2025-04-14.toml
+++ b/priv/llm_db/local/openai/ft-gpt-4.1-nano-2025-04-14.toml
@@ -1,0 +1,7 @@
+id = "ft-gpt-4.1-nano-2025-04-14"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-5-nano"

--- a/priv/llm_db/local/openai/ft-gpt-4.toml
+++ b/priv/llm_db/local/openai/ft-gpt-4.toml
@@ -1,0 +1,7 @@
+id = "ft-gpt-4"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1"

--- a/priv/llm_db/local/openai/ft-o4-mini-2025-04-16.toml
+++ b/priv/llm_db/local/openai/ft-o4-mini-2025-04-16.toml
@@ -1,0 +1,7 @@
+id = "ft-o4-mini-2025-04-16"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-5-mini"

--- a/priv/llm_db/local/openai/gpt-3.5-turbo-0125.toml
+++ b/priv/llm_db/local/openai/gpt-3.5-turbo-0125.toml
@@ -5,3 +5,9 @@ protocol = "openai_chat"
 
 [extra]
 api = "chat"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1-mini"

--- a/priv/llm_db/local/openai/gpt-3.5-turbo.toml
+++ b/priv/llm_db/local/openai/gpt-3.5-turbo.toml
@@ -1,7 +1,14 @@
 id = "gpt-3.5-turbo"
 
+aliases = ["gpt-3.5-turbo-completions"]
 [extra.wire]
 protocol = "openai_chat"
 
 [extra]
 api = "chat"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1-mini"

--- a/priv/llm_db/local/openai/gpt-4-0613.toml
+++ b/priv/llm_db/local/openai/gpt-4-0613.toml
@@ -1,7 +1,14 @@
 id = "gpt-4-0613"
 
+aliases = ["gpt-4-0613-completions"]
 [extra.wire]
 protocol = "openai_chat"
 
 [extra]
 api = "chat"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1"

--- a/priv/llm_db/local/openai/gpt-4-1106-preview.toml
+++ b/priv/llm_db/local/openai/gpt-4-1106-preview.toml
@@ -5,3 +5,9 @@ protocol = "openai_chat"
 
 [extra]
 api = "chat"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1"

--- a/priv/llm_db/local/openai/gpt-4-turbo-2024-04-09.toml
+++ b/priv/llm_db/local/openai/gpt-4-turbo-2024-04-09.toml
@@ -5,3 +5,9 @@ protocol = "openai_chat"
 
 [extra]
 api = "chat"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1"

--- a/priv/llm_db/local/openai/gpt-4-turbo.toml
+++ b/priv/llm_db/local/openai/gpt-4-turbo.toml
@@ -1,5 +1,6 @@
 id = "gpt-4-turbo"
 
+aliases = ["gpt-4-turbo-completions"]
 [capabilities.tools]
 strict = true
 
@@ -8,3 +9,9 @@ protocol = "openai_chat"
 
 [extra]
 api = "chat"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1"

--- a/priv/llm_db/local/openai/gpt-4.1-nano-2025-04-14.toml
+++ b/priv/llm_db/local/openai/gpt-4.1-nano-2025-04-14.toml
@@ -5,3 +5,9 @@ protocol = "openai_responses"
 
 [extra]
 api = "responses"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-5-nano"

--- a/priv/llm_db/local/openai/gpt-4.1-nano.toml
+++ b/priv/llm_db/local/openai/gpt-4.1-nano.toml
@@ -5,3 +5,9 @@ protocol = "openai_responses"
 
 [extra]
 api = "responses"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-5-nano"

--- a/priv/llm_db/local/openai/gpt-4.toml
+++ b/priv/llm_db/local/openai/gpt-4.toml
@@ -1,5 +1,6 @@
 id = "gpt-4"
 
+aliases = ["gpt-4-completions"]
 [capabilities.tools]
 strict = true
 
@@ -8,3 +9,9 @@ protocol = "openai_chat"
 
 [extra]
 api = "chat"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1"

--- a/priv/llm_db/local/openai/gpt-4o-2024-05-13.toml
+++ b/priv/llm_db/local/openai/gpt-4o-2024-05-13.toml
@@ -8,3 +8,9 @@ protocol = "openai_responses"
 
 [extra]
 api = "chat"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-4.1"

--- a/priv/llm_db/local/openai/gpt-4o-audio-preview-2024-12-17.toml
+++ b/priv/llm_db/local/openai/gpt-4o-audio-preview-2024-12-17.toml
@@ -1,0 +1,7 @@
+id = "gpt-4o-audio-preview-2024-12-17"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-audio"

--- a/priv/llm_db/local/openai/gpt-4o-mini-audio-preview-2024-12-17.toml
+++ b/priv/llm_db/local/openai/gpt-4o-mini-audio-preview-2024-12-17.toml
@@ -1,0 +1,7 @@
+id = "gpt-4o-mini-audio-preview-2024-12-17"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-audio"

--- a/priv/llm_db/local/openai/gpt-4o-mini-realtime-preview-2024-12-17.toml
+++ b/priv/llm_db/local/openai/gpt-4o-mini-realtime-preview-2024-12-17.toml
@@ -1,0 +1,7 @@
+id = "gpt-4o-mini-realtime-preview-2024-12-17"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-realtime-mini"

--- a/priv/llm_db/local/openai/gpt-4o-mini-search-preview-2025-03-11.toml
+++ b/priv/llm_db/local/openai/gpt-4o-mini-search-preview-2025-03-11.toml
@@ -1,0 +1,7 @@
+id = "gpt-4o-mini-search-preview-2025-03-11"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-4.1-mini"

--- a/priv/llm_db/local/openai/gpt-4o-mini-tts-2025-03-20.toml
+++ b/priv/llm_db/local/openai/gpt-4o-mini-tts-2025-03-20.toml
@@ -1,0 +1,7 @@
+id = "gpt-4o-mini-tts-2025-03-20"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-realtime"

--- a/priv/llm_db/local/openai/gpt-4o-search-preview-2025-03-11.toml
+++ b/priv/llm_db/local/openai/gpt-4o-search-preview-2025-03-11.toml
@@ -1,0 +1,7 @@
+id = "gpt-4o-search-preview-2025-03-11"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-4.1-mini"

--- a/priv/llm_db/local/openai/gpt-5-chat-latest.toml
+++ b/priv/llm_db/local/openai/gpt-5-chat-latest.toml
@@ -13,3 +13,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "any"
 reasoning_effort = "unsupported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.3-chat-latest"

--- a/priv/llm_db/local/openai/gpt-5-codex.toml
+++ b/priv/llm_db/local/openai/gpt-5-codex.toml
@@ -16,3 +16,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.4"

--- a/priv/llm_db/local/openai/gpt-5.1-chat-latest.toml
+++ b/priv/llm_db/local/openai/gpt-5.1-chat-latest.toml
@@ -13,3 +13,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "any"
 reasoning_effort = "unsupported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.3-chat-latest"

--- a/priv/llm_db/local/openai/gpt-5.1-codex-max.toml
+++ b/priv/llm_db/local/openai/gpt-5.1-codex-max.toml
@@ -16,3 +16,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.4"

--- a/priv/llm_db/local/openai/gpt-5.1-codex-mini.toml
+++ b/priv/llm_db/local/openai/gpt-5.1-codex-mini.toml
@@ -16,3 +16,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.4-mini"

--- a/priv/llm_db/local/openai/gpt-5.1-codex.toml
+++ b/priv/llm_db/local/openai/gpt-5.1-codex.toml
@@ -16,3 +16,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5"

--- a/priv/llm_db/local/openai/gpt-5.2-codex.toml
+++ b/priv/llm_db/local/openai/gpt-5.2-codex.toml
@@ -16,3 +16,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.4"

--- a/priv/llm_db/local/openai/gpt-audio-mini-2025-10-06.toml
+++ b/priv/llm_db/local/openai/gpt-audio-mini-2025-10-06.toml
@@ -1,0 +1,7 @@
+id = "gpt-audio-mini-2025-10-06"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-audio"

--- a/priv/llm_db/local/openai/gpt-image-1.toml
+++ b/priv/llm_db/local/openai/gpt-image-1.toml
@@ -104,3 +104,9 @@ size_class = "1536x1024:high"
 [extra]
 api = "images"
 description = "OpenAI image generation model with text rendering and editing capabilities"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-image-1.5"

--- a/priv/llm_db/local/openai/gpt-realtime-mini-2025-10-06.toml
+++ b/priv/llm_db/local/openai/gpt-realtime-mini-2025-10-06.toml
@@ -1,0 +1,7 @@
+id = "gpt-realtime-mini-2025-10-06"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-realtime-mini"

--- a/priv/llm_db/local/openai/o1-2024-12-17.toml
+++ b/priv/llm_db/local/openai/o1-2024-12-17.toml
@@ -7,3 +7,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "o3"

--- a/priv/llm_db/local/openai/o1-pro-2025-03-19.toml
+++ b/priv/llm_db/local/openai/o1-pro-2025-03-19.toml
@@ -1,5 +1,6 @@
 id = "o1-pro-2025-03-19"
 
+aliases = ["o1-pro"]
 [extra.wire]
 protocol = "openai_responses"
 
@@ -7,3 +8,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-5.4-pro"

--- a/priv/llm_db/local/openai/o1.toml
+++ b/priv/llm_db/local/openai/o1.toml
@@ -7,3 +7,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "o3"

--- a/priv/llm_db/local/openai/o3-deep-research-2025-06-26.toml
+++ b/priv/llm_db/local/openai/o3-deep-research-2025-06-26.toml
@@ -1,0 +1,8 @@
+id = "o3-deep-research-2025-06-26"
+aliases = ["o3-deep-research"]
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.4-pro"

--- a/priv/llm_db/local/openai/o3-mini-2025-01-31.toml
+++ b/priv/llm_db/local/openai/o3-mini-2025-01-31.toml
@@ -7,3 +7,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "o3"

--- a/priv/llm_db/local/openai/o3-mini.toml
+++ b/priv/llm_db/local/openai/o3-mini.toml
@@ -7,3 +7,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "o3"

--- a/priv/llm_db/local/openai/o4-mini-2025-04-16.toml
+++ b/priv/llm_db/local/openai/o4-mini-2025-04-16.toml
@@ -7,3 +7,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-5-mini"

--- a/priv/llm_db/local/openai/o4-mini-deep-research-2025-06-26.toml
+++ b/priv/llm_db/local/openai/o4-mini-deep-research-2025-06-26.toml
@@ -1,0 +1,8 @@
+id = "o4-mini-deep-research-2025-06-26"
+aliases = ["o4-mini-deep-research"]
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-07-23"
+replacement = "gpt-5.4-pro"

--- a/priv/llm_db/local/openai/o4-mini.toml
+++ b/priv/llm_db/local/openai/o4-mini.toml
@@ -7,3 +7,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-04-22"
+retires_at = "2026-10-23"
+replacement = "gpt-5-mini"

--- a/test/llm_db/openai_deprecations_test.exs
+++ b/test/llm_db/openai_deprecations_test.exs
@@ -1,0 +1,158 @@
+defmodule LLMDB.OpenAIDeprecationsTest do
+  use ExUnit.Case, async: false
+
+  alias LLMDB.{Model, Normalize, Provider, Store}
+  alias LLMDB.Sources.Local
+
+  @local_dir "priv/llm_db/local"
+
+  @expected_lifecycle %{
+    "computer-use-preview" => {"2026-07-23", "gpt-5.4-mini"},
+    "computer-use-preview-2025-03-11" => {"2026-07-23", "gpt-5.4-mini"},
+    "ft-babbage-002" => {"2026-10-23", "gpt-5-mini"},
+    "ft-davinci-002" => {"2026-10-23", "gpt-5-mini"},
+    "ft-gpt-3.5-turbo" => {"2026-10-23", "gpt-4.1-mini"},
+    "ft-gpt-4" => {"2026-10-23", "gpt-4.1"},
+    "ft-gpt-4.1-nano-2025-04-14" => {"2026-10-23", "gpt-5-nano"},
+    "ft-o4-mini-2025-04-16" => {"2026-10-23", "gpt-5-mini"},
+    "gpt-3.5-turbo" => {"2026-10-23", "gpt-4.1-mini"},
+    "gpt-3.5-turbo-0125" => {"2026-10-23", "gpt-4.1-mini"},
+    "gpt-4" => {"2026-10-23", "gpt-4.1"},
+    "gpt-4-0613" => {"2026-10-23", "gpt-4.1"},
+    "gpt-4-1106-preview" => {"2026-10-23", "gpt-4.1"},
+    "gpt-4-turbo" => {"2026-10-23", "gpt-4.1"},
+    "gpt-4-turbo-2024-04-09" => {"2026-10-23", "gpt-4.1"},
+    "gpt-4.1-nano" => {"2026-10-23", "gpt-5-nano"},
+    "gpt-4.1-nano-2025-04-14" => {"2026-10-23", "gpt-5-nano"},
+    "gpt-4o-2024-05-13" => {"2026-10-23", "gpt-4.1"},
+    "gpt-4o-audio-preview-2024-12-17" => {"2026-07-23", "gpt-audio"},
+    "gpt-4o-mini-audio-preview-2024-12-17" => {"2026-07-23", "gpt-audio"},
+    "gpt-4o-mini-realtime-preview-2024-12-17" => {"2026-07-23", "gpt-realtime-mini"},
+    "gpt-4o-mini-search-preview-2025-03-11" => {"2026-07-23", "gpt-4.1-mini"},
+    "gpt-4o-mini-tts-2025-03-20" => {"2026-07-23", "gpt-realtime"},
+    "gpt-4o-search-preview-2025-03-11" => {"2026-07-23", "gpt-4.1-mini"},
+    "gpt-5-chat-latest" => {"2026-07-23", "gpt-5.3-chat-latest"},
+    "gpt-5-codex" => {"2026-07-23", "gpt-5.4"},
+    "gpt-5.1-chat-latest" => {"2026-07-23", "gpt-5.3-chat-latest"},
+    "gpt-5.1-codex" => {"2026-07-23", "gpt-5"},
+    "gpt-5.1-codex-max" => {"2026-07-23", "gpt-5.4"},
+    "gpt-5.1-codex-mini" => {"2026-07-23", "gpt-5.4-mini"},
+    "gpt-5.2-codex" => {"2026-07-23", "gpt-5.4"},
+    "gpt-audio-mini-2025-10-06" => {"2026-07-23", "gpt-audio"},
+    "gpt-image-1" => {"2026-10-23", "gpt-image-1.5"},
+    "gpt-realtime-mini-2025-10-06" => {"2026-07-23", "gpt-realtime-mini"},
+    "o1" => {"2026-10-23", "o3"},
+    "o1-2024-12-17" => {"2026-10-23", "o3"},
+    "o1-pro-2025-03-19" => {"2026-10-23", "gpt-5.4-pro"},
+    "o3-deep-research-2025-06-26" => {"2026-07-23", "gpt-5.4-pro"},
+    "o3-mini" => {"2026-10-23", "o3"},
+    "o3-mini-2025-01-31" => {"2026-10-23", "o3"},
+    "o4-mini" => {"2026-10-23", "gpt-5-mini"},
+    "o4-mini-2025-04-16" => {"2026-10-23", "gpt-5-mini"},
+    "o4-mini-deep-research-2025-06-26" => {"2026-07-23", "gpt-5.4-pro"}
+  }
+
+  @alias_expectations %{
+    "gpt-3.5-turbo-completions" => "gpt-3.5-turbo",
+    "gpt-4-completions" => "gpt-4",
+    "gpt-4-0613-completions" => "gpt-4-0613",
+    "gpt-4-turbo-completions" => "gpt-4-turbo",
+    "o1-pro" => "o1-pro-2025-03-19",
+    "o3-deep-research" => "o3-deep-research-2025-06-26",
+    "o4-mini-deep-research" => "o4-mini-deep-research-2025-06-26"
+  }
+
+  setup do
+    Store.clear!()
+
+    on_exit(fn ->
+      Store.clear!()
+    end)
+
+    :ok
+  end
+
+  test "local OpenAI overrides codify the 2026-04-22 deprecation batch" do
+    models = openai_models()
+
+    Enum.each(@expected_lifecycle, fn {model_id, {retires_at, replacement}} ->
+      model = Map.fetch!(models, model_id)
+
+      assert model.lifecycle.status == "deprecated"
+      assert model.lifecycle.deprecated_at == "2026-04-22"
+      assert model.lifecycle.retires_at == retires_at
+      assert model.lifecycle.replacement == replacement
+      assert Model.lifecycle_status(model) == "deprecated"
+    end)
+  end
+
+  test "lifecycle helpers advance representative July and October rows" do
+    models = openai_models()
+
+    july_model = Map.fetch!(models, "gpt-5-codex")
+    october_model = Map.fetch!(models, "gpt-4")
+
+    assert Model.effective_status(july_model, ~U[2026-04-21 00:00:00Z]) == "deprecated"
+    assert Model.effective_status(july_model, ~U[2026-07-24 00:00:00Z]) == "retired"
+    assert Model.deprecated?(october_model, ~U[2026-05-01 00:00:00Z])
+    assert Model.retired?(october_model, ~U[2026-10-24 00:00:00Z])
+  end
+
+  test "deprecated OpenAI aliases resolve to queryable canonical records" do
+    load_openai_models_into_store!()
+
+    Enum.each(@alias_expectations, fn {alias_id, canonical_id} ->
+      assert {:ok, model} = LLMDB.model(:openai, alias_id)
+      assert model.id == canonical_id
+      assert model.lifecycle.status == "deprecated"
+    end)
+  end
+
+  defp openai_models do
+    {_provider, models} = openai_provider_and_models()
+    models
+  end
+
+  defp openai_provider_and_models do
+    {:ok, data} = Local.load(%{dir: @local_dir})
+    openai = Map.fetch!(data, "openai")
+    provider = openai |> Map.delete(:models) |> Map.put(:id, :openai) |> Provider.new!()
+
+    models =
+      openai.models
+      |> Normalize.normalize_models()
+      |> Enum.map(&Model.new!/1)
+      |> Map.new(&{&1.id, &1})
+
+    {provider, models}
+  end
+
+  defp load_openai_models_into_store! do
+    {provider, models_by_id} = openai_provider_and_models()
+    models = Map.values(models_by_id)
+
+    snapshot = %{
+      providers_by_id: %{openai: provider},
+      models_by_key: Map.new(models, &{{&1.provider, &1.id}, &1}),
+      aliases_by_key: build_aliases_index(models),
+      providers: [provider],
+      models: %{openai: models},
+      base_models: models,
+      filters: %{allow: :all, deny: %{}},
+      prefer: [],
+      meta: %{epoch: nil, generated_at: DateTime.utc_now() |> DateTime.to_iso8601()}
+    }
+
+    Store.put!(snapshot, [])
+  end
+
+  defp build_aliases_index(models) do
+    models
+    |> Enum.flat_map(fn model ->
+      Enum.map(model.aliases, fn alias_name ->
+        {{model.provider, alias_name}, model.id}
+      end)
+    end)
+    |> Map.new()
+  end
+end


### PR DESCRIPTION
## Summary
- encode OpenAI's 2026-04-22 legacy GPT model deprecation batch in local metadata
- add local overlay records and aliases for affected snapshot/completion/fine-tune model IDs
- rebuild the packaged catalog snapshot and add regression coverage for lifecycle status and alias lookup

## Verification
- mix test
- mix quality
- mix llm_db.build --check --install
- verified all 50 issue model strings resolve to deprecated OpenAI records

Closes #180