### PR TITLE
feat(openrouter): detect embedding models from output_modalities and add dimension overlays for 25 models

### DIFF
--- a/lib/llm_db/enrich/runtime_contract.ex
+++ b/lib/llm_db/enrich/runtime_contract.ex
@@ -680,7 +680,7 @@ defmodule LLMDB.Enrich.RuntimeContract do
   defp text_output?(_model), do: false
 
   defp embedding_model?(%Model{modalities: %{output: output}}) when is_list(output),
-    do: :embedding in output
+    do: :embedding in output or :embeddings in output
 
   defp embedding_model?(%Model{capabilities: capabilities}) when is_map(capabilities) do
     case Map.get(capabilities, :embeddings) do

--- a/lib/llm_db/sources/openrouter.ex
+++ b/lib/llm_db/sources/openrouter.ex
@@ -423,6 +423,14 @@ defmodule LLMDB.Sources.OpenRouter do
         capabilities
       end
 
+    capabilities =
+      if is_list(get_in(source, ["architecture", "output_modalities"])) and
+           "embedding" in get_in(source, ["architecture", "output_modalities"]) do
+        Map.put(capabilities, :embeddings, true)
+      else
+        capabilities
+      end
+
     if map_size(capabilities) > 0 do
       Map.put(model, :capabilities, capabilities)
     else

--- a/priv/llm_db/local/openrouter/baai_bge-base-en-v1.5.toml
+++ b/priv/llm_db/local/openrouter/baai_bge-base-en-v1.5.toml
@@ -1,0 +1,6 @@
+id = "baai/bge-base-en-v1.5"
+
+[capabilities.embeddings]
+min_dimensions = 768
+max_dimensions = 768
+default_dimensions = 768

--- a/priv/llm_db/local/openrouter/baai_bge-large-en-v1.5.toml
+++ b/priv/llm_db/local/openrouter/baai_bge-large-en-v1.5.toml
@@ -1,0 +1,6 @@
+id = "baai/bge-large-en-v1.5"
+
+[capabilities.embeddings]
+min_dimensions = 1024
+max_dimensions = 1024
+default_dimensions = 1024

--- a/priv/llm_db/local/openrouter/baai_bge-m3.toml
+++ b/priv/llm_db/local/openrouter/baai_bge-m3.toml
@@ -1,0 +1,6 @@
+id = "baai/bge-m3"
+
+[capabilities.embeddings]
+min_dimensions = 1024
+max_dimensions = 1024
+default_dimensions = 1024

--- a/priv/llm_db/local/openrouter/google_gemini-embedding-001.toml
+++ b/priv/llm_db/local/openrouter/google_gemini-embedding-001.toml
@@ -1,0 +1,6 @@
+id = "google/gemini-embedding-001"
+
+[capabilities.embeddings]
+min_dimensions = 768
+max_dimensions = 768
+default_dimensions = 768

--- a/priv/llm_db/local/openrouter/google_gemini-embedding-2-preview.toml
+++ b/priv/llm_db/local/openrouter/google_gemini-embedding-2-preview.toml
@@ -1,0 +1,6 @@
+id = "google/gemini-embedding-2-preview"
+
+[capabilities.embeddings]
+min_dimensions = 1
+max_dimensions = 3072
+default_dimensions = 3072

--- a/priv/llm_db/local/openrouter/intfloat_e5-base-v2.toml
+++ b/priv/llm_db/local/openrouter/intfloat_e5-base-v2.toml
@@ -1,0 +1,6 @@
+id = "intfloat/e5-base-v2"
+
+[capabilities.embeddings]
+min_dimensions = 768
+max_dimensions = 768
+default_dimensions = 768

--- a/priv/llm_db/local/openrouter/intfloat_e5-large-v2.toml
+++ b/priv/llm_db/local/openrouter/intfloat_e5-large-v2.toml
@@ -1,0 +1,6 @@
+id = "intfloat/e5-large-v2"
+
+[capabilities.embeddings]
+min_dimensions = 1024
+max_dimensions = 1024
+default_dimensions = 1024

--- a/priv/llm_db/local/openrouter/intfloat_multilingual-e5-large.toml
+++ b/priv/llm_db/local/openrouter/intfloat_multilingual-e5-large.toml
@@ -1,0 +1,6 @@
+id = "intfloat/multilingual-e5-large"
+
+[capabilities.embeddings]
+min_dimensions = 1024
+max_dimensions = 1024
+default_dimensions = 1024

--- a/priv/llm_db/local/openrouter/mistralai_codestral-embed-2505.toml
+++ b/priv/llm_db/local/openrouter/mistralai_codestral-embed-2505.toml
@@ -1,0 +1,6 @@
+id = "mistralai/codestral-embed-2505"
+
+[capabilities.embeddings]
+min_dimensions = 1024
+max_dimensions = 1024
+default_dimensions = 1024

--- a/priv/llm_db/local/openrouter/mistralai_mistral-embed-2312.toml
+++ b/priv/llm_db/local/openrouter/mistralai_mistral-embed-2312.toml
@@ -1,0 +1,6 @@
+id = "mistralai/mistral-embed-2312"
+
+[capabilities.embeddings]
+min_dimensions = 1024
+max_dimensions = 1024
+default_dimensions = 1024

--- a/priv/llm_db/local/openrouter/nvidia_llama-nemotron-embed-vl-1b-v2:free.toml
+++ b/priv/llm_db/local/openrouter/nvidia_llama-nemotron-embed-vl-1b-v2:free.toml
@@ -1,0 +1,6 @@
+id = "nvidia/llama-nemotron-embed-vl-1b-v2:free"
+
+[capabilities.embeddings]
+min_dimensions = 4096
+max_dimensions = 4096
+default_dimensions = 4096

--- a/priv/llm_db/local/openrouter/openai_text-embedding-3-large.toml
+++ b/priv/llm_db/local/openrouter/openai_text-embedding-3-large.toml
@@ -1,0 +1,6 @@
+id = "openai/text-embedding-3-large"
+
+[capabilities.embeddings]
+min_dimensions = 1
+max_dimensions = 3072
+default_dimensions = 3072

--- a/priv/llm_db/local/openrouter/openai_text-embedding-3-small.toml
+++ b/priv/llm_db/local/openrouter/openai_text-embedding-3-small.toml
@@ -1,0 +1,6 @@
+id = "openai/text-embedding-3-small"
+
+[capabilities.embeddings]
+min_dimensions = 1
+max_dimensions = 1536
+default_dimensions = 1536

--- a/priv/llm_db/local/openrouter/openai_text-embedding-ada-002.toml
+++ b/priv/llm_db/local/openrouter/openai_text-embedding-ada-002.toml
@@ -1,0 +1,6 @@
+id = "openai/text-embedding-ada-002"
+
+[capabilities.embeddings]
+min_dimensions = 1536
+max_dimensions = 1536
+default_dimensions = 1536

--- a/priv/llm_db/local/openrouter/perplexity_pplx-embed-v1-0.6b.toml
+++ b/priv/llm_db/local/openrouter/perplexity_pplx-embed-v1-0.6b.toml
@@ -1,0 +1,6 @@
+id = "perplexity/pplx-embed-v1-0.6b"
+
+[capabilities.embeddings]
+min_dimensions = 768
+max_dimensions = 768
+default_dimensions = 768

--- a/priv/llm_db/local/openrouter/perplexity_pplx-embed-v1-4b.toml
+++ b/priv/llm_db/local/openrouter/perplexity_pplx-embed-v1-4b.toml
@@ -1,0 +1,6 @@
+id = "perplexity/pplx-embed-v1-4b"
+
+[capabilities.embeddings]
+min_dimensions = 4096
+max_dimensions = 4096
+default_dimensions = 4096

--- a/priv/llm_db/local/openrouter/qwen_qwen3-embedding-4b.toml
+++ b/priv/llm_db/local/openrouter/qwen_qwen3-embedding-4b.toml
@@ -1,0 +1,6 @@
+id = "qwen/qwen3-embedding-4b"
+
+[capabilities.embeddings]
+min_dimensions = 2560
+max_dimensions = 2560
+default_dimensions = 2560

--- a/priv/llm_db/local/openrouter/qwen_qwen3-embedding-8b.toml
+++ b/priv/llm_db/local/openrouter/qwen_qwen3-embedding-8b.toml
@@ -1,0 +1,6 @@
+id = "qwen/qwen3-embedding-8b"
+
+[capabilities.embeddings]
+min_dimensions = 4096
+max_dimensions = 4096
+default_dimensions = 4096

--- a/priv/llm_db/local/openrouter/sentence-transformers_all-minilm-l12-v2.toml
+++ b/priv/llm_db/local/openrouter/sentence-transformers_all-minilm-l12-v2.toml
@@ -1,0 +1,6 @@
+id = "sentence-transformers/all-minilm-l12-v2"
+
+[capabilities.embeddings]
+min_dimensions = 384
+max_dimensions = 384
+default_dimensions = 384

--- a/priv/llm_db/local/openrouter/sentence-transformers_all-minilm-l6-v2.toml
+++ b/priv/llm_db/local/openrouter/sentence-transformers_all-minilm-l6-v2.toml
@@ -1,0 +1,6 @@
+id = "sentence-transformers/all-minilm-l6-v2"
+
+[capabilities.embeddings]
+min_dimensions = 384
+max_dimensions = 384
+default_dimensions = 384

--- a/priv/llm_db/local/openrouter/sentence-transformers_all-mpnet-base-v2.toml
+++ b/priv/llm_db/local/openrouter/sentence-transformers_all-mpnet-base-v2.toml
@@ -1,0 +1,6 @@
+id = "sentence-transformers/all-mpnet-base-v2"
+
+[capabilities.embeddings]
+min_dimensions = 768
+max_dimensions = 768
+default_dimensions = 768

--- a/priv/llm_db/local/openrouter/sentence-transformers_multi-qa-mpnet-base-dot-v1.toml
+++ b/priv/llm_db/local/openrouter/sentence-transformers_multi-qa-mpnet-base-dot-v1.toml
@@ -1,0 +1,6 @@
+id = "sentence-transformers/multi-qa-mpnet-base-dot-v1"
+
+[capabilities.embeddings]
+min_dimensions = 768
+max_dimensions = 768
+default_dimensions = 768

--- a/priv/llm_db/local/openrouter/sentence-transformers_paraphrase-minilm-l6-v2.toml
+++ b/priv/llm_db/local/openrouter/sentence-transformers_paraphrase-minilm-l6-v2.toml
@@ -1,0 +1,6 @@
+id = "sentence-transformers/paraphrase-minilm-l6-v2"
+
+[capabilities.embeddings]
+min_dimensions = 384
+max_dimensions = 384
+default_dimensions = 384

--- a/priv/llm_db/local/openrouter/thenlper_gte-base.toml
+++ b/priv/llm_db/local/openrouter/thenlper_gte-base.toml
@@ -1,0 +1,6 @@
+id = "thenlper/gte-base"
+
+[capabilities.embeddings]
+min_dimensions = 768
+max_dimensions = 768
+default_dimensions = 768

--- a/priv/llm_db/local/openrouter/thenlper_gte-large.toml
+++ b/priv/llm_db/local/openrouter/thenlper_gte-large.toml
@@ -1,0 +1,6 @@
+id = "thenlper/gte-large"
+
+[capabilities.embeddings]
+min_dimensions = 1024
+max_dimensions = 1024
+default_dimensions = 1024

--- a/priv/llm_db/providers/openrouter.json
+++ b/priv/llm_db/providers/openrouter.json
@@ -13810,8 +13810,8 @@
         }
       },
       "cost": {
-        "input": -1.0e6,
-        "output": -1.0e6
+        "input": -1000000.0,
+        "output": -1000000.0
       },
       "deprecated": false,
       "extra": {
@@ -13853,8 +13853,8 @@
       "base_url": null,
       "capabilities": null,
       "cost": {
-        "input": -1.0e6,
-        "output": -1.0e6
+        "input": -1000000.0,
+        "output": -1000000.0
       },
       "deprecated": false,
       "extra": {
@@ -19310,6 +19310,1511 @@
       "provider": "openrouter",
       "provider_model_id": null,
       "release_date": "2026-02-11",
+      "retired": false,
+      "tags": null
+    },
+    "baai/bge-base-en-v1.5": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 768,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.005,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "baai/bge-base-en-v1.5",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "BAAI: bge-base-en-v1.5",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "baai/bge-large-en-v1.5": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 1024,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.01,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "baai/bge-large-en-v1.5",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "BAAI: bge-large-en-v1.5",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "baai/bge-m3": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 1024,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.01,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "baai/bge-m3",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 8192,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "BAAI: bge-m3",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "google/gemini-embedding-001": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 768,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.15,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "google/gemini-embedding-001",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 20000,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Google: Gemini Embedding 001",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "google/gemini-embedding-2-preview": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 3072,
+          "max_inputs": null,
+          "dimensions_flexible": true
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.2,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "google/gemini-embedding-2-preview",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 8192,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Google: Gemini Embedding 2 Preview",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "intfloat/e5-base-v2": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 768,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.005,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "intfloat/e5-base-v2",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Intfloat: E5-Base-v2",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "intfloat/e5-large-v2": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 1024,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.01,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "intfloat/e5-large-v2",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Intfloat: E5-Large-v2",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "intfloat/multilingual-e5-large": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 1024,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.01,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "intfloat/multilingual-e5-large",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Intfloat: Multilingual-E5-Large",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "mistralai/codestral-embed-2505": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 1024,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.15,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "mistralai/codestral-embed-2505",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 8192,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Mistral: Codestral Embed 2505",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "mistralai/mistral-embed-2312": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 1024,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.1,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "mistralai/mistral-embed-2312",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 8192,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Mistral: Mistral Embed 2312",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "nvidia/llama-nemotron-embed-vl-1b-v2:free": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 4096,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.0,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "nvidia/llama-nemotron-embed-vl-1b-v2:free",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 131072,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "NVIDIA: Llama Nemotron Embed VL 1B V2",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "openai/text-embedding-3-large": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 3072,
+          "max_inputs": null,
+          "dimensions_flexible": true
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.13,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "openai/text-embedding-3-large",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 8192,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "OpenAI: Text Embedding 3 Large",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "openai/text-embedding-3-small": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 1536,
+          "max_inputs": null,
+          "dimensions_flexible": true
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.02,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "openai/text-embedding-3-small",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 8192,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "OpenAI: Text Embedding 3 Small",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "openai/text-embedding-ada-002": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 1536,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.1,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "openai/text-embedding-ada-002",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 8192,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "OpenAI: Text Embedding Ada 002",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "perplexity/pplx-embed-v1-0.6b": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 768,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.004,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "perplexity/pplx-embed-v1-0.6b",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 32000,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Perplexity: Embed V1 0.6B",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "perplexity/pplx-embed-v1-4b": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 4096,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.03,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "perplexity/pplx-embed-v1-4b",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 32000,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Perplexity: Embed V1 4B",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "qwen/qwen3-embedding-4b": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 2560,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.02,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "qwen/qwen3-embedding-4b",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 32768,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Qwen: Qwen3 Embedding 4B",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "qwen/qwen3-embedding-8b": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 4096,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.01,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "qwen/qwen3-embedding-8b",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 32000,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Qwen: Qwen3 Embedding 8B",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "sentence-transformers/all-minilm-l12-v2": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 384,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.005,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "sentence-transformers/all-minilm-l12-v2",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Sentence Transformers: all-MiniLM-L12-v2",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "sentence-transformers/all-minilm-l6-v2": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 384,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.005,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "sentence-transformers/all-minilm-l6-v2",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Sentence Transformers: all-MiniLM-L6-v2",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "sentence-transformers/all-mpnet-base-v2": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 768,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.005,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "sentence-transformers/all-mpnet-base-v2",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Sentence Transformers: all-mpnet-base-v2",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "sentence-transformers/multi-qa-mpnet-base-dot-v1": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 768,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.005,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "sentence-transformers/multi-qa-mpnet-base-dot-v1",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Sentence Transformers: multi-qa-mpnet-base-dot-v1",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "sentence-transformers/paraphrase-minilm-l6-v2": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 384,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.005,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "sentence-transformers/paraphrase-minilm-l6-v2",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Sentence Transformers: paraphrase-MiniLM-L6-v2",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "thenlper/gte-base": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 768,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.005,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "thenlper/gte-base",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Thenlper: GTE-Base",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
+      "retired": false,
+      "tags": null
+    },
+    "thenlper/gte-large": {
+      "aliases": [],
+      "base_url": null,
+      "capabilities": {
+        "chat": false,
+        "embeddings": {
+          "dimensions": 1024,
+          "max_inputs": null
+        },
+        "json": {
+          "native": false,
+          "schema": false,
+          "strict": false
+        },
+        "reasoning": {
+          "enabled": false
+        },
+        "streaming": {
+          "text": false,
+          "tool_calls": false
+        },
+        "tools": {
+          "enabled": false
+        }
+      },
+      "cost": {
+        "input": 0.01,
+        "output": 0.0
+      },
+      "deprecated": false,
+      "extra": {
+        "expiration_date": null,
+        "hugging_face_id": null
+      },
+      "family": null,
+      "id": "thenlper/gte-large",
+      "knowledge": null,
+      "last_updated": null,
+      "lifecycle": null,
+      "limits": {
+        "context": 512,
+        "output": null
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "embedding"
+        ]
+      },
+      "model": null,
+      "name": "Thenlper: GTE-Large",
+      "pricing": null,
+      "provider": "openrouter",
+      "provider_model_id": null,
+      "release_date": null,
       "retired": false,
       "tags": null
     }

--- a/priv/llm_db/upstream/openrouter-051e0609.json
+++ b/priv/llm_db/upstream/openrouter-051e0609.json
@@ -20469,6 +20469,933 @@
         "is_moderated": true,
         "max_completion_tokens": 4096
       }
+    },
+    {
+      "id": "baai/bge-base-en-v1.5",
+      "name": "BAAI: bge-base-en-v1.5",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "5e-09",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "baai/bge-base-en-v1.5",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/baai/bge-base-en-v1.5/endpoints"
+      }
+    },
+    {
+      "id": "baai/bge-large-en-v1.5",
+      "name": "BAAI: bge-large-en-v1.5",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1e-08",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "baai/bge-large-en-v1.5",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/baai/bge-large-en-v1.5/endpoints"
+      }
+    },
+    {
+      "id": "baai/bge-m3",
+      "name": "BAAI: bge-m3",
+      "context_length": 8192,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1e-08",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "baai/bge-m3",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 8192,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/baai/bge-m3/endpoints"
+      }
+    },
+    {
+      "id": "google/gemini-embedding-001",
+      "name": "Google: Gemini Embedding 001",
+      "context_length": 20000,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1.5e-07",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "google/gemini-embedding-001",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 20000,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/google/gemini-embedding-001/endpoints"
+      }
+    },
+    {
+      "id": "google/gemini-embedding-2-preview",
+      "name": "Google: Gemini Embedding 2 Preview",
+      "context_length": 8192,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text",
+          "image"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text+image->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "2e-07",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "google/gemini-embedding-2-preview",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 8192,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/google/gemini-embedding-2-preview/endpoints"
+      }
+    },
+    {
+      "id": "intfloat/e5-base-v2",
+      "name": "Intfloat: E5-Base-v2",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "5e-09",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "intfloat/e5-base-v2",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/intfloat/e5-base-v2/endpoints"
+      }
+    },
+    {
+      "id": "intfloat/e5-large-v2",
+      "name": "Intfloat: E5-Large-v2",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1e-08",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "intfloat/e5-large-v2",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/intfloat/e5-large-v2/endpoints"
+      }
+    },
+    {
+      "id": "intfloat/multilingual-e5-large",
+      "name": "Intfloat: Multilingual-E5-Large",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1e-08",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "intfloat/multilingual-e5-large",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/intfloat/multilingual-e5-large/endpoints"
+      }
+    },
+    {
+      "id": "mistralai/codestral-embed-2505",
+      "name": "Mistral: Codestral Embed 2505",
+      "context_length": 8192,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1.5e-07",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "mistralai/codestral-embed-2505",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 8192,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/mistralai/codestral-embed-2505/endpoints"
+      }
+    },
+    {
+      "id": "mistralai/mistral-embed-2312",
+      "name": "Mistral: Mistral Embed 2312",
+      "context_length": 8192,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1e-07",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "mistralai/mistral-embed-2312",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 8192,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/mistralai/mistral-embed-2312/endpoints"
+      }
+    },
+    {
+      "id": "nvidia/llama-nemotron-embed-vl-1b-v2:free",
+      "name": "NVIDIA: Llama Nemotron Embed VL 1B V2",
+      "context_length": 131072,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text",
+          "image"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text+image->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "nvidia/llama-nemotron-embed-vl-1b-v2",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 131072,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/nvidia/llama-nemotron-embed-vl-1b-v2/endpoints"
+      }
+    },
+    {
+      "id": "openai/text-embedding-3-large",
+      "name": "OpenAI: Text Embedding 3 Large",
+      "context_length": 8192,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1.3e-07",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "openai/text-embedding-3-large",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 8192,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/openai/text-embedding-3-large/endpoints"
+      }
+    },
+    {
+      "id": "openai/text-embedding-3-small",
+      "name": "OpenAI: Text Embedding 3 Small",
+      "context_length": 8192,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "2e-08",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "openai/text-embedding-3-small",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 8192,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/openai/text-embedding-3-small/endpoints"
+      }
+    },
+    {
+      "id": "openai/text-embedding-ada-002",
+      "name": "OpenAI: Text Embedding Ada 002",
+      "context_length": 8192,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1e-07",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "openai/text-embedding-ada-002",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 8192,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/openai/text-embedding-ada-002/endpoints"
+      }
+    },
+    {
+      "id": "perplexity/pplx-embed-v1-0.6b",
+      "name": "Perplexity: Embed V1 0.6B",
+      "context_length": 32000,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "4e-09",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "perplexity/pplx-embed-v1-0.6b",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 32000,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/perplexity/pplx-embed-v1-0.6b/endpoints"
+      }
+    },
+    {
+      "id": "perplexity/pplx-embed-v1-4b",
+      "name": "Perplexity: Embed V1 4B",
+      "context_length": 32000,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "3e-08",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "perplexity/pplx-embed-v1-4b",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 32000,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/perplexity/pplx-embed-v1-4b/endpoints"
+      }
+    },
+    {
+      "id": "qwen/qwen3-embedding-4b",
+      "name": "Qwen: Qwen3 Embedding 4B",
+      "context_length": 32768,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "2e-08",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "qwen/qwen3-embedding-4b",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 32768,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/qwen/qwen3-embedding-4b/endpoints"
+      }
+    },
+    {
+      "id": "qwen/qwen3-embedding-8b",
+      "name": "Qwen: Qwen3 Embedding 8B",
+      "context_length": 32000,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1e-08",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "qwen/qwen3-embedding-8b",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 32000,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/qwen/qwen3-embedding-8b/endpoints"
+      }
+    },
+    {
+      "id": "sentence-transformers/all-minilm-l12-v2",
+      "name": "Sentence Transformers: all-MiniLM-L12-v2",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "5e-09",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "sentence-transformers/all-minilm-l12-v2",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/sentence-transformers/all-minilm-l12-v2/endpoints"
+      }
+    },
+    {
+      "id": "sentence-transformers/all-minilm-l6-v2",
+      "name": "Sentence Transformers: all-MiniLM-L6-v2",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "5e-09",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "sentence-transformers/all-minilm-l6-v2",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/sentence-transformers/all-minilm-l6-v2/endpoints"
+      }
+    },
+    {
+      "id": "sentence-transformers/all-mpnet-base-v2",
+      "name": "Sentence Transformers: all-mpnet-base-v2",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "5e-09",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "sentence-transformers/all-mpnet-base-v2",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/sentence-transformers/all-mpnet-base-v2/endpoints"
+      }
+    },
+    {
+      "id": "sentence-transformers/multi-qa-mpnet-base-dot-v1",
+      "name": "Sentence Transformers: multi-qa-mpnet-base-dot-v1",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "5e-09",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "sentence-transformers/multi-qa-mpnet-base-dot-v1",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/sentence-transformers/multi-qa-mpnet-base-dot-v1/endpoints"
+      }
+    },
+    {
+      "id": "sentence-transformers/paraphrase-minilm-l6-v2",
+      "name": "Sentence Transformers: paraphrase-MiniLM-L6-v2",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "5e-09",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "sentence-transformers/paraphrase-minilm-l6-v2",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/sentence-transformers/paraphrase-minilm-l6-v2/endpoints"
+      }
+    },
+    {
+      "id": "thenlper/gte-base",
+      "name": "Thenlper: GTE-Base",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "5e-09",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "thenlper/gte-base",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/thenlper/gte-base/endpoints"
+      }
+    },
+    {
+      "id": "thenlper/gte-large",
+      "name": "Thenlper: GTE-Large",
+      "context_length": 512,
+      "description": "",
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "embedding"
+        ],
+        "modality": "text->embeddings",
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "1e-08",
+        "completion": "0"
+      },
+      "created": 1778150729,
+      "canonical_slug": "thenlper/gte-large",
+      "hugging_face_id": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "per_request_limits": null,
+      "top_provider": {
+        "context_length": 512,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [],
+      "default_parameters": {},
+      "links": {
+        "details": "/api/v1/models/thenlper/gte-large/endpoints"
+      }
     }
   ]
 }

--- a/test/llm_db/enrich/runtime_contract_test.exs
+++ b/test/llm_db/enrich/runtime_contract_test.exs
@@ -160,6 +160,47 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
       assert enriched.capabilities.streaming.text == false
     end
 
+    test "derives embed execution for openrouter model with :embeddings plural in output modalities" do
+      provider =
+        Provider.new!(%{id: :openrouter, env: ["OPENROUTER_API_KEY"]})
+        |> RuntimeContract.enrich_provider()
+
+      model =
+        Model.new!(%{
+          id: "baai/bge-m3",
+          provider: :openrouter,
+          modalities: %{input: [:text], output: [:embeddings]}
+        })
+
+      enriched = RuntimeContract.enrich_model(model, provider)
+
+      assert enriched.catalog_only == false
+      assert Map.has_key?(enriched.execution, :embed)
+      assert enriched.execution.embed.family == "openai_embeddings"
+      refute Map.has_key?(enriched.execution, :text)
+      refute Map.has_key?(enriched.execution, :object)
+    end
+
+    test "derives embed execution for openrouter model with :embedding singular in output modalities" do
+      provider =
+        Provider.new!(%{id: :openrouter, env: ["OPENROUTER_API_KEY"]})
+        |> RuntimeContract.enrich_provider()
+
+      model =
+        Model.new!(%{
+          id: "openai/text-embedding-ada-002",
+          provider: :openrouter,
+          modalities: %{input: [:text], output: [:embedding]}
+        })
+
+      enriched = RuntimeContract.enrich_model(model, provider)
+
+      assert enriched.catalog_only == false
+      assert Map.has_key?(enriched.execution, :embed)
+      assert enriched.execution.embed.family == "openai_embeddings"
+      refute Map.has_key?(enriched.execution, :text)
+    end
+
     test "derives rerank capability metadata from reranker ids on catalog-only providers" do
       provider =
         Provider.new!(%{id: :berget})

--- a/test/llm_db/sources/openrouter_test.exs
+++ b/test/llm_db/sources/openrouter_test.exs
@@ -304,6 +304,98 @@ defmodule LLMDB.Sources.OpenRouterTest do
     end
   end
 
+  describe "output_modalities embedding detection" do
+    test "sets embeddings capability when output_modalities contains 'embedding'" do
+      input = %{
+        "data" => [
+          %{
+            "id" => "baai/bge-m3",
+            "name" => "BGE-M3",
+            "architecture" => %{
+              "modality" => "text->text",
+              "output_modalities" => ["embedding"]
+            }
+          }
+        ]
+      }
+
+      result = OpenRouter.transform(input)
+      model = hd(result["openrouter"][:models])
+
+      assert model[:capabilities][:embeddings] == true
+    end
+
+    test "does not set embeddings capability when output_modalities lacks 'embedding'" do
+      input = %{
+        "data" => [
+          %{
+            "id" => "openai/gpt-4",
+            "name" => "GPT-4",
+            "architecture" => %{
+              "modality" => "text->text",
+              "output_modalities" => ["text"]
+            }
+          }
+        ]
+      }
+
+      result = OpenRouter.transform(input)
+      model = hd(result["openrouter"][:models])
+
+      refute get_in(model, [:capabilities, :embeddings])
+    end
+
+    test "does not set embeddings capability when architecture has no output_modalities" do
+      input = %{
+        "data" => [
+          %{
+            "id" => "openai/gpt-4",
+            "name" => "GPT-4",
+            "architecture" => %{"modality" => "text->text"}
+          }
+        ]
+      }
+
+      result = OpenRouter.transform(input)
+      model = hd(result["openrouter"][:models])
+
+      refute get_in(model, [:capabilities, :embeddings])
+    end
+
+    test "does not set embeddings capability when architecture is nil" do
+      input = %{
+        "data" => [%{"id" => "openai/gpt-4", "name" => "GPT-4"}]
+      }
+
+      result = OpenRouter.transform(input)
+      model = hd(result["openrouter"][:models])
+
+      refute get_in(model, [:capabilities, :embeddings])
+    end
+
+    test "sets both tools and embeddings capabilities together" do
+      input = %{
+        "data" => [
+          %{
+            "id" => "some/embed-tools-model",
+            "name" => "Embed Tools Model",
+            "architecture" => %{
+              "modality" => "text->text",
+              "output_modalities" => ["embedding"]
+            },
+            "supported_parameters" => ["tools"]
+          }
+        ]
+      }
+
+      result = OpenRouter.transform(input)
+      model = hd(result["openrouter"][:models])
+
+      assert model[:capabilities][:embeddings] == true
+      assert model[:capabilities][:tools][:enabled] == true
+    end
+  end
+
   describe "transform/1" do
     test "transforms minimal model correctly" do
       input = %{

--- a/test/llm_db/sources_test.exs
+++ b/test/llm_db/sources_test.exs
@@ -121,6 +121,93 @@ defmodule LLMDB.SourcesTest do
     end
   end
 
+  describe "OpenRouter embedding dimension overlays" do
+    test "openai/text-embedding-3-large has correct dimension range" do
+      {:ok, data} = Local.load(%{dir: "priv/llm_db/local"})
+      openrouter = data["openrouter"]
+      assert openrouter, "openrouter provider should be present in local overlays"
+
+      model = Enum.find(openrouter.models, fn m -> m.id == "openai/text-embedding-3-large" end)
+      assert model, "openai/text-embedding-3-large overlay should exist"
+
+      embeddings = get_in(model, [:capabilities, :embeddings])
+      assert is_map(embeddings), "capabilities.embeddings should be a map"
+      assert embeddings[:min_dimensions] == 1
+      assert embeddings[:max_dimensions] == 3072
+      assert embeddings[:default_dimensions] == 3072
+    end
+
+    test "openai/text-embedding-3-small has correct dimension range" do
+      {:ok, data} = Local.load(%{dir: "priv/llm_db/local"})
+
+      model =
+        data["openrouter"].models
+        |> Enum.find(&(&1.id == "openai/text-embedding-3-small"))
+
+      assert model
+      embeddings = get_in(model, [:capabilities, :embeddings])
+      assert embeddings[:min_dimensions] == 1
+      assert embeddings[:max_dimensions] == 1536
+      assert embeddings[:default_dimensions] == 1536
+    end
+
+    test "baai/bge-m3 has correct fixed dimensions" do
+      {:ok, data} = Local.load(%{dir: "priv/llm_db/local"})
+      model = Enum.find(data["openrouter"].models, &(&1.id == "baai/bge-m3"))
+
+      assert model
+      embeddings = get_in(model, [:capabilities, :embeddings])
+      assert embeddings[:min_dimensions] == 1024
+      assert embeddings[:max_dimensions] == 1024
+      assert embeddings[:default_dimensions] == 1024
+    end
+
+    test "all 25 openrouter embedding overlays have required dimension fields" do
+      {:ok, data} = Local.load(%{dir: "priv/llm_db/local"})
+
+      expected_ids = ~w[
+        openai/text-embedding-3-large
+        openai/text-embedding-3-small
+        openai/text-embedding-ada-002
+        baai/bge-m3
+        baai/bge-base-en-v1.5
+        baai/bge-large-en-v1.5
+        google/gemini-embedding-001
+        google/gemini-embedding-2-preview
+        intfloat/e5-base-v2
+        intfloat/e5-large-v2
+        intfloat/multilingual-e5-large
+        mistralai/codestral-embed-2505
+        mistralai/mistral-embed-2312
+        nvidia/llama-nemotron-embed-vl-1b-v2:free
+        perplexity/pplx-embed-v1-0.6b
+        perplexity/pplx-embed-v1-4b
+        qwen/qwen3-embedding-4b
+        qwen/qwen3-embedding-8b
+        sentence-transformers/all-minilm-l12-v2
+        sentence-transformers/all-minilm-l6-v2
+        sentence-transformers/all-mpnet-base-v2
+        sentence-transformers/multi-qa-mpnet-base-dot-v1
+        sentence-transformers/paraphrase-minilm-l6-v2
+        thenlper/gte-base
+        thenlper/gte-large
+      ]
+
+      models_by_id = Map.new(data["openrouter"].models, &{&1.id, &1})
+
+      Enum.each(expected_ids, fn id ->
+        model = models_by_id[id]
+        assert model, "overlay for #{id} should be present"
+
+        embeddings = get_in(model, [:capabilities, :embeddings])
+        assert is_map(embeddings), "#{id} should have capabilities.embeddings map"
+        assert is_integer(embeddings[:min_dimensions]), "#{id} should have min_dimensions"
+        assert is_integer(embeddings[:max_dimensions]), "#{id} should have max_dimensions"
+        assert is_integer(embeddings[:default_dimensions]), "#{id} should have default_dimensions"
+      end)
+    end
+  end
+
   describe "Source behavior contract" do
     test "all sources return {:ok, data} format with nested structure" do
       # Config


### PR DESCRIPTION
## Description

 Improves embedding model detection for the OpenRouter source in two ways:
                                                                                                           
  1. Auto-detection via output_modalities: The OpenRouter source now checks architecture.output_modalities 
  for "embedding" to mark models as embedding-capable, catching models that OpenRouter flags this way but  
  don't use the legacy output modality field.                                                              
  2. Dimension overlays for 25 models: Adds local TOML overlay files for 25 embedding models (OpenAI,
  Google, Mistral, BAAI, Qwen, Perplexity, Sentence Transformers, etc.) specifying min/max/default         
  dimension constraints.
  3. Runtime contract fix: embedding_model?/1 now recognises both :embedding and :embeddings in the output 
  modalities list, fixing a pluralisation inconsistency.  

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N/A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
- [x] I have **NOT** directly edited generated snapshot/history artifacts unless this PR intentionally regenerates them (`priv/llm_db/snapshot.json`, `priv/llm_db/history/**`)

## Related Issues

Closes #
