### PR TITLE
fix: update azure model metadata

### DIFF
--- a/priv/llm_db/local/azure/cohere_cohere-command-r-08-2024.toml
+++ b/priv/llm_db/local/azure/cohere_cohere-command-r-08-2024.toml
@@ -1,0 +1,5 @@
+id = "cohere-command-r-08-2024"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-12"

--- a/priv/llm_db/local/azure/cohere_cohere-command-r-plus-08-2024.toml
+++ b/priv/llm_db/local/azure/cohere_cohere-command-r-plus-08-2024.toml
@@ -1,0 +1,5 @@
+id = "cohere-command-r-plus-08-2024"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-12"

--- a/priv/llm_db/local/azure/cohere_cohere-embed-v-4-0.toml
+++ b/priv/llm_db/local/azure/cohere_cohere-embed-v-4-0.toml
@@ -1,5 +1,8 @@
 id = "cohere-embed-v-4-0"
 
+[capabilities]
+chat = false
+
 [capabilities.embeddings]
 min_dimensions = 256
 max_dimensions = 1536
@@ -7,7 +10,7 @@ default_dimensions = 1536
 
 [modalities]
 input = ["text", "image"]
-output = ["text", "embedding"]
+output = ["embedding"]
 
 [extra]
 type = "embedding"

--- a/priv/llm_db/local/azure/cohere_cohere-embed-v3-english.toml
+++ b/priv/llm_db/local/azure/cohere_cohere-embed-v3-english.toml
@@ -1,5 +1,8 @@
 id = "cohere-embed-v3-english"
 
+[capabilities]
+chat = false
+
 [capabilities.embeddings]
 min_dimensions = 1024
 max_dimensions = 1024
@@ -7,7 +10,7 @@ default_dimensions = 1024
 
 [modalities]
 input = ["text"]
-output = ["text", "embedding"]
+output = ["embedding"]
 
 [extra]
 type = "embedding"

--- a/priv/llm_db/local/azure/cohere_cohere-embed-v3-multilingual.toml
+++ b/priv/llm_db/local/azure/cohere_cohere-embed-v3-multilingual.toml
@@ -1,5 +1,8 @@
 id = "cohere-embed-v3-multilingual"
 
+[capabilities]
+chat = false
+
 [capabilities.embeddings]
 min_dimensions = 1024
 max_dimensions = 1024
@@ -7,7 +10,7 @@ default_dimensions = 1024
 
 [modalities]
 input = ["text"]
-output = ["text", "embedding"]
+output = ["embedding"]
 
 [extra]
 type = "embedding"

--- a/priv/llm_db/local/azure/meta_llama-3.2-11b-vision-instruct.toml
+++ b/priv/llm_db/local/azure/meta_llama-3.2-11b-vision-instruct.toml
@@ -1,0 +1,5 @@
+id = "llama-3.2-11b-vision-instruct"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-06-13"

--- a/priv/llm_db/local/azure/meta_llama-3.2-90b-vision-instruct.toml
+++ b/priv/llm_db/local/azure/meta_llama-3.2-90b-vision-instruct.toml
@@ -1,0 +1,5 @@
+id = "llama-3.2-90b-vision-instruct"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-06-13"

--- a/priv/llm_db/local/azure/meta_meta-llama-3-70b-instruct.toml
+++ b/priv/llm_db/local/azure/meta_meta-llama-3-70b-instruct.toml
@@ -1,0 +1,6 @@
+id = "meta-llama-3-70b-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-06-30"
+replacement = "llama-3.3-70b-instruct"

--- a/priv/llm_db/local/azure/meta_meta-llama-3-8b-instruct.toml
+++ b/priv/llm_db/local/azure/meta_meta-llama-3-8b-instruct.toml
@@ -1,0 +1,6 @@
+id = "meta-llama-3-8b-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-06-30"
+replacement = "meta-llama-3.1-8b-instruct"

--- a/priv/llm_db/local/azure/meta_meta-llama-3.1-405b-instruct.toml
+++ b/priv/llm_db/local/azure/meta_meta-llama-3.1-405b-instruct.toml
@@ -1,0 +1,5 @@
+id = "meta-llama-3.1-405b-instruct"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-06-13"

--- a/priv/llm_db/local/azure/meta_meta-llama-3.1-70b-instruct.toml
+++ b/priv/llm_db/local/azure/meta_meta-llama-3.1-70b-instruct.toml
@@ -1,0 +1,6 @@
+id = "meta-llama-3.1-70b-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-06-30"
+replacement = "llama-3.3-70b-instruct"

--- a/priv/llm_db/local/azure/meta_meta-llama-3.1-8b-instruct.toml
+++ b/priv/llm_db/local/azure/meta_meta-llama-3.1-8b-instruct.toml
@@ -1,0 +1,5 @@
+id = "meta-llama-3.1-8b-instruct"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-06-13"

--- a/priv/llm_db/local/azure/microsoft_mai-ds-r1.toml
+++ b/priv/llm_db/local/azure/microsoft_mai-ds-r1.toml
@@ -1,0 +1,6 @@
+id = "mai-ds-r1"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-02-27"
+replacement = "Any DeepSeek model available in the Model catalog"

--- a/priv/llm_db/local/azure/microsoft_phi-3-medium-128k-instruct.toml
+++ b/priv/llm_db/local/azure/microsoft_phi-3-medium-128k-instruct.toml
@@ -1,0 +1,6 @@
+id = "phi-3-medium-128k-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-08-30"
+replacement = "phi-4"

--- a/priv/llm_db/local/azure/microsoft_phi-3-medium-4k-instruct.toml
+++ b/priv/llm_db/local/azure/microsoft_phi-3-medium-4k-instruct.toml
@@ -1,0 +1,6 @@
+id = "phi-3-medium-4k-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-08-30"
+replacement = "phi-4"

--- a/priv/llm_db/local/azure/microsoft_phi-3-mini-128k-instruct.toml
+++ b/priv/llm_db/local/azure/microsoft_phi-3-mini-128k-instruct.toml
@@ -1,0 +1,6 @@
+id = "phi-3-mini-128k-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-08-30"
+replacement = "phi-4-mini"

--- a/priv/llm_db/local/azure/microsoft_phi-3-mini-4k-instruct.toml
+++ b/priv/llm_db/local/azure/microsoft_phi-3-mini-4k-instruct.toml
@@ -1,0 +1,6 @@
+id = "phi-3-mini-4k-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-08-30"
+replacement = "phi-4-mini"

--- a/priv/llm_db/local/azure/microsoft_phi-3-small-128k-instruct.toml
+++ b/priv/llm_db/local/azure/microsoft_phi-3-small-128k-instruct.toml
@@ -1,0 +1,6 @@
+id = "phi-3-small-128k-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-08-30"
+replacement = "phi-4-mini"

--- a/priv/llm_db/local/azure/microsoft_phi-3-small-8k-instruct.toml
+++ b/priv/llm_db/local/azure/microsoft_phi-3-small-8k-instruct.toml
@@ -1,0 +1,6 @@
+id = "phi-3-small-8k-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-08-30"
+replacement = "phi-4-mini"

--- a/priv/llm_db/local/azure/microsoft_phi-3.5-mini-instruct.toml
+++ b/priv/llm_db/local/azure/microsoft_phi-3.5-mini-instruct.toml
@@ -1,0 +1,6 @@
+id = "phi-3.5-mini-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-08-30"
+replacement = "phi-4-mini"

--- a/priv/llm_db/local/azure/microsoft_phi-3.5-moe-instruct.toml
+++ b/priv/llm_db/local/azure/microsoft_phi-3.5-moe-instruct.toml
@@ -1,0 +1,6 @@
+id = "phi-3.5-moe-instruct"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-08-30"
+replacement = "phi-4-mini"

--- a/priv/llm_db/local/azure/mistral_mistral-large-2411.toml
+++ b/priv/llm_db/local/azure/mistral_mistral-large-2411.toml
@@ -1,0 +1,6 @@
+id = "mistral-large-2411"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-01-30"
+replacement = "mistral-medium-2505"

--- a/priv/llm_db/local/azure/mistral_mistral-nemo.toml
+++ b/priv/llm_db/local/azure/mistral_mistral-nemo.toml
@@ -1,0 +1,6 @@
+id = "mistral-nemo"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-01-30"
+replacement = "mistral-small-2503"

--- a/priv/llm_db/local/azure/moonshotai_kimi-k2-thinking.toml
+++ b/priv/llm_db/local/azure/moonshotai_kimi-k2-thinking.toml
@@ -1,0 +1,6 @@
+id = "kimi-k2-thinking"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-03-29"
+replacement = "kimi-k2.5"

--- a/priv/llm_db/local/azure/openai_o1-preview.toml
+++ b/priv/llm_db/local/azure/openai_o1-preview.toml
@@ -1,0 +1,6 @@
+id = "o1-preview"
+
+[lifecycle]
+status = "retired"
+retires_at = "2025-07-28"
+replacement = "o1"

--- a/priv/llm_db/local/azure/openai_o1.toml
+++ b/priv/llm_db/local/azure/openai_o1.toml
@@ -1,0 +1,5 @@
+id = "o1"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-07-15"

--- a/priv/llm_db/local/azure/openai_o3-mini.toml
+++ b/priv/llm_db/local/azure/openai_o3-mini.toml
@@ -1,0 +1,6 @@
+id = "o3-mini"
+
+[lifecycle]
+status = "deprecated"
+retires_at = "2026-08-02"
+replacement = "o4-mini"

--- a/priv/llm_db/local/azure/openai_text-embedding-3-large.toml
+++ b/priv/llm_db/local/azure/openai_text-embedding-3-large.toml
@@ -1,5 +1,8 @@
 id = "text-embedding-3-large"
 
+[capabilities]
+chat = false
+
 [capabilities.embeddings]
 min_dimensions = 1
 max_dimensions = 3072
@@ -7,7 +10,7 @@ default_dimensions = 3072
 
 [modalities]
 input = ["text"]
-output = ["text", "embedding"]
+output = ["embedding"]
 
 [extra]
 type = "embedding"

--- a/priv/llm_db/local/azure/openai_text-embedding-3-small.toml
+++ b/priv/llm_db/local/azure/openai_text-embedding-3-small.toml
@@ -1,5 +1,8 @@
 id = "text-embedding-3-small"
 
+[capabilities]
+chat = false
+
 [capabilities.embeddings]
 min_dimensions = 1
 max_dimensions = 1536
@@ -7,7 +10,7 @@ default_dimensions = 1536
 
 [modalities]
 input = ["text"]
-output = ["text", "embedding"]
+output = ["embedding"]
 
 [extra]
 type = "embedding"

--- a/priv/llm_db/local/azure/openai_text-embedding-ada-002.toml
+++ b/priv/llm_db/local/azure/openai_text-embedding-ada-002.toml
@@ -1,5 +1,8 @@
 id = "text-embedding-ada-002"
 
+[capabilities]
+chat = false
+
 [capabilities.embeddings]
 min_dimensions = 1536
 max_dimensions = 1536
@@ -7,7 +10,7 @@ default_dimensions = 1536
 
 [modalities]
 input = ["text"]
-output = ["text", "embedding"]
+output = ["embedding"]
 
 [extra]
 type = "embedding"

--- a/priv/llm_db/local/azure/xai_grok-4-fast-reasoning.toml
+++ b/priv/llm_db/local/azure/xai_grok-4-fast-reasoning.toml
@@ -1,0 +1,6 @@
+id = "grok-4-fast-reasoning"
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-01"
+replacement = "grok-4-1-fast-reasoning"

--- a/test/llm_db/sources_test.exs
+++ b/test/llm_db/sources_test.exs
@@ -222,6 +222,76 @@ defmodule LLMDB.SourcesTest do
     end
   end
 
+  describe "Azure embedding overlays" do
+    test "embedding models are not chat-capable" do
+      {:ok, data} = Local.load(%{dir: "priv/llm_db/local"})
+
+      models_by_id = Map.new(data["azure"].models, &{&1.id, &1})
+
+      expected_ids = ~w[
+        cohere-embed-v-4-0
+        cohere-embed-v3-english
+        cohere-embed-v3-multilingual
+        text-embedding-3-large
+        text-embedding-3-small
+        text-embedding-ada-002
+      ]
+
+      Enum.each(expected_ids, fn id ->
+        model = models_by_id[id]
+        assert model, "Azure overlay for #{id} should be present"
+
+        assert model.capabilities.chat == false
+        assert model.modalities.output == ["embedding"]
+        assert is_map(model.capabilities.embeddings)
+      end)
+    end
+  end
+
+  describe "Azure lifecycle overlays" do
+    test "retirement schedule entries are captured for exact model IDs" do
+      {:ok, data} = Local.load(%{dir: "priv/llm_db/local"})
+
+      models_by_id = Map.new(data["azure"].models, &{&1.id, &1})
+
+      expected = %{
+        "cohere-command-r-08-2024" => {"retired", "2026-05-12"},
+        "cohere-command-r-plus-08-2024" => {"retired", "2026-05-12"},
+        "grok-4-fast-reasoning" => {"retired", "2026-05-01"},
+        "kimi-k2-thinking" => {"retired", "2026-03-29"},
+        "llama-3.2-11b-vision-instruct" => {"deprecated", "2026-06-13"},
+        "llama-3.2-90b-vision-instruct" => {"deprecated", "2026-06-13"},
+        "mai-ds-r1" => {"retired", "2026-02-27"},
+        "meta-llama-3-70b-instruct" => {"retired", "2025-06-30"},
+        "meta-llama-3-8b-instruct" => {"retired", "2025-06-30"},
+        "meta-llama-3.1-405b-instruct" => {"deprecated", "2026-06-13"},
+        "meta-llama-3.1-70b-instruct" => {"retired", "2025-06-30"},
+        "meta-llama-3.1-8b-instruct" => {"deprecated", "2026-06-13"},
+        "mistral-large-2411" => {"retired", "2026-01-30"},
+        "mistral-nemo" => {"retired", "2026-01-30"},
+        "o1" => {"deprecated", "2026-07-15"},
+        "o1-preview" => {"retired", "2025-07-28"},
+        "o3-mini" => {"deprecated", "2026-08-02"},
+        "phi-3-medium-128k-instruct" => {"retired", "2025-08-30"},
+        "phi-3-medium-4k-instruct" => {"retired", "2025-08-30"},
+        "phi-3-mini-128k-instruct" => {"retired", "2025-08-30"},
+        "phi-3-mini-4k-instruct" => {"retired", "2025-08-30"},
+        "phi-3-small-128k-instruct" => {"retired", "2025-08-30"},
+        "phi-3-small-8k-instruct" => {"retired", "2025-08-30"},
+        "phi-3.5-mini-instruct" => {"retired", "2025-08-30"},
+        "phi-3.5-moe-instruct" => {"retired", "2025-08-30"}
+      }
+
+      Enum.each(expected, fn {id, {status, retires_at}} ->
+        model = models_by_id[id]
+        assert model, "Azure lifecycle overlay for #{id} should be present"
+
+        assert model.lifecycle.status == status
+        assert model.lifecycle.retires_at == retires_at
+      end)
+    end
+  end
+
   describe "Source behavior contract" do
     test "all sources return {:ok, data} format with nested structure" do
       # Config


### PR DESCRIPTION
Provider: azure | Result: mismatches found

Sources checked on 2026-06-08:
- Microsoft Foundry Models sold by Azure: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure
- Model retirement schedule: https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/model-retirement-schedule
- Retired Foundry Models: https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/retired-models
- Microsoft Foundry endpoints: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints
- Cohere Embed API and model docs: https://docs.cohere.com/v2/reference/embed and https://docs.cohere.com/v2/docs/models/
- Existing public Azure Foundry cache: `priv/llm_db/remote/azure-foundry.json`, from `https://ai.azure.com/api/eastus/ux/v1.0/entities/crossRegion`, downloaded 2026-05-27
- Existing models.dev cache: `priv/llm_db/upstream/models-dev-ea9de843.json`, from `https://models.dev/api.json`, downloaded 2026-05-28

Summary:
- Checked: 103 Azure snapshot model IDs plus provider/source/cache docs
- Fixed: 6 Azure embedding capability overlays and 25 exact-ID lifecycle overlays
- Unverified/skipped: lifecycle stages not represented by the current schema (`GA`, `Preview`, `Legacy`) and ambiguous Azure naming/version mappings

Findings and capture layers:
- P1 lifecycle metadata was missing for Azure models that Microsoft lists as `Deprecated` or `Retired`. Capture layer: `local-override`; added sparse TOML lifecycle overlays under `priv/llm_db/local/azure/` and rebuilt the snapshot.
- P2 Azure embedding models were still locally marked chat-capable by schema defaults. Microsoft says Azure OpenAI embedding models are only for Embedding API requests, and Cohere docs describe Embed models as returning embeddings. Capture layer: `local-override`; set `capabilities.chat = false` and embedding-only local output modality for Azure OpenAI/Cohere embedding overlays.
- Remote cache refresh was attempted with `mix llm_db.pull --source azure_foundry`, but Microsoft returned HTTP 429. Capture layer: `remote-cache`; no hand edits were made to remote cache files.

Changes:
- Added 25 sparse Azure lifecycle TOML overlays for exact model IDs in the official retirement schedule.
- Updated 6 Azure embedding TOML overlays to opt out of chat capability.
- Rebuilt `priv/llm_db/snapshot.json` with `mix llm_db.build --install`.
- Added focused source tests for Azure embedding and lifecycle overlays.

Verification:
- `mix test test/llm_db/sources_test.exs`: 19 tests, 0 failures
- `mix test test/llm_db/enrich/azure_wire_protocol_test.exs`: 1 test, 0 failures
- `mix test`: 41 doctests, 702 tests, 0 failures
- `mix llm_db.build --check --install`: passed
- Pre-push hook: `mix test` and `mix quality` passed

Residual uncertainty:
- The generated snapshot still includes upstream `modalities.output = ["text", "embedding"]` for embedding models because the engine unions modality lists. This PR corrects the local Azure source layer but does not make a cross-provider merge/enrichment change in an isolated Azure run.
- Azure docs use some model names that do not exactly match repo IDs, for example `gpt-35-*` vs `gpt-3.5-*`, so those were left unchanged without exact-ID public evidence.
- `Legacy`, `Preview`, and `GA` lifecycle stages are documented by Microsoft but not expressible in the current three-state lifecycle schema, so they were not captured here.