### PR TITLE
chore(xai): codify May 2026 model retirements

### DIFF
--- a/priv/llm_db/local/xai/grok-3.toml
+++ b/priv/llm_db/local/xai/grok-3.toml
@@ -1,0 +1,7 @@
+id = "grok-3"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-07"
+retires_at = "2026-05-15T19:00:00Z"
+replacement = "grok-4.20-non-reasoning"

--- a/priv/llm_db/local/xai/grok-4-0709.toml
+++ b/priv/llm_db/local/xai/grok-4-0709.toml
@@ -25,6 +25,12 @@ enabled = true
 [capabilities.tools]
 enabled = true
 
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-07"
+retires_at = "2026-05-15T19:00:00Z"
+replacement = "grok-4.3"
+
 [extra]
 attachment = true
 open_weights = false

--- a/priv/llm_db/local/xai/grok-4-1-fast-non-reasoning.toml
+++ b/priv/llm_db/local/xai/grok-4-1-fast-non-reasoning.toml
@@ -1,0 +1,11 @@
+id = "grok-4-1-fast-non-reasoning"
+provider_model_id = "grok-4-1-fast-non-reasoning"
+
+[capabilities.reasoning]
+enabled = false
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-07"
+retires_at = "2026-05-15T19:00:00Z"
+replacement = "grok-4.20-non-reasoning"

--- a/priv/llm_db/local/xai/grok-4-1-fast-reasoning.toml
+++ b/priv/llm_db/local/xai/grok-4-1-fast-reasoning.toml
@@ -24,6 +24,12 @@ enabled = true
 [capabilities.tools]
 enabled = true
 
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-07"
+retires_at = "2026-05-15T19:00:00Z"
+replacement = "grok-4.3"
+
 [extra]
 attachment = true
 open_weights = false

--- a/priv/llm_db/local/xai/grok-4-fast-non-reasoning.toml
+++ b/priv/llm_db/local/xai/grok-4-fast-non-reasoning.toml
@@ -24,6 +24,12 @@ enabled = false
 [capabilities.tools]
 enabled = true
 
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-07"
+retires_at = "2026-05-15T19:00:00Z"
+replacement = "grok-4.20-non-reasoning"
+
 [extra]
 attachment = false
 open_weights = false

--- a/priv/llm_db/local/xai/grok-4-fast-reasoning.toml
+++ b/priv/llm_db/local/xai/grok-4-fast-reasoning.toml
@@ -19,10 +19,16 @@ input = ["text"]
 output = ["text"]
 
 [capabilities.reasoning]
-enabled = false
+enabled = true
 
 [capabilities.tools]
 enabled = true
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-07"
+retires_at = "2026-05-15T19:00:00Z"
+replacement = "grok-4.3"
 
 [extra]
 attachment = false

--- a/priv/llm_db/local/xai/grok-4.20-non-reasoning.toml
+++ b/priv/llm_db/local/xai/grok-4.20-non-reasoning.toml
@@ -1,0 +1,29 @@
+id = "grok-4.20-non-reasoning"
+name = "Grok 4.20 Non-Reasoning"
+provider_model_id = "grok-4.20-non-reasoning"
+release_date = "2026-03-09"
+last_updated = "2026-05-07"
+
+[limits]
+context = 2000000
+output = 30000
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.2
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[capabilities.reasoning]
+enabled = false
+
+[capabilities.tools]
+enabled = true
+
+[extra]
+attachment = true
+open_weights = false
+temperature = true

--- a/priv/llm_db/local/xai/grok-4.3.toml
+++ b/priv/llm_db/local/xai/grok-4.3.toml
@@ -1,0 +1,31 @@
+id = "grok-4.3"
+name = "Grok 4.3"
+provider_model_id = "grok-4.3"
+release_date = "2026-05-07"
+last_updated = "2026-05-07"
+
+[limits]
+context = 1000000
+
+[cost]
+input = 1.25
+output = 2.50
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[capabilities.reasoning]
+enabled = true
+
+[capabilities.tools]
+enabled = true
+
+[extra]
+attachment = true
+open_weights = false
+temperature = true
+
+[extra.constraints]
+reasoning_effort = "supported"
+reasoning_effort_values = ["low", "medium", "high"]

--- a/priv/llm_db/local/xai/grok-code-fast-1.toml
+++ b/priv/llm_db/local/xai/grok-code-fast-1.toml
@@ -2,3 +2,9 @@ id = "grok-code-fast-1"
 
 [capabilities.reasoning]
 enabled = false
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-07"
+retires_at = "2026-05-15T19:00:00Z"
+replacement = "grok-4.20-non-reasoning"

--- a/priv/llm_db/local/xai/grok-imagine-image-pro.toml
+++ b/priv/llm_db/local/xai/grok-imagine-image-pro.toml
@@ -1,0 +1,7 @@
+id = "grok-imagine-image-pro"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-07"
+retires_at = "2026-05-15T19:00:00Z"
+replacement = "grok-imagine-image"

--- a/test/llm_db/xai_deprecations_test.exs
+++ b/test/llm_db/xai_deprecations_test.exs
@@ -1,0 +1,78 @@
+defmodule LLMDB.XAIDeprecationsTest do
+  use ExUnit.Case, async: false
+
+  alias LLMDB.{Model, Normalize}
+  alias LLMDB.Sources.Local
+
+  @local_dir "priv/llm_db/local"
+  @deprecated_at "2026-05-07"
+  @retires_at "2026-05-15T19:00:00Z"
+
+  @expected_lifecycle %{
+    "grok-4-1-fast-reasoning" => "grok-4.3",
+    "grok-4-1-fast-non-reasoning" => "grok-4.20-non-reasoning",
+    "grok-4-fast-reasoning" => "grok-4.3",
+    "grok-4-fast-non-reasoning" => "grok-4.20-non-reasoning",
+    "grok-4-0709" => "grok-4.3",
+    "grok-code-fast-1" => "grok-4.20-non-reasoning",
+    "grok-3" => "grok-4.20-non-reasoning",
+    "grok-imagine-image-pro" => "grok-imagine-image"
+  }
+
+  test "local xAI overrides codify the 2026-05-15 retirement batch" do
+    models = xai_models()
+
+    Enum.each(@expected_lifecycle, fn {model_id, replacement} ->
+      model = Map.fetch!(models, model_id)
+
+      assert model.lifecycle.status == "deprecated"
+      assert model.lifecycle.deprecated_at == @deprecated_at
+      assert model.lifecycle.retires_at == @retires_at
+      assert model.lifecycle.replacement == replacement
+      assert Model.lifecycle_status(model) == "deprecated"
+      assert Model.effective_status(model, ~U[2026-05-15 18:59:59Z]) == "deprecated"
+      assert Model.effective_status(model, ~U[2026-05-15 19:00:00Z]) == "retired"
+    end)
+  end
+
+  test "Grok 4.3 metadata captures launch details from xAI announcement" do
+    model = xai_models() |> Map.fetch!("grok-4.3")
+
+    assert model.limits.context == 1_000_000
+    assert model.cost.input == 1.25
+    assert model.cost.output == 2.5
+    assert model.capabilities.reasoning.enabled == true
+    assert model.capabilities.tools.enabled == true
+    assert get_in(model.extra, [:constraints, :reasoning_effort]) == "supported"
+
+    assert get_in(model.extra, [:constraints, :reasoning_effort_values]) == [
+             "low",
+             "medium",
+             "high"
+           ]
+  end
+
+  test "recommended replacement models are present for non-reasoning and image workloads" do
+    models = xai_models()
+    non_reasoning = Map.fetch!(models, "grok-4.20-non-reasoning")
+    image = Map.fetch!(models, "grok-imagine-image")
+
+    assert non_reasoning.capabilities.reasoning.enabled == false
+    assert non_reasoning.limits.context == 2_000_000
+    assert non_reasoning.cost.input == 2
+    assert non_reasoning.cost.output == 6
+
+    assert image.capabilities.chat == false
+    assert image.modalities.output == [:image]
+  end
+
+  defp xai_models do
+    {:ok, data} = Local.load(%{dir: @local_dir})
+    xai = Map.fetch!(data, "xai")
+
+    xai.models
+    |> Normalize.normalize_models()
+    |> Enum.map(&Model.new!/1)
+    |> Map.new(&{&1.id, &1})
+  end
+end


### PR DESCRIPTION
## Summary

- Marks the xAI models retiring on May 15, 2026 at 12:00pm PT as deprecated with `retires_at = "2026-05-15T19:00:00Z"`.
- Adds replacement pointers for reasoning, non-reasoning, code, and image-generation workloads from the xAI announcement.
- Adds local metadata for `grok-4.3` and `grok-4.20-non-reasoning`, then regenerates the packaged snapshot.
- Adds xAI lifecycle tests covering the retirement batch and replacement model metadata.

Closes #184

## Validation

- `mix test test/llm_db/xai_deprecations_test.exs`
- `mix llm_db.build --install`
- `mix llm_db.build --check --install`
- `mix test`
- `mix quality`
- pre-push hook: `mix test` and `mix quality`
