### PR TITLE
fix: update google vertex model metadata

### DIFF
--- a/priv/llm_db/local/google_vertex/claude-3-5-sonnet-v2@20241022.toml
+++ b/priv/llm_db/local/google_vertex/claude-3-5-sonnet-v2@20241022.toml
@@ -1,0 +1,2 @@
+id = "claude-3-5-sonnet-v2@20241022"
+name = "Claude Sonnet 3.5 v2"

--- a/priv/llm_db/local/google_vertex/gemini-2.0-flash-lite.toml
+++ b/priv/llm_db/local/google_vertex/gemini-2.0-flash-lite.toml
@@ -1,0 +1,7 @@
+id = "gemini-2.0-flash-lite"
+release_date = "2025-02-25"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-06-01"
+replacement = "gemini-3.1-flash-lite"

--- a/priv/llm_db/local/google_vertex/gemini-2.0-flash.toml
+++ b/priv/llm_db/local/google_vertex/gemini-2.0-flash.toml
@@ -1,0 +1,7 @@
+id = "gemini-2.0-flash"
+release_date = "2025-02-05"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-06-01"
+replacement = "gemini-3.1-flash-lite"

--- a/priv/llm_db/local/google_vertex/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/priv/llm_db/local/google_vertex/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -1,0 +1,26 @@
+id = "gemini-2.5-flash-lite-preview-09-2025"
+name = "Gemini 2.5 Flash-Lite Preview 09-2025"
+release_date = "2025-09-25"
+knowledge = "2025-01"
+
+[limits]
+context = 1048576
+output = 65535
+
+[modalities]
+input = ["text", "code", "image", "audio", "video"]
+output = ["text"]
+
+[capabilities.reasoning]
+enabled = true
+
+[capabilities.tools]
+enabled = true
+
+[capabilities.streaming]
+tool_calls = true
+
+[lifecycle]
+status = "active"
+retires_at = "2026-07-09"
+replacement = "gemini-2.5-flash-lite"

--- a/priv/llm_db/local/google_vertex/gemini-2.5-flash-lite.toml
+++ b/priv/llm_db/local/google_vertex/gemini-2.5-flash-lite.toml
@@ -1,0 +1,2 @@
+id = "gemini-2.5-flash-lite"
+release_date = "2025-07-22"

--- a/priv/llm_db/local/google_vertex/gemini-2.5-flash-preview-09-2025.toml
+++ b/priv/llm_db/local/google_vertex/gemini-2.5-flash-preview-09-2025.toml
@@ -1,0 +1,6 @@
+id = "gemini-2.5-flash-preview-09-2025"
+
+[lifecycle]
+status = "active"
+retires_at = "2026-07-09"
+replacement = "gemini-2.5-flash"

--- a/priv/llm_db/local/google_vertex/gemini-2.5-pro.toml
+++ b/priv/llm_db/local/google_vertex/gemini-2.5-pro.toml
@@ -1,0 +1,2 @@
+id = "gemini-2.5-pro"
+release_date = "2025-06-17"

--- a/priv/llm_db/local/google_vertex/gemini-3.1-flash-lite-preview.toml
+++ b/priv/llm_db/local/google_vertex/gemini-3.1-flash-lite-preview.toml
@@ -1,7 +1,6 @@
 id = "gemini-3.1-flash-lite-preview"
 
 [lifecycle]
-status = "deprecated"
-deprecated_at = "2026-05-12"
-retires_at = "2026-05-25"
+status = "active"
+retires_at = "2026-07-09"
 replacement = "gemini-3.1-flash-lite"

--- a/priv/llm_db/local/google_vertex/gemini-embedding-001.toml
+++ b/priv/llm_db/local/google_vertex/gemini-embedding-001.toml
@@ -1,0 +1,5 @@
+id = "gemini-embedding-001"
+
+[lifecycle]
+status = "active"
+retires_at = "2026-07-14"

--- a/priv/llm_db/local/google_vertex/provider.toml
+++ b/priv/llm_db/local/google_vertex/provider.toml
@@ -6,6 +6,10 @@ doc = "https://cloud.google.com/vertex-ai/docs"
 
 env = ["GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT"]
 
+exclude_models = [
+  "claude-3-5-sonnet@20241022",
+]
+
 # Runtime configuration schema
 [[config_schema]]
 name = "service_account_json"


### PR DESCRIPTION
Provider: `google_vertex` | Result: mismatches found and fixed

Sources checked on 2026-06-08:
- Google model versions and lifecycle: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/model-versions
- Gemini 2.0 Flash: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/2-0-flash
- Gemini 2.0 Flash-Lite: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/2-0-flash-lite
- Gemini 2.5 Pro: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/2-5-pro
- Gemini 2.5 Flash: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/2-5-flash
- Gemini 2.5 Flash-Lite: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/2-5-flash-lite
- Gemini 3.1 Flash-Lite: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-flash-lite
- Claude on Vertex request docs: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude

Summary:
- Checked: 41 generated `google_vertex` model records after rebuild, with focused comparison on documented Vertex Gemini lifecycle/model pages and the Claude Vertex usage page.
- Fixed: 9 model-level mismatches plus one provider-level exclusion.
- API refresh: not run. No Google/Gemini/Vertex credentials were set in this worktree, and this repo does not expose a `google_vertex` pull source. Existing aggregate cache plus official docs were used.

Findings and capture layers:
- P1 `gemini-2.0-flash` and `gemini-2.0-flash-lite`: local metadata had active lifecycle and older release dates, but Google documents both as discontinued on 2026-06-01 with 2025-02-05 / 2025-02-25 release dates. Capture layer: `local-override` in `priv/llm_db/local/google_vertex/*.toml`; generated snapshot rebuilt.
- P1 `claude-3-5-sonnet@20241022`: Google's Claude Vertex docs use `claude-3-5-sonnet-v2@20241022` for Sonnet 3.5 v2 examples. Capture layer: `local-override`; excluded the contradicted aggregate ID in `provider.toml` and added `claude-3-5-sonnet-v2@20241022.toml`.
- P1 `gemini-3.1-flash-lite-preview`: local override marked it deprecated/retired in May 2026, but Google's current page says it discontinues on 2026-07-09. Capture layer: `local-override`; corrected lifecycle to active with `retires_at = "2026-07-09"`.
- P2 `gemini-2.5-flash-preview-09-2025` and `gemini-2.5-flash-lite-preview-09-2025`: Google documents 2026-07-09 discontinuation. The Flash-Lite preview was absent from the aggregate cache, so the local override captures only documented identity, limits, modalities, release date, knowledge cutoff, and lifecycle. Capture layer: `local-override`.
- P3 `gemini-2.5-pro` and `gemini-2.5-flash-lite`: release dates corrected to Google's documented GA dates. Capture layer: `local-override`.
- P3 `gemini-embedding-001`: lifecycle page documents retirement date 2026-07-14. Capture layer: `local-override`.
- Generated artifact: `priv/llm_db/snapshot.json` rebuilt with `mix llm_db.build --install`.

Verification:
- `mix format --check-formatted`: passed.
- `mix llm_db.build --check --install`: passed.
- `mix test`: 41 doctests, 700 tests, 0 failures.
- Pre-push hook reran `mix test` and `mix quality`: passed.

Residual uncertainty:
- Current Google Claude detail pages show newer suffixless Claude model IDs, while usage examples still show a dated Sonnet 3.5 v2 ID. This PR fixes only the clearly contradicted Sonnet 3.5 v2 ID and leaves broader Claude suffix/version migration for a dedicated `google_vertex_anthropic` or partner-model audit.
- Current Google pricing docs did not expose a current Sonnet 3.5 v2 Vertex pricing row, so the new local Sonnet v2 override intentionally does not invent pricing, limits, or modality fields.
