### PR TITLE
fix: update google model metadata

### DIFF
--- a/priv/llm_db/local/google/gemini-2.0-flash-001.toml
+++ b/priv/llm_db/local/google/gemini-2.0-flash-001.toml
@@ -1,0 +1,6 @@
+id = "gemini-2.0-flash-001"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-06-01"
+replacement = "gemini-3.5-flash"

--- a/priv/llm_db/local/google/gemini-2.0-flash-lite-001.toml
+++ b/priv/llm_db/local/google/gemini-2.0-flash-lite-001.toml
@@ -1,0 +1,6 @@
+id = "gemini-2.0-flash-lite-001"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-06-01"
+replacement = "gemini-3.1-flash-lite"

--- a/priv/llm_db/local/google/gemini-2.0-flash-lite.toml
+++ b/priv/llm_db/local/google/gemini-2.0-flash-lite.toml
@@ -1,0 +1,6 @@
+id = "gemini-2.0-flash-lite"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-06-01"
+replacement = "gemini-3.1-flash-lite"

--- a/priv/llm_db/local/google/gemini-2.0-flash.toml
+++ b/priv/llm_db/local/google/gemini-2.0-flash.toml
@@ -1,0 +1,6 @@
+id = "gemini-2.0-flash"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-06-01"
+replacement = "gemini-3.5-flash"

--- a/priv/llm_db/local/google/gemini-2.5-flash-image.toml
+++ b/priv/llm_db/local/google/gemini-2.5-flash-image.toml
@@ -66,3 +66,8 @@ top_k = 64
 top_p = 0.95
 version = "2.0"
 supported_generation_methods = ["generateContent", "countTokens", "batchGenerateContent"]
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-10-02"
+replacement = "gemini-3.1-flash-image"

--- a/priv/llm_db/local/google/gemini-2.5-flash-lite.toml
+++ b/priv/llm_db/local/google/gemini-2.5-flash-lite.toml
@@ -57,3 +57,8 @@ top_k = 64
 top_p = 0.95
 version = "001"
 supported_generation_methods = ["generateContent", "countTokens", "createCachedContent", "batchGenerateContent"]
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-10-16"
+replacement = "gemini-3.1-flash-lite"

--- a/priv/llm_db/local/google/gemini-2.5-flash.toml
+++ b/priv/llm_db/local/google/gemini-2.5-flash.toml
@@ -6,3 +6,8 @@ provider = "google"
 input = 0.3
 output = 2.5
 cache_read = 0.03
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-10-16"
+replacement = "gemini-3.5-flash"

--- a/priv/llm_db/local/google/gemini-2.5-pro.toml
+++ b/priv/llm_db/local/google/gemini-2.5-pro.toml
@@ -6,3 +6,8 @@ provider = "google"
 input = 1.25
 output = 10.0
 cache_read = 0.125
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-10-16"
+replacement = "gemini-3.1-pro-preview"

--- a/priv/llm_db/local/google/gemini-3-pro-image-preview.toml
+++ b/priv/llm_db/local/google/gemini-3-pro-image-preview.toml
@@ -6,6 +6,12 @@ provider = "google"
 input = 2.0
 output = 12.0
 
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-28"
+retires_at = "2026-06-25"
+replacement = "gemini-3-pro-image"
+
 [pricing]
 currency = "USD"
 merge = "merge_by_id"

--- a/priv/llm_db/local/google/gemini-3-pro-image.toml
+++ b/priv/llm_db/local/google/gemini-3-pro-image.toml
@@ -1,0 +1,74 @@
+id = "gemini-3-pro-image"
+release_date = "2026-05-28"
+last_updated = "2025-11"
+knowledge = "2025-01"
+
+[limits]
+context = 65536
+output = 32768
+
+[cost]
+input = 2.0
+output = 12.0
+
+[pricing]
+currency = "USD"
+merge = "merge_by_id"
+
+[[pricing.components]]
+id = "image.input"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.0011
+notes = "560 tokens per input image"
+
+[[pricing.components]]
+id = "image.output.1024x1024-2048x2048"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.134
+size_class = "1024x1024-2048x2048"
+notes = "1K/2K output image (1120 tokens)"
+
+[[pricing.components]]
+id = "image.output.4096x4096"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.24
+size_class = "4096x4096"
+notes = "4K output image (2000 tokens)"
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]
+
+[capabilities]
+chat = true
+embeddings = false
+
+[capabilities.json]
+native = false
+schema = true
+strict = false
+
+[capabilities.reasoning]
+enabled = true
+
+[capabilities.streaming]
+text = true
+tool_calls = false
+
+[capabilities.tools]
+enabled = false
+parallel = false
+streaming = false
+strict = false
+
+[extra]
+attachment = true
+family = "gemini-pro-image"
+open_weights = false
+structured_output = true

--- a/priv/llm_db/local/google/gemini-3-pro-preview.toml
+++ b/priv/llm_db/local/google/gemini-3-pro-preview.toml
@@ -1,0 +1,7 @@
+id = "gemini-3-pro-preview"
+
+[lifecycle]
+status = "retired"
+deprecated_at = "2026-02-26"
+retires_at = "2026-03-09"
+replacement = "gemini-3.1-pro-preview"

--- a/priv/llm_db/local/google/gemini-3.1-flash-image-preview.toml
+++ b/priv/llm_db/local/google/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,7 @@
+id = "gemini-3.1-flash-image-preview"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-05-28"
+retires_at = "2026-06-25"
+replacement = "gemini-3.1-flash-image"

--- a/priv/llm_db/local/google/gemini-3.1-flash-image.toml
+++ b/priv/llm_db/local/google/gemini-3.1-flash-image.toml
@@ -1,0 +1,83 @@
+id = "gemini-3.1-flash-image"
+release_date = "2026-05-28"
+last_updated = "2026-02"
+knowledge = "2025-01"
+
+[limits]
+context = 131072
+output = 32768
+
+[cost]
+input = 0.5
+output = 3.0
+
+[pricing]
+currency = "USD"
+merge = "merge_by_id"
+
+[[pricing.components]]
+id = "image.output.0.5k"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.045
+size_class = "0.5K"
+notes = "512px output image"
+
+[[pricing.components]]
+id = "image.output.1k"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.067
+size_class = "1K"
+notes = "1024x1024 output image"
+
+[[pricing.components]]
+id = "image.output.2k"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.101
+size_class = "2K"
+notes = "2048x2048 output image"
+
+[[pricing.components]]
+id = "image.output.4k"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.151
+size_class = "4K"
+notes = "4096x4096 output image"
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text", "image"]
+
+[capabilities]
+chat = true
+embeddings = false
+
+[capabilities.json]
+native = false
+schema = false
+strict = false
+
+[capabilities.reasoning]
+enabled = true
+
+[capabilities.streaming]
+text = true
+tool_calls = false
+
+[capabilities.tools]
+enabled = false
+parallel = false
+streaming = false
+strict = false
+
+[extra]
+attachment = true
+family = "gemini-flash-image"
+open_weights = false

--- a/priv/llm_db/local/google/gemini-3.1-flash-lite-preview.toml
+++ b/priv/llm_db/local/google/gemini-3.1-flash-lite-preview.toml
@@ -1,7 +1,7 @@
 id = "gemini-3.1-flash-lite-preview"
 
 [lifecycle]
-status = "deprecated"
-deprecated_at = "2026-05-12"
+status = "retired"
+deprecated_at = "2026-05-11"
 retires_at = "2026-05-25"
 replacement = "gemini-3.1-flash-lite"

--- a/priv/llm_db/local/google/gemini-3.1-flash-lite.toml
+++ b/priv/llm_db/local/google/gemini-3.1-flash-lite.toml
@@ -1,0 +1,5 @@
+id = "gemini-3.1-flash-lite"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2027-05-07"

--- a/priv/llm_db/local/google/gemini-embedding-001.toml
+++ b/priv/llm_db/local/google/gemini-embedding-001.toml
@@ -10,6 +10,11 @@ context = 2048
 [cost]
 input = 0.15
 
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-07-14"
+replacement = "gemini-embedding-2"
+
 [modalities]
 input = ["text"]
 output = ["embedding"]

--- a/priv/llm_db/local/google/gemini-embedding-2.toml
+++ b/priv/llm_db/local/google/gemini-embedding-2.toml
@@ -1,0 +1,54 @@
+id = "gemini-embedding-2"
+release_date = "2026-04-22"
+last_updated = "2026-04"
+
+[limits]
+context = 8192
+
+[cost]
+input = 0.20
+image = 0.45
+audio = 6.50
+input_video = 12.00
+
+[pricing]
+currency = "USD"
+merge = "merge_by_id"
+
+[[pricing.components]]
+id = "image.input"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.00012
+
+[[pricing.components]]
+id = "audio.input.second"
+kind = "other"
+unit = "other"
+per = 1
+rate = 0.00016
+meter = "audio_second"
+
+[[pricing.components]]
+id = "video.input.frame"
+kind = "other"
+unit = "other"
+per = 1
+rate = 0.00079
+meter = "video_frame"
+
+[modalities]
+input = ["text", "image", "video", "audio", "pdf"]
+output = ["embedding"]
+
+[capabilities]
+chat = false
+
+[capabilities.embeddings]
+min_dimensions = 128
+max_dimensions = 3072
+
+[extra]
+type = "embedding"
+open_weights = false

--- a/priv/llm_db/local/google/gemini-robotics-er-1.5-preview.toml
+++ b/priv/llm_db/local/google/gemini-robotics-er-1.5-preview.toml
@@ -1,0 +1,7 @@
+id = "gemini-robotics-er-1.5-preview"
+
+[lifecycle]
+status = "retired"
+deprecated_at = "2026-04-14"
+retires_at = "2026-04-30"
+replacement = "gemini-robotics-er-1.6-preview"

--- a/priv/llm_db/local/google/imagen-4.0-fast-generate-001.toml
+++ b/priv/llm_db/local/google/imagen-4.0-fast-generate-001.toml
@@ -1,0 +1,16 @@
+id = "imagen-4.0-fast-generate-001"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-06-24"
+
+[pricing]
+currency = "USD"
+merge = "merge_by_id"
+
+[[pricing.components]]
+id = "image.output"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.02

--- a/priv/llm_db/local/google/imagen-4.0-generate-001.toml
+++ b/priv/llm_db/local/google/imagen-4.0-generate-001.toml
@@ -1,0 +1,16 @@
+id = "imagen-4.0-generate-001"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-06-24"
+
+[pricing]
+currency = "USD"
+merge = "merge_by_id"
+
+[[pricing.components]]
+id = "image.output"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.04

--- a/priv/llm_db/local/google/imagen-4.0-ultra-generate-001.toml
+++ b/priv/llm_db/local/google/imagen-4.0-ultra-generate-001.toml
@@ -1,0 +1,16 @@
+id = "imagen-4.0-ultra-generate-001"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-06-24"
+
+[pricing]
+currency = "USD"
+merge = "merge_by_id"
+
+[[pricing.components]]
+id = "image.output"
+kind = "image"
+unit = "image"
+per = 1
+rate = 0.06

--- a/priv/llm_db/local/google/provider.toml
+++ b/priv/llm_db/local/google/provider.toml
@@ -2,9 +2,9 @@
 id = "google"
 name = "Google"
 base_url = "https://generativelanguage.googleapis.com/v1beta"
-doc = "https://ai.google.dev/docs"
+doc = "https://ai.google.dev/gemini-api/docs"
 
-env = ["GOOGLE_API_KEY"]
+env = ["GOOGLE_API_KEY", "GEMINI_API_KEY"]
 
 exclude_models = [
   "gemini-1.0-pro-001",

--- a/test/llm_db/google_metadata_test.exs
+++ b/test/llm_db/google_metadata_test.exs
@@ -1,0 +1,117 @@
+defmodule LLMDB.GoogleMetadataTest do
+  use ExUnit.Case, async: true
+
+  alias LLMDB.{Model, Normalize, Provider}
+  alias LLMDB.Sources.Local
+
+  @local_dir "priv/llm_db/local"
+
+  @retired_lifecycle %{
+    "gemini-2.0-flash" => {"2026-06-01", "gemini-3.5-flash"},
+    "gemini-2.0-flash-001" => {"2026-06-01", "gemini-3.5-flash"},
+    "gemini-2.0-flash-lite" => {"2026-06-01", "gemini-3.1-flash-lite"},
+    "gemini-2.0-flash-lite-001" => {"2026-06-01", "gemini-3.1-flash-lite"},
+    "gemini-3-pro-preview" => {"2026-03-09", "gemini-3.1-pro-preview"},
+    "gemini-3.1-flash-lite-preview" => {"2026-05-25", "gemini-3.1-flash-lite"},
+    "gemini-robotics-er-1.5-preview" => {"2026-04-30", "gemini-robotics-er-1.6-preview"}
+  }
+
+  @deprecated_lifecycle %{
+    "gemini-2.5-flash" => {"2026-10-16", "gemini-3.5-flash"},
+    "gemini-2.5-flash-image" => {"2026-10-02", "gemini-3.1-flash-image"},
+    "gemini-2.5-flash-lite" => {"2026-10-16", "gemini-3.1-flash-lite"},
+    "gemini-2.5-pro" => {"2026-10-16", "gemini-3.1-pro-preview"},
+    "gemini-3.1-flash-image-preview" => {"2026-06-25", "gemini-3.1-flash-image"},
+    "gemini-3-pro-image-preview" => {"2026-06-25", "gemini-3-pro-image"},
+    "gemini-3.1-flash-lite" => {"2027-05-07", nil},
+    "gemini-embedding-001" => {"2026-07-14", "gemini-embedding-2"},
+    "imagen-4.0-fast-generate-001" => {"2026-06-24", nil},
+    "imagen-4.0-generate-001" => {"2026-06-24", nil},
+    "imagen-4.0-ultra-generate-001" => {"2026-06-24", nil}
+  }
+
+  test "Google provider metadata points at Gemini API docs and accepted API key env vars" do
+    {provider, _models} = google_provider_and_models()
+
+    assert provider.doc == "https://ai.google.dev/gemini-api/docs"
+    assert provider.env == ["GOOGLE_API_KEY", "GEMINI_API_KEY"]
+  end
+
+  test "local Google overrides codify official Gemini deprecation schedules" do
+    {_provider, models} = google_provider_and_models()
+
+    Enum.each(@retired_lifecycle, fn {model_id, {retires_at, replacement}} ->
+      model = Map.fetch!(models, model_id)
+
+      assert model.lifecycle.status == "retired"
+      assert model.lifecycle.retires_at == retires_at
+      assert model.lifecycle.replacement == replacement
+      assert model.deprecated
+      assert model.retired
+      assert Model.effective_status(model, ~U[2026-06-08 00:00:00Z]) == "retired"
+    end)
+
+    Enum.each(@deprecated_lifecycle, fn {model_id, {retires_at, replacement}} ->
+      model = Map.fetch!(models, model_id)
+
+      assert model.lifecycle.status == "deprecated"
+      assert model.lifecycle.retires_at == retires_at
+      assert Map.get(model.lifecycle, :replacement) == replacement
+      assert model.deprecated
+      refute model.retired
+    end)
+  end
+
+  test "local Google overrides capture docs-only image and embedding metadata" do
+    {_provider, models} = google_provider_and_models()
+
+    flash_image = Map.fetch!(models, "gemini-3.1-flash-image")
+    assert flash_image.limits.context == 131_072
+    assert flash_image.limits.output == 32_768
+    assert flash_image.cost.input == 0.5
+    assert flash_image.cost.output == 3.0
+    assert flash_image.modalities.input == [:text, :image, :pdf]
+    assert flash_image.modalities.output == [:text, :image]
+    assert flash_image.capabilities.reasoning.enabled
+    assert pricing_rate(flash_image, "image.output.4k") == 0.151
+
+    pro_image = Map.fetch!(models, "gemini-3-pro-image")
+    assert pro_image.limits.context == 65_536
+    assert pro_image.limits.output == 32_768
+    assert pro_image.cost.input == 2.0
+    assert pro_image.cost.output == 12.0
+    assert pro_image.capabilities.json.schema
+    assert pricing_rate(pro_image, "image.output.4096x4096") == 0.24
+
+    embedding = Map.fetch!(models, "gemini-embedding-2")
+    assert embedding.limits.context == 8192
+    assert embedding.cost.input == 0.20
+    assert embedding.cost.image == 0.45
+    assert embedding.cost.audio == 6.50
+    assert embedding.cost.input_video == 12.00
+    assert embedding.modalities.input == [:text, :image, :video, :audio, :pdf]
+    assert embedding.modalities.output == [:embedding]
+    assert embedding.capabilities.embeddings.min_dimensions == 128
+    assert embedding.capabilities.embeddings.max_dimensions == 3072
+  end
+
+  defp google_provider_and_models do
+    {:ok, data} = Local.load(%{dir: @local_dir})
+    google = Map.fetch!(data, "google")
+    provider = google |> Map.delete(:models) |> Map.put(:id, :google) |> Provider.new!()
+
+    models =
+      google.models
+      |> Normalize.normalize_models()
+      |> Enum.map(&Model.new!/1)
+      |> Map.new(&{&1.id, &1})
+
+    {provider, models}
+  end
+
+  defp pricing_rate(model, component_id) do
+    model.pricing.components
+    |> Enum.find(&(&1.id == component_id))
+    |> Map.fetch!(:rate)
+  end
+end


### PR DESCRIPTION
## Summary

Provider: `google` | Result: mismatches found and fixed

This PR updates Google/Gemini metadata from official public Google AI documentation and the checked-in Google `models.list` cache. The Google pull task was attempted, but this worktree has no `GOOGLE_API_KEY`/`GEMINI_API_KEY`, so the remote-cache refresh was skipped and docs-backed facts were captured in local overlays.

## Evidence checked on 2026-06-08

- Gemini API models catalog: https://ai.google.dev/gemini-api/docs/models
- Gemini API pricing: https://ai.google.dev/gemini-api/docs/pricing
- Gemini deprecations: https://ai.google.dev/gemini-api/docs/deprecations
- Gemini API release notes: https://ai.google.dev/gemini-api/docs/changelog
- Gemini 3.1 Flash Image model page: https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-image
- Gemini 3 Pro Image model page: https://ai.google.dev/gemini-api/docs/models/gemini-3-pro-image
- Gemini Embedding 2 model page: https://ai.google.dev/gemini-api/docs/models/gemini-embedding-2
- Gemini Robotics-ER 1.6 model page: https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview

## Capture layers

- `remote-cache`: attempted `mix llm_db.pull --source google`; skipped because no API key was available.
- `local-override`: added sparse TOML overlays for lifecycle, provider docs/env hints, GA image model limits/modalities/pricing, Gemini Embedding 2 metadata/pricing, and Imagen 4 per-image pricing.
- `generated-artifact`: rebuilt `priv/llm_db/snapshot.json` with `mix llm_db.build --install`.
- `source-transform`: no Google source transform changes; the mismatches were docs-only facts or stale generated artifact state rather than dropped API fields.

## Notable fixes

- Marks shut-down Google models as retired: Gemini 2.0 Flash/Flash-Lite variants, Gemini 3 Pro Preview, Gemini 3.1 Flash-Lite Preview, and Robotics-ER 1.5 Preview.
- Marks scheduled deprecations for Gemini 2.5, Gemini 3.1 Flash Image Preview, Gemini 3 Pro Image Preview, Gemini Embedding 001, Gemini 3.1 Flash-Lite, and Imagen 4 models.
- Adds docs-backed metadata for `gemini-3.1-flash-image`, `gemini-3-pro-image`, and `gemini-embedding-2`.
- Updates Google provider docs URL to the Gemini API docs and includes `GEMINI_API_KEY` alongside `GOOGLE_API_KEY`.

## Tests

- `mix llm_db.pull --source google` (skipped by task: no API key)
- `mix llm_db.build --install`
- `mix test test/llm_db/google_metadata_test.exs`
- `mix test`
- `mix llm_db.build --check --install`
- Pre-push hook passed: `mix test` and `mix quality`

## Residual uncertainty

- A fresh authenticated Google `models.list` pull was not possible in this worktree. The checked-in cache was used for inventory and API-exposed fields, with official docs used for lifecycle/pricing/model-page fields.
- Some Google pricing is tiered by mode or prompt size; this PR follows the repo's current convention of storing standard token rates in `cost` and adding explicit `pricing.components` for image/audio/video meters where the schema supports them.
