### PR TITLE
fix: update Amazon Bedrock metadata

### DIFF
--- a/priv/llm_db/local/amazon_bedrock/ai21_jamba-1-5-large-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/ai21_jamba-1-5-large-v1_0.toml
@@ -1,0 +1,20 @@
+id = "ai21.jamba-1-5-large-v1:0"
+provider = "amazon_bedrock"
+name = "Jamba 1.5 Large"
+family = "jamba"
+provider_model_id = "ai21.jamba-1-5-large-v1:0"
+release_date = "2024-08-22"
+last_updated = "2024-08-22"
+knowledge = "2024-03"
+
+[limits]
+context = 256000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "active"
+eol_date = "No sooner than 9/23/2025"

--- a/priv/llm_db/local/amazon_bedrock/ai21_jamba-1-5-mini-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/ai21_jamba-1-5-mini-v1_0.toml
@@ -1,0 +1,20 @@
+id = "ai21.jamba-1-5-mini-v1:0"
+provider = "amazon_bedrock"
+name = "Jamba 1.5 Mini"
+family = "jamba"
+provider_model_id = "ai21.jamba-1-5-mini-v1:0"
+release_date = "2024-08-22"
+last_updated = "2024-08-22"
+knowledge = "2024-03"
+
+[limits]
+context = 256000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "active"
+eol_date = "No sooner than 9/23/2025"

--- a/priv/llm_db/local/amazon_bedrock/amazon_nova-premier-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/amazon_nova-premier-v1_0.toml
@@ -1,0 +1,27 @@
+id = "amazon.nova-premier-v1:0"
+provider = "amazon_bedrock"
+name = "Nova Premier"
+family = "nova"
+provider_model_id = "amazon.nova-premier-v1:0"
+release_date = "2025-10-31"
+last_updated = "2025-10-31"
+knowledge = "2024-10"
+
+aliases = [
+  "us.amazon.nova-premier-v1:0"
+]
+
+[limits]
+context = 1000000
+output = 25000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+
+[capabilities.reasoning]
+enabled = true
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-09-14"

--- a/priv/llm_db/local/amazon_bedrock/anthropic_claude-3-5-haiku-20241022-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/anthropic_claude-3-5-haiku-20241022-v1_0.toml
@@ -1,0 +1,24 @@
+id = "anthropic.claude-3-5-haiku-20241022-v1:0"
+provider = "amazon_bedrock"
+name = "Claude 3.5 Haiku"
+family = "claude"
+provider_model_id = "anthropic.claude-3-5-haiku-20241022-v1:0"
+release_date = "2024-11-04"
+last_updated = "2024-11-04"
+knowledge = "2024-07"
+
+aliases = [
+  "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+]
+
+[limits]
+context = 200000
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-06-19"

--- a/priv/llm_db/local/amazon_bedrock/anthropic_claude-3-haiku-20240307-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/anthropic_claude-3-haiku-20240307-v1_0.toml
@@ -1,0 +1,25 @@
+id = "anthropic.claude-3-haiku-20240307-v1:0"
+provider = "amazon_bedrock"
+name = "Claude 3 Haiku"
+family = "claude"
+provider_model_id = "anthropic.claude-3-haiku-20240307-v1:0"
+release_date = "2024-03-13"
+last_updated = "2024-03-13"
+knowledge = "2024-02"
+
+aliases = [
+  "us.anthropic.claude-3-haiku-20240307-v1:0",
+  "eu.anthropic.claude-3-haiku-20240307-v1:0"
+]
+
+[limits]
+context = 200000
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-09-10"

--- a/priv/llm_db/local/amazon_bedrock/anthropic_claude-opus-4-1.toml
+++ b/priv/llm_db/local/amazon_bedrock/anthropic_claude-opus-4-1.toml
@@ -4,17 +4,11 @@ name = "Claude Opus 4.1"
 family = "claude"
 release_date = "2025-08-05"
 
-# Bedrock requires inference profile prefix for API calls
-# Note: Opus 4.1 only available with us. prefix, not global.
+# Bedrock documents only the US geo inference profile for Opus 4.1.
 provider_model_id = "us.anthropic.claude-opus-4-1-20250805-v1:0"
 
-# Inference profile aliases - allow routing across AWS regions
 aliases = [
-  "us.anthropic.claude-opus-4-1-20250805-v1:0",
-  "eu.anthropic.claude-opus-4-1-20250805-v1:0",
-  "ap.anthropic.claude-opus-4-1-20250805-v1:0",
-  "ca.anthropic.claude-opus-4-1-20250805-v1:0",
-  "global.anthropic.claude-opus-4-1-20250805-v1:0"
+  "us.anthropic.claude-opus-4-1-20250805-v1:0"
 ]
 
 # Override: Disable object generation hack - wait for native Anthropic support

--- a/priv/llm_db/local/amazon_bedrock/anthropic_claude-sonnet-4-20250514-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/anthropic_claude-sonnet-4-20250514-v1_0.toml
@@ -1,0 +1,30 @@
+id = "anthropic.claude-sonnet-4-20250514-v1:0"
+provider = "amazon_bedrock"
+name = "Claude Sonnet 4"
+family = "claude"
+provider_model_id = "anthropic.claude-sonnet-4-20250514-v1:0"
+release_date = "2025-05-23"
+last_updated = "2025-05-23"
+knowledge = "2025-03"
+
+aliases = [
+  "us.anthropic.claude-sonnet-4-20250514-v1:0",
+  "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+  "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+  "global.anthropic.claude-sonnet-4-20250514-v1:0"
+]
+
+[limits]
+context = 200000
+output = 64000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[capabilities.reasoning]
+enabled = true
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-10-14"

--- a/priv/llm_db/local/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0.toml
@@ -8,8 +8,8 @@ provider_model_id = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
 aliases = [
   "us.anthropic.claude-haiku-4-5-20251001-v1:0",
   "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
-  "ap.anthropic.claude-haiku-4-5-20251001-v1:0",
-  "ca.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "au.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
   "global.anthropic.claude-haiku-4-5-20251001-v1:0"
 ]
 

--- a/priv/llm_db/local/amazon_bedrock/anthropic_claude_sonnet_4_5_20250929_v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/anthropic_claude_sonnet_4_5_20250929_v1_0.toml
@@ -8,8 +8,8 @@ provider_model_id = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
 aliases = [
   "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
   "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
-  "ap.anthropic.claude-sonnet-4-5-20250929-v1:0",
-  "ca.anthropic.claude-sonnet-4-5-20250929-v1:0",
+  "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+  "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
   "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
 ]
 

--- a/priv/llm_db/local/amazon_bedrock/cohere_command-r-plus-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/cohere_command-r-plus-v1_0.toml
@@ -1,0 +1,20 @@
+id = "cohere.command-r-plus-v1:0"
+provider = "amazon_bedrock"
+name = "Command R+"
+family = "command-r"
+provider_model_id = "cohere.command-r-plus-v1:0"
+release_date = "2024-08"
+last_updated = "2024-08"
+knowledge = "2024-03"
+
+[limits]
+context = 128000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-08-19"

--- a/priv/llm_db/local/amazon_bedrock/cohere_command-r-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/cohere_command-r-v1_0.toml
@@ -1,0 +1,20 @@
+id = "cohere.command-r-v1:0"
+provider = "amazon_bedrock"
+name = "Command R"
+family = "command-r"
+provider_model_id = "cohere.command-r-v1:0"
+release_date = "2024-08"
+last_updated = "2024-08"
+knowledge = "2024-03"
+
+[limits]
+context = 128000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-08-19"

--- a/priv/llm_db/local/amazon_bedrock/meta_llama-3-3-70b.toml
+++ b/priv/llm_db/local/amazon_bedrock/meta_llama-3-3-70b.toml
@@ -9,16 +9,12 @@ provider_model_id = "us.meta.llama3-3-70b-instruct-v1:0"
 
 # Inference profile aliases
 aliases = [
-  "us.meta.llama3-3-70b-instruct-v1:0",
-  "eu.meta.llama3-3-70b-instruct-v1:0",
-  "ap.meta.llama3-3-70b-instruct-v1:0",
-  "ca.meta.llama3-3-70b-instruct-v1:0",
-  "global.meta.llama3-3-70b-instruct-v1:0"
+  "us.meta.llama3-3-70b-instruct-v1:0"
 ]
 
 [limits]
 context = 128000
-output = 2048
+output = 4096
 
 [cost]
 input = 0.265
@@ -50,6 +46,8 @@ tool_calls = false  # Can't stream tool calls
 
 [extra]
 requires_converse = true
+aws_lifecycle = "active"
+eol_date = "No sooner than 12/19/2025"
 # Known issues documented in extra field
 known_limitations = [
   "Tools not supported in streaming mode",

--- a/priv/llm_db/local/amazon_bedrock/meta_llama3-2-11b-instruct-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/meta_llama3-2-11b-instruct-v1_0.toml
@@ -1,0 +1,24 @@
+id = "meta.llama3-2-11b-instruct-v1:0"
+provider = "amazon_bedrock"
+name = "Llama 3.2 11B Instruct"
+family = "llama"
+provider_model_id = "meta.llama3-2-11b-instruct-v1:0"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+knowledge = "2023-12"
+
+aliases = [
+  "us.meta.llama3-2-11b-instruct-v1:0"
+]
+
+[limits]
+context = 128000
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-07-07"

--- a/priv/llm_db/local/amazon_bedrock/meta_llama3-2-1b-instruct-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/meta_llama3-2-1b-instruct-v1_0.toml
@@ -1,0 +1,25 @@
+id = "meta.llama3-2-1b-instruct-v1:0"
+provider = "amazon_bedrock"
+name = "Llama 3.2 1B Instruct"
+family = "llama"
+provider_model_id = "meta.llama3-2-1b-instruct-v1:0"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+knowledge = "2023-12"
+
+aliases = [
+  "us.meta.llama3-2-1b-instruct-v1:0",
+  "eu.meta.llama3-2-1b-instruct-v1:0"
+]
+
+[limits]
+context = 128000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-07-07"

--- a/priv/llm_db/local/amazon_bedrock/meta_llama3-2-90b-instruct-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/meta_llama3-2-90b-instruct-v1_0.toml
@@ -1,0 +1,24 @@
+id = "meta.llama3-2-90b-instruct-v1:0"
+provider = "amazon_bedrock"
+name = "Llama 3.2 90B Instruct"
+family = "llama"
+provider_model_id = "meta.llama3-2-90b-instruct-v1:0"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+knowledge = "2023-12"
+
+aliases = [
+  "us.meta.llama3-2-90b-instruct-v1:0"
+]
+
+[limits]
+context = 128000
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-07-07"

--- a/priv/llm_db/local/amazon_bedrock/meta_llama3-70b-instruct-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/meta_llama3-70b-instruct-v1_0.toml
@@ -1,0 +1,20 @@
+id = "meta.llama3-70b-instruct-v1:0"
+provider = "amazon_bedrock"
+name = "Llama 3 70B Instruct"
+family = "llama"
+provider_model_id = "meta.llama3-70b-instruct-v1:0"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+knowledge = "2023-12"
+
+[limits]
+context = 8192
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "active"
+eol_date = "No sooner than 4/23/2025"

--- a/priv/llm_db/local/amazon_bedrock/meta_llama3-8b-instruct-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/meta_llama3-8b-instruct-v1_0.toml
@@ -1,0 +1,20 @@
+id = "meta.llama3-8b-instruct-v1:0"
+provider = "amazon_bedrock"
+name = "Llama 3 8B Instruct"
+family = "llama"
+provider_model_id = "meta.llama3-8b-instruct-v1:0"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+knowledge = "2023-12"
+
+[limits]
+context = 8192
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "active"
+eol_date = "No sooner than 4/23/2025"

--- a/priv/llm_db/local/amazon_bedrock/meta_llama3_2_3b_instruct_v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/meta_llama3_2_3b_instruct_v1_0.toml
@@ -1,14 +1,26 @@
 id = "meta.llama3-2-3b-instruct-v1:0"
 name = "Llama 3.2 3B Instruct"
+provider = "amazon_bedrock"
+family = "llama"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+knowledge = "2023-12"
 
-# Bedrock requires inference profile prefix for API calls
-provider_model_id = "global.meta.llama3-2-3b-instruct-v1:0"
+provider_model_id = "meta.llama3-2-3b-instruct-v1:0"
 
-# Inference profile aliases - allow routing across AWS regions
 aliases = [
   "us.meta.llama3-2-3b-instruct-v1:0",
-  "eu.meta.llama3-2-3b-instruct-v1:0",
-  "ap.meta.llama3-2-3b-instruct-v1:0",
-  "ca.meta.llama3-2-3b-instruct-v1:0",
-  "global.meta.llama3-2-3b-instruct-v1:0"
+  "eu.meta.llama3-2-3b-instruct-v1:0"
 ]
+
+[limits]
+context = 128000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "legacy"
+eol_date = "2026-07-07"

--- a/priv/llm_db/local/amazon_bedrock/mistral_mistral-7b-instruct-v0_2.toml
+++ b/priv/llm_db/local/amazon_bedrock/mistral_mistral-7b-instruct-v0_2.toml
@@ -1,0 +1,19 @@
+id = "mistral.mistral-7b-instruct-v0:2"
+provider = "amazon_bedrock"
+name = "Mistral 7B Instruct"
+family = "mistral"
+provider_model_id = "mistral.mistral-7b-instruct-v0:2"
+release_date = "2023-09-28"
+last_updated = "2023-09-28"
+
+[limits]
+context = 32000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "active"
+eol_date = "No sooner than 3/1/2025"

--- a/priv/llm_db/local/amazon_bedrock/mistral_mistral-large-2402-v1_0.toml
+++ b/priv/llm_db/local/amazon_bedrock/mistral_mistral-large-2402-v1_0.toml
@@ -1,0 +1,19 @@
+id = "mistral.mistral-large-2402-v1:0"
+provider = "amazon_bedrock"
+name = "Mistral Large"
+family = "mistral"
+provider_model_id = "mistral.mistral-large-2402-v1:0"
+release_date = "2024-02-26"
+last_updated = "2024-02-26"
+
+[limits]
+context = 32000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "active"
+eol_date = "No sooner than 4/3/2025"

--- a/priv/llm_db/local/amazon_bedrock/mistral_mixtral-8x7b-instruct-v0_1.toml
+++ b/priv/llm_db/local/amazon_bedrock/mistral_mixtral-8x7b-instruct-v0_1.toml
@@ -1,0 +1,19 @@
+id = "mistral.mixtral-8x7b-instruct-v0:1"
+provider = "amazon_bedrock"
+name = "Mixtral 8x7B Instruct"
+family = "mixtral"
+provider_model_id = "mistral.mixtral-8x7b-instruct-v0:1"
+release_date = "2023-12-10"
+last_updated = "2023-12-10"
+
+[limits]
+context = 32000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[extra]
+aws_lifecycle = "active"
+eol_date = "No sooner than 3/1/2025"

--- a/priv/llm_db/upstream/models-dev-ea9de843.json
+++ b/priv/llm_db/upstream/models-dev-ea9de843.json
@@ -199,6 +199,33 @@
         "release_date": "2025-12-22",
         "tool_call": true
       },
+      "minimax-m3": {
+        "attachment": false,
+        "family": "minimax-m3",
+        "id": "minimax-m3",
+        "knowledge": "2025-01",
+        "last_updated": "2026-05-31",
+        "limit": {
+          "context": 512000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "minimax-m3",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-05-31",
+        "temperature": true,
+        "tool_call": true
+      },
       "ministral-3:14b": {
         "attachment": true,
         "family": "ministral",
@@ -604,6 +631,7 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-11",
+        "temperature": true,
         "tool_call": true
       },
       "minimax-m2": {
@@ -959,6 +987,7 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2025-12-15",
+        "temperature": true,
         "tool_call": true
       },
       "ministral-3:3b": {
@@ -3450,6 +3479,49 @@
         "temperature": true,
         "tool_call": true
       },
+      "qwen3.7-plus": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.05,
+          "cache_write": 0.625,
+          "input": 0.5,
+          "output": 3,
+          "tiers": [
+            {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "input": 2,
+              "output": 6,
+              "tier": {
+                "size": 128000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "qwen",
+        "id": "qwen3.7-plus",
+        "knowledge": "2025-04",
+        "last_updated": "2026-06-02",
+        "limit": {
+          "context": 131072,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7 Plus",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-02",
+        "temperature": true,
+        "tool_call": true
+      },
       "qwen-long": {
         "attachment": false,
         "cost": {
@@ -3618,7 +3690,7 @@
           ]
         },
         "name": "GLM 5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -4708,7 +4780,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -4914,6 +4986,11 @@
         "name": "Kimi K2.5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-01",
         "structured_output": true,
         "temperature": false,
@@ -4950,6 +5027,11 @@
         "name": "Kimi K2.6",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-04-21",
         "structured_output": true,
         "temperature": true,
@@ -5055,7 +5137,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -7380,6 +7462,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2024-09-12",
+        "status": "deprecated",
         "structured_output": true,
         "temperature": false,
         "tool_call": false
@@ -8558,6 +8641,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2024-09-12",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": false
       },
@@ -9089,9 +9173,9 @@
       "deepseek-ai/DeepSeek-V4-Pro": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.003625,
-          "input": 0.435,
-          "output": 0.87
+          "cache_read": 0.1,
+          "input": 1.3,
+          "output": 2.6
         },
         "family": "deepseek-thinking",
         "id": "deepseek-ai/DeepSeek-V4-Pro",
@@ -9101,8 +9185,8 @@
         "knowledge": "2025-05",
         "last_updated": "2026-04-24",
         "limit": {
-          "context": 65536,
-          "output": 65536
+          "context": 1048576,
+          "output": 16384
         },
         "modalities": {
           "input": [
@@ -9117,58 +9201,6 @@
         "reasoning": true,
         "release_date": "2026-04-24",
         "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
-      "xiaomi/mimo-v2.5": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0.08,
-          "context_over_200k": {
-            "cache_read": 0.16,
-            "input": 0.8,
-            "output": 4
-          },
-          "input": 0.4,
-          "output": 2,
-          "tiers": [
-            {
-              "cache_read": 0.16,
-              "input": 0.8,
-              "output": 4,
-              "tier": {
-                "size": 256000,
-                "type": "context"
-              }
-            }
-          ]
-        },
-        "family": "mimo",
-        "id": "xiaomi/mimo-v2.5",
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "knowledge": "2024-12",
-        "last_updated": "2026-04-22",
-        "limit": {
-          "context": 262144,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "audio",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "MiMo-V2.5",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2026-04-22",
         "temperature": true,
         "tool_call": true
       },
@@ -9202,22 +9234,22 @@
         "temperature": true,
         "tool_call": true
       },
-      "xiaomi/mimo-v2.5-pro": {
-        "attachment": false,
+      "XiaomiMiMo/MiMo-V2.5": {
+        "attachment": true,
         "cost": {
-          "cache_read": 0.2,
+          "cache_read": 0.08,
           "context_over_200k": {
-            "cache_read": 0.4,
-            "input": 2,
-            "output": 6
+            "cache_read": 0.16,
+            "input": 0.8,
+            "output": 4
           },
-          "input": 1,
-          "output": 3,
+          "input": 0.4,
+          "output": 2,
           "tiers": [
             {
-              "cache_read": 0.4,
-              "input": 2,
-              "output": 6,
+              "cache_read": 0.16,
+              "input": 0.8,
+              "output": 4,
               "tier": {
                 "size": 256000,
                 "type": "context"
@@ -9226,25 +9258,28 @@
           ]
         },
         "family": "mimo",
-        "id": "xiaomi/mimo-v2.5-pro",
+        "id": "XiaomiMiMo/MiMo-V2.5",
         "interleaved": {
           "field": "reasoning_content"
         },
         "knowledge": "2024-12",
         "last_updated": "2026-04-22",
         "limit": {
-          "context": 1048576,
+          "context": 262144,
           "output": 16384
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "audio",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "MiMo-V2.5-Pro",
+        "name": "MiMo-V2.5",
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-04-22",
@@ -9311,9 +9346,9 @@
       "deepseek-ai/DeepSeek-V4-Flash": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.0028,
-          "input": 0.14,
-          "output": 0.28
+          "cache_read": 0.02,
+          "input": 0.1,
+          "output": 0.2
         },
         "family": "deepseek-flash",
         "id": "deepseek-ai/DeepSeek-V4-Flash",
@@ -9323,8 +9358,8 @@
         "knowledge": "2025-05",
         "last_updated": "2026-04-24",
         "limit": {
-          "context": 1000000,
-          "output": 384000
+          "context": 1048576,
+          "output": 16384
         },
         "modalities": {
           "input": [
@@ -9426,6 +9461,55 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-02-12",
+        "temperature": true,
+        "tool_call": true
+      },
+      "XiaomiMiMo/MiMo-V2.5-Pro": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 2,
+            "output": 6
+          },
+          "input": 1,
+          "output": 3,
+          "tiers": [
+            {
+              "cache_read": 0.4,
+              "input": 2,
+              "output": 6,
+              "tier": {
+                "size": 256000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "mimo",
+        "id": "XiaomiMiMo/MiMo-V2.5-Pro",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2024-12",
+        "last_updated": "2026-04-22",
+        "limit": {
+          "context": 1048576,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiMo-V2.5-Pro",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-22",
         "temperature": true,
         "tool_call": true
       },
@@ -10332,12 +10416,21 @@
         "name": "Step 3.5 Flash 2603",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-04-02",
         "temperature": true,
         "tool_call": true
       }
     },
-    "name": "StepFun",
+    "name": "StepFun AI",
     "npm": "@ai-sdk/openai-compatible"
   },
   "xiaomi-token-plan-ams": {
@@ -11977,6 +12070,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2026-01-07",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -13496,6 +13590,38 @@
         "release_date": "2023-11-06",
         "structured_output": false,
         "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
         "tool_call": true
       },
       "workers-ai/@cf/openai/gpt-oss-120b": {
@@ -19023,7 +19149,7 @@
         "family": "gpt",
         "id": "gpt-5.4",
         "knowledge": "2025-08-31",
-        "last_updated": "2026-04-27",
+        "last_updated": "2026-03-05",
         "limit": {
           "context": 1050000,
           "input": 922000,
@@ -19042,7 +19168,41 @@
         "name": "gpt-5.4",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2026-04-27",
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "input": 5,
+          "output": 30
+        },
+        "family": "gpt",
+        "id": "gpt-5.5",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-04-23",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "gpt-5.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-23",
         "structured_output": true,
         "temperature": false,
         "tool_call": true
@@ -19148,123 +19308,206 @@
     ],
     "id": "nano-gpt",
     "models": {
-      "openai/gpt-5.1-chat": {
+      "Qwen3.5-27B-NaNovel-Derestricted-Lite": {
         "attachment": true,
         "cost": {
-          "input": 1.25,
-          "output": 10
-        },
-        "family": "gpt",
-        "id": "openai/gpt-5.1-chat",
-        "last_updated": "2025-11-13",
-        "limit": {
-          "context": 400000,
-          "input": 400000,
-          "output": 128000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT 5.1 Chat",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-11-13",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "gemini-2.0-flash-lite": {
-        "attachment": true,
-        "cost": {
-          "input": 0.0748,
+          "input": 0.306,
           "output": 0.306
         },
-        "id": "gemini-2.0-flash-lite",
-        "last_updated": "2024-12-11",
+        "id": "Qwen3.5-27B-NaNovel-Derestricted-Lite",
+        "last_updated": "2026-04-30",
         "limit": {
-          "context": 1000000,
-          "input": 1000000,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Gemini 2.0 Flash Lite",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-11",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "claude-3-7-sonnet-thinking": {
-        "attachment": true,
-        "cost": {
-          "input": 2.992,
-          "output": 14.994
-        },
-        "id": "claude-3-7-sonnet-thinking",
-        "last_updated": "2025-02-24",
-        "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 16000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Claude 3.7 Sonnet Thinking",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-02-24",
-        "structured_output": true,
-        "tool_call": true
-      },
-      "ernie-5.0-thinking-latest": {
-        "attachment": true,
-        "cost": {
-          "input": 1.1,
-          "output": 2
-        },
-        "id": "ernie-5.0-thinking-latest",
-        "last_updated": "2025-11-18",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Ernie 5.0 Thinking",
+        "name": "Qwen3.5 27B NaNovel Derestricted Lite",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-11-18",
+        "release_date": "2026-04-30",
         "structured_output": false,
         "tool_call": false
+      },
+      "Qwen3.5-27B-Infracelestial": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Infracelestial",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Infracelestial",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "qwen/qwen3-coder-plus": {
+        "attachment": false,
+        "cost": {
+          "input": 1,
+          "output": 5
+        },
+        "id": "qwen/qwen3-coder-plus",
+        "last_updated": "2025-09-17",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3 Coder Plus",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-09-17",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "qwen/qwen3-coder-flash": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 1.5
+        },
+        "id": "qwen/qwen3-coder-flash",
+        "last_updated": "2025-09-17",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3 Coder Flash",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-09-17",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "liquid/lfm-2-24b-a2b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.03,
+          "output": 0.12
+        },
+        "id": "liquid/lfm-2-24b-a2b",
+        "last_updated": "2025-12-20",
+        "limit": {
+          "context": 32768,
+          "input": 32768,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "LFM2 24B A2B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-12-20",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "hermes-medium": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "id": "hermes-medium",
+        "last_updated": "2026-05-11",
+        "limit": {
+          "context": 204800,
+          "input": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Hermes Medium",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-11",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "TEE/glm-5.1-thinking": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.3,
+          "input": 1.5,
+          "output": 5.25
+        },
+        "id": "TEE/glm-5.1-thinking",
+        "last_updated": "2026-04-20",
+        "limit": {
+          "context": 202752,
+          "input": 202752,
+          "output": 65535
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 5.1 Thinking TEE",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-20",
+        "structured_output": true,
+        "tool_call": true
       },
       "doubao-seed-2-0-mini-260215": {
         "attachment": false,
@@ -19323,6 +19566,93 @@
         "structured_output": true,
         "tool_call": true
       },
+      "deepseek/deepseek-v4-pro-cheaper:thinking": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.003625,
+          "input": 0.435,
+          "output": 0.87
+        },
+        "id": "deepseek/deepseek-v4-pro-cheaper:thinking",
+        "last_updated": "2026-04-25",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro Cheaper (Thinking)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-25",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "Qwen3.5-27B-Writer-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Writer-Derestricted-Lite",
+        "last_updated": "2026-04-06",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Writer Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-06",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "NousResearch/DeepHermes-3-Mistral-24B-Preview": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 0.3
+        },
+        "id": "NousResearch/DeepHermes-3-Mistral-24B-Preview",
+        "last_updated": "2025-05-10",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepHermes-3 Mistral 24B (Preview)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-05-10",
+        "structured_output": false,
+        "tool_call": false
+      },
       "mistralai/ministral-3b-2512": {
         "attachment": false,
         "cost": {
@@ -19352,18 +19682,18 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Progenitor-V3.3": {
+      "qwen/qwen3-next-80b-a3b-thinking": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 0.15,
+          "output": 0.65
         },
-        "id": "Llama-3.3-70B-Progenitor-V3.3",
-        "last_updated": "2025-07-26",
+        "id": "qwen/qwen3-next-80b-a3b-thinking",
+        "last_updated": "2024-01-01",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
+          "context": 256000,
+          "input": 256000,
+          "output": 32768
         },
         "modalities": {
           "input": [
@@ -19373,10 +19703,10 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Progenitor V3.3",
+        "name": "Qwen3 Next 80B A3B (Thinking)",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-07-26",
+        "release_date": "2024-01-01",
         "structured_output": false,
         "tool_call": false
       },
@@ -19407,34 +19737,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-07-26",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "GLM-4.5-Air-Derestricted-Iceblink-ReExtract": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "GLM-4.5-Air-Derestricted-Iceblink-ReExtract",
-        "last_updated": "2025-12-12",
-        "limit": {
-          "context": 131072,
-          "input": 131072,
-          "output": 98304
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GLM 4.5 Air Derestricted Iceblink ReExtract",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-12-12",
         "structured_output": false,
         "tool_call": false
       },
@@ -19497,6 +19799,35 @@
         "structured_output": true,
         "tool_call": true
       },
+      "TheDrummer/skyfall-36b-v2": {
+        "attachment": true,
+        "cost": {
+          "input": 0.493,
+          "output": 0.493
+        },
+        "id": "TheDrummer/skyfall-36b-v2",
+        "last_updated": "2025-03-10",
+        "limit": {
+          "context": 64000,
+          "input": 64000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "TheDrummer Skyfall 36B V2",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-03-10",
+        "structured_output": false,
+        "tool_call": false
+      },
       "chutesai/Mistral-Small-3.2-24B-Instruct-2506": {
         "attachment": false,
         "cost": {
@@ -19526,18 +19857,49 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3+(3.1v3.3)-70B-New-Dawn-v1.1": {
-        "attachment": false,
+      "Qwen3.5-27B-Vivid-Durian": {
+        "attachment": true,
         "cost": {
           "input": 0.306,
           "output": 0.306
         },
-        "id": "Llama-3.3+(3.1v3.3)-70B-New-Dawn-v1.1",
-        "last_updated": "2024-12-06",
+        "id": "Qwen3.5-27B-Vivid-Durian",
+        "last_updated": "2026-03-18",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Vivid Durian",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-18",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "upstage/solar-pro-3": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.015,
+          "input": 0.15,
+          "output": 0.6
+        },
+        "id": "upstage/solar-pro-3",
+        "last_updated": "2026-03-03",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 128000
         },
         "modalities": {
           "input": [
@@ -19547,10 +19909,10 @@
             "text"
           ]
         },
-        "name": "Llama 3.3+ 70B New Dawn v1.1",
+        "name": "Solar Pro 3",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-12-06",
+        "release_date": "2026-03-03",
         "structured_output": false,
         "tool_call": false
       },
@@ -19642,6 +20004,36 @@
         "structured_output": false,
         "tool_call": false
       },
+      "qwen/qwen3.5-397b-a17b-thinking": {
+        "attachment": true,
+        "cost": {
+          "input": 0.6,
+          "output": 3.6
+        },
+        "id": "qwen/qwen3.5-397b-a17b-thinking",
+        "last_updated": "2026-02-16",
+        "limit": {
+          "context": 258048,
+          "input": 258048,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 397B A17B Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-16",
+        "structured_output": false,
+        "tool_call": false
+      },
       "claude-opus-4-1-thinking:8192": {
         "attachment": true,
         "cost": {
@@ -19671,6 +20063,66 @@
         "release_date": "2025-05-22",
         "structured_output": true,
         "tool_call": true
+      },
+      "Gemma-4-31B-Cognitive-Unshackled": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Gemma-4-31B-Cognitive-Unshackled",
+        "last_updated": "2026-05-01",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B Cognitive Unshackled",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-01",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-BlueStar-v3-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-BlueStar-v3-Derestricted",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B BlueStar v3 Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
+        "structured_output": false,
+        "tool_call": false
       },
       "EVA-UNIT-01/EVA-Qwen2.5-32B-v0.2": {
         "attachment": false,
@@ -19789,34 +20241,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Forgotten-Abomination-v5.0": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Forgotten-Abomination-v5.0",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Forgotten Abomination v5.0",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
       "openai/gpt-5.2-codex": {
         "attachment": true,
         "cost": {
@@ -19874,6 +20298,36 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-01-29",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-Marvin-V2-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Marvin-V2-Derestricted",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Marvin V2 Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
         "structured_output": false,
         "tool_call": false
       },
@@ -19963,6 +20417,36 @@
         "structured_output": false,
         "tool_call": false
       },
+      "google/gemini-3.1-pro-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 2,
+          "output": 12
+        },
+        "id": "google/gemini-3.1-pro-preview",
+        "last_updated": "2026-02-19",
+        "limit": {
+          "context": 1048756,
+          "input": 1048756,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Pro (Preview)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-19",
+        "structured_output": true,
+        "tool_call": true
+      },
       "moonshotai/Kimi-K2-Instruct-0905": {
         "attachment": false,
         "cost": {
@@ -19991,6 +20475,35 @@
         "release_date": "2025-09-25",
         "structured_output": true,
         "tool_call": true
+      },
+      "zai-org/glm-4.6v-original": {
+        "attachment": true,
+        "cost": {
+          "input": 0.6,
+          "output": 0.9
+        },
+        "id": "zai-org/glm-4.6v-original",
+        "last_updated": "2025-12-08",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 24000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.6V Original",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-12-08",
+        "structured_output": false,
+        "tool_call": false
       },
       "moonshotai/kimi-k2.6": {
         "attachment": true,
@@ -20108,6 +20621,94 @@
         "reasoning": false,
         "release_date": "2025-08-08",
         "structured_output": false,
+        "temperature": true,
+        "tool_call": false
+      },
+      "openai/gpt-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "input": 5,
+          "output": 30
+        },
+        "id": "openai/gpt-latest",
+        "last_updated": "2026-03-29",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-29",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "TEE/gemma4-31b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.45,
+          "output": 1
+        },
+        "id": "TEE/gemma4-31b",
+        "last_updated": "2026-04-04",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-04-04",
+        "structured_output": true,
+        "tool_call": false
+      },
+      "TheDrummer/Magidonia-24B-v4.3": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1003,
+          "output": 0.1207
+        },
+        "id": "TheDrummer/Magidonia-24B-v4.3",
+        "last_updated": "2025-12-25",
+        "limit": {
+          "context": 32768,
+          "input": 32768,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "The Drummer Magidonia 24B v4.3",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-12-25",
+        "structured_output": false,
         "tool_call": false
       },
       "deepseek-r1": {
@@ -20137,6 +20738,36 @@
         "release_date": "2025-01-20",
         "structured_output": false,
         "tool_call": false
+      },
+      "minimax/minimax-m3:thinking": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.06,
+          "input": 0.3,
+          "output": 1.2
+        },
+        "id": "minimax/minimax-m3:thinking",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 512000,
+          "input": 512000,
+          "output": 80000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax M3 Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-01",
+        "structured_output": true,
+        "tool_call": true
       },
       "openai/gpt-4o": {
         "attachment": true,
@@ -20197,35 +20828,6 @@
         "release_date": "2025-05-22",
         "structured_output": true,
         "tool_call": true
-      },
-      "TheDrummer 2/Anubis-70B-v1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.31,
-          "output": 0.31
-        },
-        "family": "llama",
-        "id": "TheDrummer 2/Anubis-70B-v1",
-        "last_updated": "2024-07-01",
-        "limit": {
-          "context": 65536,
-          "input": 65536,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Anubis 70B v1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-07-01",
-        "structured_output": false,
-        "tool_call": false
       },
       "Steelskull/L3.3-MS-Evayale-70B": {
         "attachment": false,
@@ -20313,6 +20915,35 @@
         "release_date": "2026-02-28",
         "structured_output": false,
         "tool_call": false
+      },
+      "mistral/mistral-medium-3.5": {
+        "attachment": true,
+        "cost": {
+          "input": 1.5,
+          "output": 7.5
+        },
+        "id": "mistral/mistral-medium-3.5",
+        "last_updated": "2026-04-29",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Medium 3.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-29",
+        "structured_output": true,
+        "tool_call": true
       },
       "openai/gpt-5-pro": {
         "attachment": true,
@@ -20464,31 +21095,94 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Ignition-v0.1": {
-        "attachment": false,
+      "anthropic/claude-opus-4.8": {
+        "attachment": true,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "cache_read": 0.4998,
+          "input": 4.998,
+          "output": 25.007
         },
-        "id": "Llama-3.3-70B-Ignition-v0.1",
-        "last_updated": "2024-12-06",
+        "id": "anthropic/claude-opus-4.8",
+        "last_updated": "2026-05-28",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Ignition v0.1",
+        "name": "Claude Opus 4.8",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "xiaomi/mimo-v2.5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.0028,
+          "input": 0.14,
+          "output": 0.28
+        },
+        "id": "xiaomi/mimo-v2.5",
+        "last_updated": "2026-04-22",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiMo V2.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-22",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "TheDrummer/Skyfall-31B-v4.2": {
+        "attachment": true,
+        "cost": {
+          "input": 0.55,
+          "output": 0.8
+        },
+        "id": "TheDrummer/Skyfall-31B-v4.2",
+        "last_updated": "2026-03-26",
+        "limit": {
+          "context": 131072,
+          "input": 131072,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "TheDrummer Skyfall 31B v4.2",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-12-06",
+        "release_date": "2026-03-26",
         "structured_output": false,
         "tool_call": false
       },
@@ -20520,6 +21214,36 @@
         "structured_output": false,
         "tool_call": false
       },
+      "qwen3.5-35b-a3b:thinking": {
+        "attachment": true,
+        "cost": {
+          "input": 0.225,
+          "output": 1.8
+        },
+        "id": "qwen3.5-35b-a3b:thinking",
+        "last_updated": "2026-02-24",
+        "limit": {
+          "context": 260096,
+          "input": 260096,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 35B A3B Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-24",
+        "structured_output": false,
+        "tool_call": false
+      },
       "doubao-seed-1-6-flash-250615": {
         "attachment": false,
         "cost": {
@@ -20545,65 +21269,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-06-15",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "x-ai/grok-4.1-fast": {
-        "attachment": true,
-        "cost": {
-          "input": 0.2,
-          "output": 0.5
-        },
-        "family": "grok",
-        "id": "x-ai/grok-4.1-fast",
-        "last_updated": "2025-11-20",
-        "limit": {
-          "context": 2000000,
-          "input": 2000000,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Grok 4.1 Fast",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-11-20",
-        "structured_output": true,
-        "tool_call": true
-      },
-      "TEE/deepseek-r1-0528": {
-        "attachment": false,
-        "cost": {
-          "input": 2,
-          "output": 2
-        },
-        "family": "deepseek",
-        "id": "TEE/deepseek-r1-0528",
-        "last_updated": "2025-05-28",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 65536
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "DeepSeek R1 0528 TEE",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-05-28",
         "structured_output": false,
         "tool_call": false
       },
@@ -20636,19 +21301,18 @@
         "structured_output": false,
         "tool_call": false
       },
-      "unsloth/gemma-3-1b-it": {
+      "qwen/Qwen3-235B-A22B-Thinking-2507": {
         "attachment": false,
         "cost": {
-          "input": 0.1003,
-          "output": 0.1003
+          "input": 0.3,
+          "output": 0.5
         },
-        "family": "unsloth",
-        "id": "unsloth/gemma-3-1b-it",
-        "last_updated": "2025-03-10",
+        "id": "qwen/Qwen3-235B-A22B-Thinking-2507",
+        "last_updated": "2025-09-11",
         "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 8192
+          "context": 256000,
+          "input": 256000,
+          "output": 262144
         },
         "modalities": {
           "input": [
@@ -20658,10 +21322,40 @@
             "text"
           ]
         },
-        "name": "Gemma 3 1B IT",
+        "name": "Qwen 3 235b A22B 2507 Thinking",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-03-10",
+        "release_date": "2025-09-11",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted-Lite",
+        "last_updated": "2026-05-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Omega Evolution v2.2 Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-02",
         "structured_output": false,
         "tool_call": false
       },
@@ -20722,48 +21416,49 @@
         "structured_output": true,
         "tool_call": true
       },
-      "claude-3-7-sonnet-reasoner": {
+      "qwen3.5-flash": {
         "attachment": true,
         "cost": {
-          "input": 3,
-          "output": 15
+          "input": 0.09,
+          "output": 0.36
         },
-        "id": "claude-3-7-sonnet-reasoner",
-        "last_updated": "2025-03-29",
+        "id": "qwen3.5-flash",
+        "last_updated": "2026-02-24",
         "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 8192
+          "context": 991808,
+          "input": 991808,
+          "output": 65536
         },
         "modalities": {
           "input": [
             "text",
-            "pdf"
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Claude 3.7 Sonnet Reasoner",
+        "name": "Qwen3.5 Flash",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-03-29",
+        "release_date": "2026-02-24",
         "structured_output": false,
         "tool_call": false
       },
-      "NousResearch 2/hermes-4-405b:thinking": {
+      "zai-org/glm-latest": {
         "attachment": false,
         "cost": {
-          "input": 0.3,
-          "output": 1.2
+          "cache_read": 0.15,
+          "input": 0.75,
+          "output": 2.6
         },
-        "family": "nousresearch",
-        "id": "NousResearch 2/hermes-4-405b:thinking",
-        "last_updated": "2025-01-01",
+        "id": "zai-org/glm-latest",
+        "last_updated": "2026-05-03",
         "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 8192
+          "context": 200000,
+          "input": 200000,
+          "output": 131072
         },
         "modalities": {
           "input": [
@@ -20773,41 +21468,42 @@
             "text"
           ]
         },
-        "name": "Hermes 4 Large (Thinking)",
+        "name": "GLM Latest",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-01-01",
+        "reasoning": true,
+        "release_date": "2026-05-03",
         "structured_output": true,
         "tool_call": true
       },
-      "arcee-ai/trinity-large": {
-        "attachment": false,
+      "TEE/kimi-k2.6": {
+        "attachment": true,
         "cost": {
-          "input": 0.25,
-          "output": 1
+          "cache_read": 0.375,
+          "input": 1.5,
+          "output": 5.25
         },
-        "family": "trinity",
-        "id": "arcee-ai/trinity-large",
-        "last_updated": "2025-12-01",
+        "id": "TEE/kimi-k2.6",
+        "last_updated": "2026-04-21",
         "limit": {
-          "context": 131072,
-          "input": 131072,
-          "output": 8192
+          "context": 262144,
+          "input": 262144,
+          "output": 65536
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Trinity Large",
+        "name": "Kimi K2.6 TEE",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-12-01",
+        "release_date": "2026-04-21",
         "structured_output": false,
-        "tool_call": false
+        "tool_call": true
       },
       "glm-4-air-0111": {
         "attachment": false,
@@ -20923,6 +21619,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "qwen/qwen3-coder-next": {
+        "attachment": false,
+        "cost": {
+          "input": 0.15,
+          "output": 1.5
+        },
+        "id": "qwen/qwen3-coder-next",
+        "last_updated": "2025-12-08",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3 Coder Next",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-12-08",
+        "structured_output": true,
+        "tool_call": true
+      },
       "Magistral-Small-2506": {
         "attachment": false,
         "cost": {
@@ -20977,6 +21701,36 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-06-17",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-RpRMax-v1": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-RpRMax-v1",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B RpRMax v1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
         "structured_output": false,
         "tool_call": false
       },
@@ -21040,6 +21794,35 @@
         "structured_output": true,
         "tool_call": true
       },
+      "xiaomi/mimo-v2.5-pro": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.0036,
+          "input": 0.435,
+          "output": 0.87
+        },
+        "id": "xiaomi/mimo-v2.5-pro",
+        "last_updated": "2026-04-22",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiMo V2.5 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-22",
+        "structured_output": true,
+        "tool_call": true
+      },
       "TEE/qwen3-30b-a3b-instruct-2507": {
         "attachment": false,
         "cost": {
@@ -21066,6 +21849,34 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-07-29",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "poolside/laguna-m.1": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.3
+        },
+        "id": "poolside/laguna-m.1",
+        "last_updated": "2026-04-29",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Laguna M.1",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-04-29",
         "structured_output": false,
         "tool_call": false
       },
@@ -21127,35 +21938,6 @@
         "structured_output": true,
         "tool_call": true
       },
-      "TEE/minimax-m2.1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.3,
-          "output": 1.2
-        },
-        "family": "minimax",
-        "id": "TEE/minimax-m2.1",
-        "last_updated": "2025-12-23",
-        "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "MiniMax M2.1 TEE",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-12-23",
-        "structured_output": true,
-        "tool_call": true
-      },
       "meta-llama/llama-4-scout": {
         "attachment": true,
         "cost": {
@@ -21214,6 +21996,34 @@
         "release_date": "2024-10-11",
         "structured_output": false,
         "tool_call": false
+      },
+      "zai-org/glm-4.7-flash-original": {
+        "attachment": false,
+        "cost": {
+          "input": 0.07,
+          "output": 0.4
+        },
+        "id": "zai-org/glm-4.7-flash-original",
+        "last_updated": "2026-01-19",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.7 Flash Original",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-01-19",
+        "structured_output": true,
+        "tool_call": true
       },
       "glm-z1-air": {
         "attachment": false,
@@ -21301,35 +22111,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "NousResearch 2/Hermes-4-70B:thinking": {
-        "attachment": false,
-        "cost": {
-          "input": 0.2006,
-          "output": 0.39949999999999997
-        },
-        "family": "nousresearch",
-        "id": "NousResearch 2/Hermes-4-70B:thinking",
-        "last_updated": "2025-09-17",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Hermes 4 (Thinking)",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-09-17",
-        "structured_output": false,
-        "tool_call": false
-      },
       "mistralai/devstral-2-123b-instruct-2512": {
         "attachment": false,
         "cost": {
@@ -21388,18 +22169,47 @@
         "structured_output": false,
         "tool_call": false
       },
-      "NousResearch 2/hermes-3-llama-3.1-70b": {
+      "gemma-4-31B-Fabled": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "gemma-4-31B-Fabled",
+        "last_updated": "2026-05-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B Fabled",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-02",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "NousResearch/hermes-4-405b:thinking": {
         "attachment": false,
         "cost": {
-          "input": 0.408,
-          "output": 0.408
+          "input": 0.3,
+          "output": 1.2
         },
-        "family": "nousresearch",
-        "id": "NousResearch 2/hermes-3-llama-3.1-70b",
-        "last_updated": "2026-01-07",
+        "id": "NousResearch/hermes-4-405b:thinking",
+        "last_updated": "2024-01-01",
         "limit": {
-          "context": 65536,
-          "input": 65536,
+          "context": 128000,
+          "input": 128000,
           "output": 8192
         },
         "modalities": {
@@ -21410,24 +22220,55 @@
             "text"
           ]
         },
-        "name": "Hermes 3 70B",
+        "name": "Hermes 4 Large (Thinking)",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2026-01-07",
-        "structured_output": false,
+        "release_date": "2024-01-01",
+        "structured_output": true,
         "tool_call": false
       },
-      "Llama-3.3-70B-Aurora-Borealis": {
+      "openai/gpt-5.4-pro": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 3,
+          "input": 30,
+          "output": 180
+        },
+        "id": "openai/gpt-5.4-pro",
+        "last_updated": "2026-03-05",
+        "limit": {
+          "context": 922000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT 5.4 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "TheDrummer/Anubis-70B-v1.1": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 0.31,
+          "output": 0.31
         },
-        "id": "Llama-3.3-70B-Aurora-Borealis",
-        "last_updated": "2024-12-06",
+        "id": "TheDrummer/Anubis-70B-v1.1",
+        "last_updated": "2024-01-01",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 131072,
+          "input": 131072,
           "output": 16384
         },
         "modalities": {
@@ -21438,12 +22279,69 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Aurora Borealis",
+        "name": "Anubis 70B v1.1",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-12-06",
+        "release_date": "2024-01-01",
         "structured_output": false,
         "tool_call": false
+      },
+      "zai-org/glm-4.7-flash:thinking": {
+        "attachment": false,
+        "cost": {
+          "input": 0.07,
+          "output": 0.4
+        },
+        "id": "zai-org/glm-4.7-flash:thinking",
+        "last_updated": "2026-01-19",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.7 Flash Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-01-19",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "TEE/deepseek-v4-pro:thinking": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.15,
+          "input": 1.5,
+          "output": 5.25
+        },
+        "id": "TEE/deepseek-v4-pro:thinking",
+        "last_updated": "2026-04-29",
+        "limit": {
+          "context": 800000,
+          "input": 800000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro Thinking TEE",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-29",
+        "structured_output": true,
+        "tool_call": true
       },
       "TEE/qwen2.5-vl-72b-instruct": {
         "attachment": true,
@@ -21533,74 +22431,18 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-ArliAI-RPMax-v3": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-ArliAI-RPMax-v3",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B ArliAI RPMax v3",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-GeneticLemonade-Unleashed-v3": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-GeneticLemonade-Unleashed-v3",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B GeneticLemonade Unleashed v3",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "claude-3-7-sonnet-thinking:1024": {
+      "claw-high": {
         "attachment": true,
         "cost": {
-          "input": 2.992,
-          "output": 14.994
+          "input": 4.998,
+          "output": 25.007
         },
-        "id": "claude-3-7-sonnet-thinking:1024",
-        "last_updated": "2025-02-24",
+        "id": "claw-high",
+        "last_updated": "2026-05-11",
         "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 64000
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
         },
         "modalities": {
           "input": [
@@ -21612,10 +22454,10 @@
             "text"
           ]
         },
-        "name": "Claude 3.7 Sonnet Thinking (1K)",
+        "name": "Claw High",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-02-24",
+        "release_date": "2026-05-11",
         "structured_output": true,
         "tool_call": true
       },
@@ -21648,6 +22490,35 @@
         "structured_output": false,
         "tool_call": false
       },
+      "mistralai/mistral-small-4-119b-2603": {
+        "attachment": true,
+        "cost": {
+          "input": 0.4,
+          "output": 1.4
+        },
+        "id": "mistralai/mistral-small-4-119b-2603",
+        "last_updated": "2026-03-16",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Small 4 119B",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-16",
+        "structured_output": true,
+        "tool_call": true
+      },
       "zai-org/glm-4.7-flash": {
         "attachment": false,
         "cost": {
@@ -21677,63 +22548,92 @@
         "structured_output": true,
         "tool_call": true
       },
-      "openai/chatgpt-4o-latest": {
-        "attachment": true,
+      "arcee-ai/trinity-large-thinking": {
+        "attachment": false,
         "cost": {
-          "input": 4.998,
-          "output": 14.993999999999998
+          "input": 0.25,
+          "output": 0.9
         },
-        "family": "gpt",
-        "id": "openai/chatgpt-4o-latest",
-        "last_updated": "2024-05-13",
+        "id": "arcee-ai/trinity-large-thinking",
+        "last_updated": "2026-04-01",
         "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 16384
+          "context": 262144,
+          "input": 262144,
+          "output": 80000
         },
         "modalities": {
           "input": [
-            "text",
-            "image"
+            "text"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "ChatGPT 4o",
+        "name": "Trinity Large Thinking",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-05-13",
-        "structured_output": true,
+        "reasoning": true,
+        "release_date": "2026-04-01",
+        "structured_output": false,
         "tool_call": true
       },
-      "microsoft/MAI-DS-R1-FP8": {
+      "openai/gpt-5.4-mini": {
         "attachment": true,
         "cost": {
-          "input": 0.3,
-          "output": 0.3
+          "cache_read": 0.075,
+          "input": 0.75,
+          "output": 4.5
         },
-        "family": "deepseek",
-        "id": "microsoft/MAI-DS-R1-FP8",
-        "last_updated": "2025-09-25",
+        "id": "openai/gpt-5.4-mini",
+        "last_updated": "2026-03-17",
         "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 8192
+          "context": 400000,
+          "input": 400000,
+          "output": 128000
         },
         "modalities": {
           "input": [
             "text",
+            "image",
             "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Microsoft DeepSeek R1",
+        "name": "GPT 5.4 Mini",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-09-25",
+        "reasoning": true,
+        "release_date": "2026-03-17",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "gemma-4-31B-Garnet": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "gemma-4-31B-Garnet",
+        "last_updated": "2026-05-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B Garnet",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-02",
         "structured_output": false,
         "tool_call": false
       },
@@ -21824,6 +22724,34 @@
         "structured_output": true,
         "tool_call": true
       },
+      "owl": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.3
+        },
+        "id": "owl",
+        "last_updated": "2026-05-01",
+        "limit": {
+          "context": 1048756,
+          "input": 1048756,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "OWL",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-05-01",
+        "structured_output": true,
+        "tool_call": true
+      },
       "qwen3-vl-235b-a22b-instruct-original": {
         "attachment": true,
         "cost": {
@@ -21852,6 +22780,35 @@
         "release_date": "2025-09-25",
         "structured_output": false,
         "tool_call": false
+      },
+      "mercury-2": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 0.75
+        },
+        "id": "mercury-2",
+        "last_updated": "2024-01-01",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 50000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mercury 2",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-01-01",
+        "structured_output": true,
+        "tool_call": true
       },
       "huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated": {
         "attachment": false,
@@ -21911,6 +22868,35 @@
         "structured_output": false,
         "tool_call": false
       },
+      "qwen3.7-max": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.25,
+          "input": 2.5,
+          "output": 7.5
+        },
+        "id": "qwen3.7-max",
+        "last_updated": "2026-05-21",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7 Max",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-05-21",
+        "structured_output": false,
+        "tool_call": false
+      },
       "gemini-2.5-flash": {
         "attachment": true,
         "cost": {
@@ -21966,120 +22952,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-05-20",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Sapphira-0.1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Sapphira-0.1",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Sapphira 0.1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "tngtech/tng-r1t-chimera": {
-        "attachment": false,
-        "cost": {
-          "input": 0.3,
-          "output": 1.2
-        },
-        "family": "tngtech",
-        "id": "tngtech/tng-r1t-chimera",
-        "last_updated": "2025-11-26",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 65536
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "TNG R1T Chimera",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-11-26",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "TheDrummer 2/Rocinante-12B-v1.1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.408,
-          "output": 0.595
-        },
-        "family": "llama",
-        "id": "TheDrummer 2/Rocinante-12B-v1.1",
-        "last_updated": "2024-07-01",
-        "limit": {
-          "context": 16384,
-          "input": 16384,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Rocinante 12b",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-07-01",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Fallen-v1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Fallen-v1",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Fallen v1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -22145,6 +23017,34 @@
         "structured_output": true,
         "tool_call": true
       },
+      "qwen/Qwen2.5-Coder-32B-Instruct": {
+        "attachment": false,
+        "cost": {
+          "input": 0.2006,
+          "output": 0.2006
+        },
+        "id": "qwen/Qwen2.5-Coder-32B-Instruct",
+        "last_updated": "2025-07-03",
+        "limit": {
+          "context": 32000,
+          "input": 32000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen 2.5 Coder 32b",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-07-03",
+        "structured_output": false,
+        "tool_call": false
+      },
       "mistral-small-31-24b-instruct": {
         "attachment": true,
         "cost": {
@@ -22203,6 +23103,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "Unbabel/M-Prometheus-14B": {
+        "attachment": false,
+        "cost": {
+          "input": 0.2,
+          "output": 0.2
+        },
+        "id": "Unbabel/M-Prometheus-14B",
+        "last_updated": "2026-05-29",
+        "limit": {
+          "context": 32768,
+          "input": 32768,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "M-Prometheus 14B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-05-29",
+        "structured_output": false,
+        "tool_call": false
+      },
       "step-r1-v-mini": {
         "attachment": false,
         "cost": {
@@ -22228,66 +23156,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-04-08",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "openai/gpt-5-chat-latest": {
-        "attachment": true,
-        "cost": {
-          "input": 1.25,
-          "output": 10
-        },
-        "family": "gpt",
-        "id": "openai/gpt-5-chat-latest",
-        "last_updated": "2025-08-07",
-        "limit": {
-          "context": 400000,
-          "input": 400000,
-          "output": 128000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT 5 Chat",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-08-07",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "TheDrummer 2/UnslopNemo-12B-v4.1": {
-        "attachment": true,
-        "cost": {
-          "input": 0.49299999999999994,
-          "output": 0.49299999999999994
-        },
-        "family": "llama",
-        "id": "TheDrummer 2/UnslopNemo-12B-v4.1",
-        "last_updated": "2024-07-01",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "UnslopNemo 12b v4",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-07-01",
         "structured_output": false,
         "tool_call": false
       },
@@ -22320,6 +23188,65 @@
         "structured_output": true,
         "tool_call": true
       },
+      "holo3-35b-a3b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.25,
+          "output": 1.8
+        },
+        "id": "holo3-35b-a3b",
+        "last_updated": "2024-01-01",
+        "limit": {
+          "context": 65536,
+          "input": 65536,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Holo3-35B-A3B",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-01-01",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "Qwen3.5-27B-Writer-V2-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Writer-V2-Derestricted-Lite",
+        "last_updated": "2026-04-06",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Writer V2 Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-06",
+        "structured_output": false,
+        "tool_call": false
+      },
       "Steelskull/L3.3-Electra-R1-70b": {
         "attachment": false,
         "cost": {
@@ -22348,35 +23275,6 @@
         "release_date": "2024-12-06",
         "structured_output": false,
         "tool_call": false
-      },
-      "claude-3-5-sonnet-20241022": {
-        "attachment": true,
-        "cost": {
-          "input": 2.992,
-          "output": 14.994
-        },
-        "id": "claude-3-5-sonnet-20241022",
-        "last_updated": "2025-08-26",
-        "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Claude 3.5 Sonnet",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-08-26",
-        "structured_output": true,
-        "tool_call": true
       },
       "claude-sonnet-4-thinking:8192": {
         "attachment": true,
@@ -22408,19 +23306,50 @@
         "structured_output": true,
         "tool_call": true
       },
-      "meta-llama/llama-3.2-90b-vision-instruct": {
+      "ernie-5.1": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.75,
+          "input": 0.75,
+          "output": 3
+        },
+        "id": "ernie-5.1",
+        "last_updated": "2026-05-10",
+        "limit": {
+          "context": 119000,
+          "input": 119000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "ERNIE 5.1",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-05-10",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "ibm-granite/granite-4.1-8b": {
         "attachment": false,
         "cost": {
-          "input": 0.9009999999999999,
-          "output": 0.9009999999999999
+          "cache_read": 0.05,
+          "input": 0.05,
+          "output": 0.1
         },
-        "family": "llama",
-        "id": "meta-llama/llama-3.2-90b-vision-instruct",
-        "last_updated": "2025-09-25",
+        "id": "ibm-granite/granite-4.1-8b",
+        "last_updated": "2026-04-29",
         "limit": {
           "context": 131072,
           "input": 131072,
-          "output": 16384
+          "output": 131072
         },
         "modalities": {
           "input": [
@@ -22430,126 +23359,12 @@
             "text"
           ]
         },
-        "name": "Llama 3.2 Medium",
+        "name": "Granite 4.1 8B",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-09-25",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "GLM-4.5-Air-Derestricted": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "GLM-4.5-Air-Derestricted",
-        "last_updated": "2025-07-28",
-        "limit": {
-          "context": 202600,
-          "input": 202600,
-          "output": 98304
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GLM 4.5 Air Derestricted",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-07-28",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-The-Omega-Directive-Unslop-v2.1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-The-Omega-Directive-Unslop-v2.1",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Omega Directive Unslop v2.1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "TheDrummer 2/Magidonia-24B-v4.3": {
-        "attachment": false,
-        "cost": {
-          "input": 0.1003,
-          "output": 0.1207
-        },
-        "family": "llama",
-        "id": "TheDrummer 2/Magidonia-24B-v4.3",
-        "last_updated": "2025-12-25",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 32768
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "The Drummer Magidonia 24B v4.3",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-12-25",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "miromind-ai/mirothinker-v1.5-235b": {
-        "attachment": false,
-        "cost": {
-          "input": 0.3,
-          "output": 1.2
-        },
-        "family": "gpt",
-        "id": "miromind-ai/mirothinker-v1.5-235b",
-        "last_updated": "2026-01-07",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 4000
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "MiroThinker v1.5 235B",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2026-01-07",
-        "structured_output": false,
-        "tool_call": false
+        "release_date": "2026-04-29",
+        "structured_output": true,
+        "tool_call": true
       },
       "doubao-1.5-vision-pro-32k": {
         "attachment": true,
@@ -22579,6 +23394,66 @@
         "release_date": "2025-01-22",
         "structured_output": false,
         "tool_call": false
+      },
+      "claude-haiku-4-5-20251001-thinking": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "input": 1,
+          "output": 5
+        },
+        "id": "claude-haiku-4-5-20251001-thinking",
+        "last_updated": "2025-10-15",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 4.5 Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-10-15",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "mistralai/mistral-small-4-119b-2603:thinking": {
+        "attachment": true,
+        "cost": {
+          "input": 0.4,
+          "output": 1.4
+        },
+        "id": "mistralai/mistral-small-4-119b-2603:thinking",
+        "last_updated": "2026-03-17",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Small 4 119B Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-17",
+        "structured_output": true,
+        "tool_call": true
       },
       "minimax/minimax-m2.5": {
         "attachment": false,
@@ -22670,6 +23545,37 @@
         "structured_output": true,
         "tool_call": true
       },
+      "anthropic/claude-opus-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.4998,
+          "input": 4.998,
+          "output": 25.007
+        },
+        "id": "anthropic/claude-opus-latest",
+        "last_updated": "2026-03-29",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-29",
+        "structured_output": true,
+        "tool_call": true
+      },
       "KAT-Coder-Air-V1": {
         "attachment": false,
         "cost": {
@@ -22698,71 +23604,44 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Bigger-Body": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Bigger-Body",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Bigger Body",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "CrucibleLab/L3.3-70B-Loki-V2.0": {
-        "attachment": false,
-        "cost": {
-          "input": 0.49299999999999994,
-          "output": 0.49299999999999994
-        },
-        "family": "llama",
-        "id": "CrucibleLab/L3.3-70B-Loki-V2.0",
-        "last_updated": "2026-01-22",
-        "limit": {
-          "context": 16384,
-          "input": 16384,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "L3.3 70B Loki v2.0",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2026-01-22",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "gemini-3-pro-preview-thinking": {
+      "google/gemma-4-31b-it:thinking": {
         "attachment": true,
         "cost": {
+          "input": 0.1,
+          "output": 0.35
+        },
+        "id": "google/gemma-4-31b-it:thinking",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "structured_output": true,
+        "tool_call": false
+      },
+      "google/gemini-3.1-pro-preview-high": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
           "input": 2,
           "output": 12
         },
-        "id": "gemini-3-pro-preview-thinking",
-        "last_updated": "2025-11-18",
+        "id": "google/gemini-3.1-pro-preview-high",
+        "last_updated": "2026-02-21",
         "limit": {
           "context": 1048756,
           "input": 1048756,
@@ -22777,12 +23656,158 @@
             "text"
           ]
         },
-        "name": "Gemini 3 Pro Thinking",
+        "name": "Gemini 3.1 Pro (Preview High)",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-11-18",
+        "release_date": "2026-02-21",
         "structured_output": true,
         "tool_call": true
+      },
+      "qwen/qwen3.5-9b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.05,
+          "output": 0.15
+        },
+        "id": "qwen/qwen3.5-9b",
+        "last_updated": "2026-03-10",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 9B",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-10",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "qwen/qwen3.5-plus-thinking": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.04,
+          "input": 0.4,
+          "output": 2.4
+        },
+        "id": "qwen/qwen3.5-plus-thinking",
+        "last_updated": "2026-02-16",
+        "limit": {
+          "context": 983616,
+          "input": 983616,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 Plus Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-16",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Gemma-4-31B-it": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Gemma-4-31B-it",
+        "last_updated": "2026-04-09",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B IT",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-09",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "TheDrummer/Rocinante-12B-v1.1": {
+        "attachment": false,
+        "cost": {
+          "input": 0.408,
+          "output": 0.595
+        },
+        "id": "TheDrummer/Rocinante-12B-v1.1",
+        "last_updated": "2024-01-01",
+        "limit": {
+          "context": 16384,
+          "input": 16384,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Rocinante 12b",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-01-01",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "poolside/laguna-xs.2": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.3
+        },
+        "id": "poolside/laguna-xs.2",
+        "last_updated": "2026-04-29",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Laguna XS.2",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-04-29",
+        "structured_output": false,
+        "tool_call": false
       },
       "doubao-1-5-thinking-pro-250415": {
         "attachment": true,
@@ -22810,6 +23835,37 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-04-17",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.0306,
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled",
+        "last_updated": "2026-05-01",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B Claude 4.6 Opus Reasoning Distilled",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-01",
         "structured_output": false,
         "tool_call": false
       },
@@ -22871,18 +23927,47 @@
         "structured_output": true,
         "tool_call": true
       },
-      "Llama-3.3-70B-Anthrobomination": {
+      "google/gemma-4-31b-it": {
+        "attachment": true,
+        "cost": {
+          "input": 0.1,
+          "output": 0.35
+        },
+        "id": "google/gemma-4-31b-it",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "structured_output": true,
+        "tool_call": false
+      },
+      "qwen/qwen3-max": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 1.08018,
+          "output": 5.4009
         },
-        "id": "Llama-3.3-70B-Anthrobomination",
-        "last_updated": "2024-12-06",
+        "id": "qwen/qwen3-max",
+        "last_updated": "2025-09-05",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
+          "context": 256000,
+          "input": 256000,
+          "output": 32768
         },
         "modalities": {
           "input": [
@@ -22892,12 +23977,41 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Anthrobomination",
+        "name": "Qwen3 Max",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-12-06",
+        "release_date": "2025-09-05",
         "structured_output": false,
         "tool_call": false
+      },
+      "zai-org/glm-5-original:thinking": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 1,
+          "output": 3.2
+        },
+        "id": "zai-org/glm-5-original:thinking",
+        "last_updated": "2026-02-11",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 5 Original Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-11",
+        "structured_output": true,
+        "tool_call": true
       },
       "gemini-2.5-flash-preview-05-20:thinking": {
         "attachment": true,
@@ -22957,34 +24071,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-The-Omega-Directive-Unslop-v2.0": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-The-Omega-Directive-Unslop-v2.0",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Omega Directive Unslop v2.0",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
       "gemini-2.5-pro-exp-03-25": {
         "attachment": true,
         "cost": {
@@ -23011,6 +24097,36 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-03-25",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "qwen3.5-122b-a10b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.36,
+          "output": 2.88
+        },
+        "id": "qwen3.5-122b-a10b",
+        "last_updated": "2026-02-24",
+        "limit": {
+          "context": 260096,
+          "input": 260096,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 122B A10B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-02-24",
         "structured_output": false,
         "tool_call": false
       },
@@ -23132,6 +24248,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "zai-org/glm-4.6-original": {
+        "attachment": false,
+        "cost": {
+          "input": 0.35,
+          "output": 1.4
+        },
+        "id": "zai-org/glm-4.6-original",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 65535
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.6 Original",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-11",
+        "structured_output": false,
+        "tool_call": false
+      },
       "openai/gpt-5-codex": {
         "attachment": false,
         "cost": {
@@ -23161,6 +24305,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "NousResearch/Hermes-4-70B:thinking": {
+        "attachment": false,
+        "cost": {
+          "input": 0.2006,
+          "output": 0.3995
+        },
+        "id": "NousResearch/Hermes-4-70B:thinking",
+        "last_updated": "2025-09-17",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Hermes 4 (Thinking)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-09-17",
+        "structured_output": false,
+        "tool_call": false
+      },
       "Tongyi-Zhiwen/QwenLong-L1-32B": {
         "attachment": false,
         "cost": {
@@ -23187,34 +24359,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-01-25",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "GLM-4.5-Air-Derestricted-Iceblink-v2-ReExtract": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "GLM-4.5-Air-Derestricted-Iceblink-v2-ReExtract",
-        "last_updated": "2025-12-12",
-        "limit": {
-          "context": 131072,
-          "input": 131072,
-          "output": 65536
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GLM 4.5 Air Derestricted Iceblink v2 ReExtract",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-12-12",
         "structured_output": false,
         "tool_call": false
       },
@@ -23275,32 +24419,33 @@
         "structured_output": false,
         "tool_call": false
       },
-      "huihui-ai/Llama-3.1-Nemotron-70B-Instruct-HF-abliterated": {
-        "attachment": false,
+      "qwen3.5-flash:thinking": {
+        "attachment": true,
         "cost": {
-          "input": 0.7,
-          "output": 0.7
+          "input": 0.09,
+          "output": 0.36
         },
-        "family": "nemotron",
-        "id": "huihui-ai/Llama-3.1-Nemotron-70B-Instruct-HF-abliterated",
-        "last_updated": "2024-07-23",
+        "id": "qwen3.5-flash:thinking",
+        "last_updated": "2026-02-24",
         "limit": {
-          "context": 16384,
-          "input": 16384,
-          "output": 16384
+          "context": 991808,
+          "input": 991808,
+          "output": 65536
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Nemotron 3.1 70B abliterated",
+        "name": "Qwen3.5 Flash Thinking",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-07-23",
+        "reasoning": true,
+        "release_date": "2026-02-24",
         "structured_output": false,
         "tool_call": false
       },
@@ -23332,34 +24477,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Mhnnn-x1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Mhnnn-x1",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Mhnnn x1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
       "brave-research": {
         "attachment": false,
         "cost": {
@@ -23385,6 +24502,64 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2023-03-02",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "aion-labs/aion-2.0": {
+        "attachment": false,
+        "cost": {
+          "input": 0.8,
+          "output": 1.6
+        },
+        "id": "aion-labs/aion-2.0",
+        "last_updated": "2026-02-23",
+        "limit": {
+          "context": 131072,
+          "input": 131072,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "AionLabs: Aion-2.0",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-02-23",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Gemma-4-31B-DarkIdol": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Gemma-4-31B-DarkIdol",
+        "last_updated": "2026-05-01",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B DarkIdol",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-01",
         "structured_output": false,
         "tool_call": false
       },
@@ -23417,6 +24592,36 @@
         "structured_output": false,
         "tool_call": false
       },
+      "x-ai/grok-4.3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 1.25,
+          "output": 2.5
+        },
+        "id": "x-ai/grok-4.3",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 1000000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Grok 4.3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
+        "structured_output": true,
+        "tool_call": true
+      },
       "deepseek-ai/DeepSeek-V3.1-Terminus": {
         "attachment": false,
         "cost": {
@@ -23443,6 +24648,65 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-08-02",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "TEE/qwen3.5-27b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.3,
+          "output": 2.4
+        },
+        "id": "TEE/qwen3.5-27b",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B TEE",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-13",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "xiaomi/mimo-v2-pro": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 1,
+          "output": 3
+        },
+        "id": "xiaomi/mimo-v2-pro",
+        "last_updated": "2026-03-19",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiMo V2 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-19",
         "structured_output": true,
         "tool_call": true
       },
@@ -23533,35 +24797,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "TEE/glm-4.6": {
-        "attachment": false,
-        "cost": {
-          "input": 0.75,
-          "output": 2
-        },
-        "family": "glm",
-        "id": "TEE/glm-4.6",
-        "last_updated": "2025-09-30",
-        "limit": {
-          "context": 203000,
-          "input": 203000,
-          "output": 65535
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GLM 4.6 TEE",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-09-30",
-        "structured_output": false,
-        "tool_call": false
-      },
       "qwen/qwen3.5-397b-a17b": {
         "attachment": false,
         "cost": {
@@ -23618,63 +24853,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-08-19",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Mistral-Nemo-12B-Instruct-2407": {
-        "attachment": true,
-        "cost": {
-          "input": 0.01,
-          "output": 0.01
-        },
-        "id": "Mistral-Nemo-12B-Instruct-2407",
-        "last_updated": "2024-07-18",
-        "limit": {
-          "context": 16384,
-          "input": 16384,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Mistral Nemo 12B Instruct 2407",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-07-18",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Sapphira-0.2": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Sapphira-0.2",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Sapphira 0.2",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -23739,88 +24917,33 @@
         "structured_output": false,
         "tool_call": false
       },
-      "QwQ-32B-ArliAI-RpR-v1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.2,
-          "output": 0.2
-        },
-        "id": "QwQ-32B-ArliAI-RpR-v1",
-        "last_updated": "2025-02-17",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 32768
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "QwQ 32b Arli V1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-02-17",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "nvidia/Llama-3.1-Nemotron-Ultra-253B-v1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.4,
-          "output": 0.8
-        },
-        "family": "nemotron",
-        "id": "nvidia/Llama-3.1-Nemotron-Ultra-253B-v1",
-        "last_updated": "2025-07-03",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Nvidia Nemotron Ultra 253B",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-07-03",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Argunaut-1-SFT": {
-        "attachment": false,
+      "Qwen3.5-27B-BlueStar-Derestricted": {
+        "attachment": true,
         "cost": {
           "input": 0.306,
           "output": 0.306
         },
-        "id": "Llama-3.3-70B-Argunaut-1-SFT",
-        "last_updated": "2024-12-06",
+        "id": "Qwen3.5-27B-BlueStar-Derestricted",
+        "last_updated": "2026-04-06",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Argunaut 1 SFT",
+        "name": "Qwen3.5 27B BlueStar Derestricted",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
+        "reasoning": true,
+        "release_date": "2026-04-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -23853,6 +24976,64 @@
         "structured_output": false,
         "tool_call": false
       },
+      "minimax/minimax-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.06,
+          "input": 0.3,
+          "output": 1.2
+        },
+        "id": "minimax/minimax-latest",
+        "last_updated": "2026-05-03",
+        "limit": {
+          "context": 512000,
+          "input": 512000,
+          "output": 80000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-03",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "TheDrummer/Anubis-70B-v1": {
+        "attachment": false,
+        "cost": {
+          "input": 0.31,
+          "output": 0.31
+        },
+        "id": "TheDrummer/Anubis-70B-v1",
+        "last_updated": "2024-01-01",
+        "limit": {
+          "context": 65536,
+          "input": 65536,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Anubis 70B v1",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-01-01",
+        "structured_output": false,
+        "tool_call": false
+      },
       "doubao-1-5-thinking-pro-vision-250415": {
         "attachment": true,
         "cost": {
@@ -23879,34 +25060,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-04-15",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Gemma-3-27B-Nidum-Uncensored": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Gemma-3-27B-Nidum-Uncensored",
-        "last_updated": "2025-08-08",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 96000
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Gemma 3 27B Nidum Uncensored",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-08-08",
         "structured_output": false,
         "tool_call": false
       },
@@ -23940,16 +25093,16 @@
         "tool_call": false
       },
       "qwen/Qwen3.6-35B-A3B": {
-        "attachment": false,
+        "attachment": true,
         "cost": {
-          "input": 0.29,
-          "output": 1.74
+          "input": 0.112,
+          "output": 0.8
         },
-        "family": "qwen3.6",
         "id": "qwen/Qwen3.6-35B-A3B",
-        "last_updated": "2026-04-21",
+        "last_updated": "2026-04-17",
         "limit": {
           "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
@@ -23963,7 +25116,7 @@
           ]
         },
         "name": "Qwen3.6 35B A3B",
-        "open_weights": true,
+        "open_weights": false,
         "reasoning": false,
         "release_date": "2026-04-17",
         "structured_output": false,
@@ -23995,6 +25148,34 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-07-26",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "qwen/qwen3-14b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.08,
+          "output": 0.24
+        },
+        "id": "qwen/qwen3-14b",
+        "last_updated": "2024-01-01",
+        "limit": {
+          "context": 41000,
+          "input": 41000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen 3 14b",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-01-01",
         "structured_output": false,
         "tool_call": false
       },
@@ -24111,6 +25292,35 @@
         "structured_output": false,
         "tool_call": false
       },
+      "TEE/gemma-4-26b-a4b-uncensored": {
+        "attachment": true,
+        "cost": {
+          "input": 0.15,
+          "output": 0.7
+        },
+        "id": "TEE/gemma-4-26b-a4b-uncensored",
+        "last_updated": "2026-05-23",
+        "limit": {
+          "context": 65536,
+          "input": 65536,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 26B A4B Uncensored TEE",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-05-23",
+        "structured_output": true,
+        "tool_call": true
+      },
       "meta-llama/llama-3.2-3b-instruct": {
         "attachment": true,
         "cost": {
@@ -24170,18 +25380,48 @@
         "structured_output": false,
         "tool_call": false
       },
-      "GLM-4.5-Air-Derestricted-Steam-ReExtract": {
+      "TheDrummer/UnslopNemo-12B-v4.1": {
+        "attachment": true,
+        "cost": {
+          "input": 0.493,
+          "output": 0.493
+        },
+        "id": "TheDrummer/UnslopNemo-12B-v4.1",
+        "last_updated": "2024-01-01",
+        "limit": {
+          "context": 32768,
+          "input": 32768,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "UnslopNemo 12b v4",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-01-01",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "nanogpt/coding-router:max": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "cache_read": 0.5,
+          "input": 5,
+          "output": 30
         },
-        "id": "GLM-4.5-Air-Derestricted-Steam-ReExtract",
-        "last_updated": "2025-12-12",
+        "id": "nanogpt/coding-router:max",
+        "last_updated": "2026-05-12",
         "limit": {
-          "context": 131072,
-          "input": 131072,
-          "output": 65536
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
         },
         "modalities": {
           "input": [
@@ -24191,12 +25431,12 @@
             "text"
           ]
         },
-        "name": "GLM 4.5 Air Derestricted Steam ReExtract",
+        "name": "Coding Router Max",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-12-12",
-        "structured_output": false,
-        "tool_call": false
+        "reasoning": true,
+        "release_date": "2026-05-12",
+        "structured_output": true,
+        "tool_call": true
       },
       "TEE/gpt-oss-20b": {
         "attachment": false,
@@ -24224,34 +25464,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-08-05",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "doubao-seed-code-preview-latest": {
-        "attachment": false,
-        "cost": {
-          "input": 0.1,
-          "output": 0.4
-        },
-        "id": "doubao-seed-code-preview-latest",
-        "last_updated": "2025-11-13",
-        "limit": {
-          "context": 256000,
-          "input": 256000,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Doubao Seed Code Preview",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-11-13",
         "structured_output": false,
         "tool_call": false
       },
@@ -24341,6 +25553,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "stepfun-ai/step-3.5-flash-2603": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.3
+        },
+        "id": "stepfun-ai/step-3.5-flash-2603",
+        "last_updated": "2026-04-14",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 256000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Step 3.5 Flash 2603",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-14",
+        "structured_output": false,
+        "tool_call": false
+      },
       "mistralai/codestral-2508": {
         "attachment": false,
         "cost": {
@@ -24369,6 +25609,35 @@
         "release_date": "2025-08-01",
         "structured_output": false,
         "tool_call": false
+      },
+      "x-ai/grok-4.20": {
+        "attachment": true,
+        "cost": {
+          "input": 2,
+          "output": 6
+        },
+        "id": "x-ai/grok-4.20",
+        "last_updated": "2026-03-31",
+        "limit": {
+          "context": 2000000,
+          "input": 2000000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Grok 4.20",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-31",
+        "structured_output": true,
+        "tool_call": true
       },
       "qwen-max": {
         "attachment": false,
@@ -24428,34 +25697,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Vulpecula-R1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Vulpecula-R1",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Vulpecula R1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
       "deepseek/deepseek-v3.2-speciale": {
         "attachment": true,
         "cost": {
@@ -24483,34 +25724,6 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-12-02",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-RAWMAW": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-RAWMAW",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B RAWMAW",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -24543,31 +25756,34 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-MiraiFanfare": {
-        "attachment": false,
+      "qwen3.5-omni-flash": {
+        "attachment": true,
         "cost": {
-          "input": 0.493,
-          "output": 0.493
+          "input": 0,
+          "output": 0
         },
-        "id": "Llama-3.3-70B-MiraiFanfare",
-        "last_updated": "2025-07-26",
+        "id": "qwen3.5-omni-flash",
+        "last_updated": "2026-03-30",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 49152,
+          "input": 49152,
           "output": 16384
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video",
+            "audio"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Llama 3.3 70b Mirai Fanfare",
+        "name": "Qwen3.5 Omni Flash",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-07-26",
+        "release_date": "2026-03-30",
         "structured_output": false,
         "tool_call": false
       },
@@ -24658,6 +25874,125 @@
         "structured_output": false,
         "tool_call": false
       },
+      "nanogpt/coding-router:low": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.028,
+          "input": 0.14,
+          "output": 0.28
+        },
+        "id": "nanogpt/coding-router:low",
+        "last_updated": "2026-05-12",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Coding Router Low",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-12",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4.8:thinking": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.4998,
+          "input": 4.998,
+          "output": 25.007
+        },
+        "id": "anthropic/claude-opus-4.8:thinking",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8 Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "inclusionai/ling-2.6-1t": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.06,
+          "input": 0.3,
+          "output": 2.5
+        },
+        "id": "inclusionai/ling-2.6-1t",
+        "last_updated": "2026-04-23",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Ling 2.6 1T",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-04-23",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "qwen3.5-35b-a3b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.225,
+          "output": 1.8
+        },
+        "id": "qwen3.5-35b-a3b",
+        "last_updated": "2026-02-24",
+        "limit": {
+          "context": 260096,
+          "input": 260096,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 35B A3B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-02-24",
+        "structured_output": false,
+        "tool_call": false
+      },
       "dmind/dmind-1-mini": {
         "attachment": false,
         "cost": {
@@ -24718,47 +26053,49 @@
         "structured_output": true,
         "tool_call": true
       },
-      "grok-3-beta": {
-        "attachment": false,
+      "qwen3.7-plus:thinking": {
+        "attachment": true,
         "cost": {
-          "input": 3,
-          "output": 15
+          "cache_read": 0.04,
+          "input": 0.4,
+          "output": 1.6
         },
-        "id": "grok-3-beta",
-        "last_updated": "2025-09-29",
+        "id": "qwen3.7-plus:thinking",
+        "last_updated": "2026-06-01",
         "limit": {
-          "context": 131072,
-          "input": 131072,
-          "output": 131072
+          "context": 983616,
+          "input": 983616,
+          "output": 65536
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Grok 3 Beta",
+        "name": "Qwen3.7 Plus Thinking",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-09-29",
+        "reasoning": true,
+        "release_date": "2026-06-01",
         "structured_output": false,
         "tool_call": false
       },
-      "TheDrummer 2/Cydonia-24B-v2": {
+      "zai-org/glm-4.7-flash-original:thinking": {
         "attachment": false,
         "cost": {
-          "input": 0.1003,
-          "output": 0.1207
+          "input": 0.07,
+          "output": 0.4
         },
-        "family": "llama",
-        "id": "TheDrummer 2/Cydonia-24B-v2",
-        "last_updated": "2025-02-17",
+        "id": "zai-org/glm-4.7-flash-original:thinking",
+        "last_updated": "2026-01-19",
         "limit": {
-          "context": 16384,
-          "input": 16384,
-          "output": 32768
+          "context": 200000,
+          "input": 200000,
+          "output": 128000
         },
         "modalities": {
           "input": [
@@ -24768,10 +26105,38 @@
             "text"
           ]
         },
-        "name": "The Drummer Cydonia 24B v2",
+        "name": "GLM 4.7 Flash Original Thinking",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-02-17",
+        "reasoning": true,
+        "release_date": "2026-01-19",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "mirothinker-1-7-deepresearch-mini": {
+        "attachment": false,
+        "cost": {
+          "input": 1.25,
+          "output": 10
+        },
+        "id": "mirothinker-1-7-deepresearch-mini",
+        "last_updated": "2026-05-11",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiroThinker 1.7 Deep Research Mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-11",
         "structured_output": false,
         "tool_call": false
       },
@@ -24803,6 +26168,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "bytedance-seed/seed-2.0-lite": {
+        "attachment": false,
+        "cost": {
+          "input": 0.25,
+          "output": 2
+        },
+        "id": "bytedance-seed/seed-2.0-lite",
+        "last_updated": "2026-03-10",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "ByteDance Seed 2.0 Lite",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-10",
+        "structured_output": true,
+        "tool_call": false
+      },
       "KAT-Coder-Exp-72B-1010": {
         "attachment": false,
         "cost": {
@@ -24830,35 +26223,6 @@
         "release_date": "2025-10-28",
         "structured_output": false,
         "tool_call": false
-      },
-      "meituan-longcat/LongCat-Flash-Chat-FP8": {
-        "attachment": false,
-        "cost": {
-          "input": 0.15,
-          "output": 0.7
-        },
-        "family": "longcat",
-        "id": "meituan-longcat/LongCat-Flash-Chat-FP8",
-        "last_updated": "2025-08-31",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 32768
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "LongCat Flash",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-08-31",
-        "structured_output": true,
-        "tool_call": true
       },
       "v0-1.5-md": {
         "attachment": false,
@@ -24917,6 +26281,36 @@
         "release_date": "2025-09-25",
         "structured_output": true,
         "tool_call": true
+      },
+      "gemma-4-31B-K1-v5": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "gemma-4-31B-K1-v5",
+        "last_updated": "2026-05-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B K1 v5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-02",
+        "structured_output": false,
+        "tool_call": false
       },
       "claude-opus-4-20250514": {
         "attachment": true,
@@ -24977,6 +26371,35 @@
         "structured_output": false,
         "tool_call": false
       },
+      "sarvam-30b": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.017,
+          "input": 0.028,
+          "output": 0.111
+        },
+        "id": "sarvam-30b",
+        "last_updated": "2026-05-12",
+        "limit": {
+          "context": 65536,
+          "input": 65536,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Sarvam 30B",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-12",
+        "structured_output": false,
+        "tool_call": true
+      },
       "deepseek-reasoner-cheaper": {
         "attachment": false,
         "cost": {
@@ -25005,6 +26428,64 @@
         "structured_output": false,
         "tool_call": false
       },
+      "qwen/Qwen3-VL-235B-A22B-Instruct": {
+        "attachment": true,
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "id": "qwen/Qwen3-VL-235B-A22B-Instruct",
+        "last_updated": "2024-01-01",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3 VL 235B A22B Instruct",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-01-01",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "TEE/deepseek-v4-pro": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.15,
+          "input": 1.5,
+          "output": 5.25
+        },
+        "id": "TEE/deepseek-v4-pro",
+        "last_updated": "2026-04-25",
+        "limit": {
+          "context": 800000,
+          "input": 800000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro TEE",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-25",
+        "structured_output": true,
+        "tool_call": true
+      },
       "claude-sonnet-4-5-20250929-thinking": {
         "attachment": true,
         "cost": {
@@ -25032,6 +26513,35 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-09-29",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "z-ai/glm-5-turbo": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.24,
+          "input": 1.2,
+          "output": 4
+        },
+        "id": "z-ai/glm-5-turbo",
+        "last_updated": "2026-03-15",
+        "limit": {
+          "context": 202800,
+          "input": 202800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 5 Turbo",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-15",
         "structured_output": true,
         "tool_call": true
       },
@@ -25094,18 +26604,18 @@
         "structured_output": true,
         "tool_call": true
       },
-      "Llama-3.3-70B-Dark-Ages-v0.1": {
+      "TheDrummer/Cydonia-24B-v4": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 0.2006,
+          "output": 0.2414
         },
-        "id": "Llama-3.3-70B-Dark-Ages-v0.1",
-        "last_updated": "2024-12-06",
+        "id": "TheDrummer/Cydonia-24B-v4",
+        "last_updated": "2025-07-22",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
+          "context": 16384,
+          "input": 16384,
+          "output": 32768
         },
         "modalities": {
           "input": [
@@ -25115,10 +26625,68 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Dark Ages v0.1",
+        "name": "The Drummer Cydonia 24B v4",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-12-06",
+        "release_date": "2025-07-22",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "inclusionai/ring-2.6-1t": {
+        "attachment": false,
+        "cost": {
+          "input": 1,
+          "output": 3
+        },
+        "id": "inclusionai/ring-2.6-1t",
+        "last_updated": "2026-05-08",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Ring 2.6 1T",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-08",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "qwen3.5-27b:thinking": {
+        "attachment": true,
+        "cost": {
+          "input": 0.27,
+          "output": 2.16
+        },
+        "id": "qwen3.5-27b:thinking",
+        "last_updated": "2026-02-24",
+        "limit": {
+          "context": 260096,
+          "input": 260096,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-24",
         "structured_output": false,
         "tool_call": false
       },
@@ -25152,34 +26720,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Forgotten-Safeword-3.6": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Forgotten-Safeword-3.6",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Forgotten Safeword 3.6",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
       "minimax/minimax-01": {
         "attachment": true,
         "cost": {
@@ -25210,33 +26750,36 @@
         "structured_output": false,
         "tool_call": false
       },
-      "sarvan-medium": {
-        "attachment": false,
+      "openai/gpt-5.3-codex": {
+        "attachment": true,
         "cost": {
-          "input": 0.25,
-          "output": 0.75
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
         },
-        "id": "sarvan-medium",
-        "last_updated": "2025-01-01",
+        "id": "openai/gpt-5.3-codex",
+        "last_updated": "2026-02-24",
         "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 16384
+          "context": 400000,
+          "input": 400000,
+          "output": 128000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Sarvam Medium",
+        "name": "GPT 5.3 Codex",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-01-01",
-        "structured_output": false,
-        "tool_call": false
+        "reasoning": true,
+        "release_date": "2026-02-24",
+        "structured_output": true,
+        "tool_call": true
       },
       "sonar": {
         "attachment": false,
@@ -25326,6 +26869,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "zai-org/glm-4.7:thinking": {
+        "attachment": false,
+        "cost": {
+          "input": 0.2,
+          "output": 0.8
+        },
+        "id": "zai-org/glm-4.7:thinking",
+        "last_updated": "2025-12-22",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 65535
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.7 Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-22",
+        "structured_output": true,
+        "tool_call": true
+      },
       "venice-uncensored:web": {
         "attachment": false,
         "cost": {
@@ -25412,31 +26983,33 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3+(3.1v3.3)-70B-Hanami-x1": {
-        "attachment": false,
+      "Qwen3.5-27B-NaNovel-Derestricted": {
+        "attachment": true,
         "cost": {
           "input": 0.306,
           "output": 0.306
         },
-        "id": "Llama-3.3+(3.1v3.3)-70B-Hanami-x1",
-        "last_updated": "2024-12-06",
+        "id": "Qwen3.5-27B-NaNovel-Derestricted",
+        "last_updated": "2026-04-30",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Llama 3.3+ 70B Hanami x1",
+        "name": "Qwen3.5 27B NaNovel Derestricted",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
+        "reasoning": true,
+        "release_date": "2026-04-30",
         "structured_output": false,
         "tool_call": false
       },
@@ -25497,6 +27070,36 @@
         "structured_output": false,
         "tool_call": false
       },
+      "minimax/minimax-m3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.06,
+          "input": 0.3,
+          "output": 1.2
+        },
+        "id": "minimax/minimax-m3",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 512000,
+          "input": 512000,
+          "output": 80000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax M3",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-06-01",
+        "structured_output": true,
+        "tool_call": true
+      },
       "MarinaraSpaghetti/NemoMix-Unleashed-12B": {
         "attachment": false,
         "cost": {
@@ -25526,46 +27129,18 @@
         "structured_output": false,
         "tool_call": false
       },
-      "GLM-4.5-Air-Derestricted-Steam": {
+      "TheDrummer/Cydonia-24B-v4.3": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 0.1003,
+          "output": 0.1207
         },
-        "id": "GLM-4.5-Air-Derestricted-Steam",
-        "last_updated": "2025-07-28",
-        "limit": {
-          "context": 220600,
-          "input": 220600,
-          "output": 65536
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GLM 4.5 Air Derestricted Steam",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-07-28",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Cirrus-x1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Cirrus-x1",
-        "last_updated": "2024-12-06",
+        "id": "TheDrummer/Cydonia-24B-v4.3",
+        "last_updated": "2025-12-25",
         "limit": {
           "context": 32768,
           "input": 32768,
-          "output": 16384
+          "output": 32768
         },
         "modalities": {
           "input": [
@@ -25575,39 +27150,10 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Cirrus x1",
+        "name": "The Drummer Cydonia 24B v4.3",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "allenai/olmo-3.1-32b-think": {
-        "attachment": false,
-        "cost": {
-          "input": 0.15,
-          "output": 0.5
-        },
-        "family": "allenai",
-        "id": "allenai/olmo-3.1-32b-think",
-        "last_updated": "2026-01-25",
-        "limit": {
-          "context": 65536,
-          "input": 65536,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Olmo 3.1 32B Think",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2026-01-25",
+        "release_date": "2025-12-25",
         "structured_output": false,
         "tool_call": false
       },
@@ -25697,63 +27243,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Strawberrylemonade-v1.2": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Strawberrylemonade-v1.2",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B StrawberryLemonade v1.2",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "deepcogito/cogito-v2.1-671b": {
-        "attachment": false,
-        "cost": {
-          "input": 1.25,
-          "output": 1.25
-        },
-        "family": "cogito",
-        "id": "deepcogito/cogito-v2.1-671b",
-        "last_updated": "2025-11-19",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Cogito v2.1 671B MoE",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-11-19",
-        "structured_output": false,
-        "tool_call": false
-      },
       "nex-agi/deepseek-v3.1-nex-n1": {
         "attachment": false,
         "cost": {
@@ -25810,6 +27299,35 @@
         "release_date": "2025-02-19",
         "structured_output": false,
         "tool_call": false
+      },
+      "holo3-35b-a3b:thinking": {
+        "attachment": true,
+        "cost": {
+          "input": 0.25,
+          "output": 1.8
+        },
+        "id": "holo3-35b-a3b:thinking",
+        "last_updated": "2024-01-01",
+        "limit": {
+          "context": 65536,
+          "input": 65536,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Holo3-35B-A3B Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-01-01",
+        "structured_output": true,
+        "tool_call": true
       },
       "minimax/minimax-m2.1": {
         "attachment": false,
@@ -25984,34 +27502,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Gemma-3-27B-ArliAI-RPMax-v3": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Gemma-3-27B-ArliAI-RPMax-v3",
-        "last_updated": "2025-07-03",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Gemma 3 27B RPMax v3",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-07-03",
-        "structured_output": false,
-        "tool_call": false
-      },
       "claude-opus-4-thinking:8192": {
         "attachment": true,
         "cost": {
@@ -26072,6 +27562,66 @@
         "structured_output": true,
         "tool_call": true
       },
+      "google/gemini-3.5-flash-thinking": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.15,
+          "input": 1.5,
+          "output": 9
+        },
+        "id": "google/gemini-3.5-flash-thinking",
+        "last_updated": "2026-05-19",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.5 Flash Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-19",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "google/gemini-pro-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 2,
+          "output": 12
+        },
+        "id": "google/gemini-pro-latest",
+        "last_updated": "2026-03-29",
+        "limit": {
+          "context": 1048756,
+          "input": 1048756,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Pro Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-29",
+        "structured_output": true,
+        "tool_call": true
+      },
       "google/gemini-3-flash-preview-thinking": {
         "attachment": true,
         "cost": {
@@ -26101,6 +27651,35 @@
         "release_date": "2025-12-17",
         "structured_output": false,
         "tool_call": false
+      },
+      "nanogpt/coding-router": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.11,
+          "input": 1.1,
+          "output": 2.2
+        },
+        "id": "nanogpt/coding-router",
+        "last_updated": "2026-05-12",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Coding Router",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-12",
+        "structured_output": true,
+        "tool_call": true
       },
       "TEE/kimi-k2.5": {
         "attachment": false,
@@ -26189,18 +27768,18 @@
         "structured_output": true,
         "tool_call": true
       },
-      "Llama-3.3-70B-MS-Nevoria": {
+      "qwen/Qwen3-Next-80B-A3B-Instruct": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 0.15,
+          "output": 0.65
         },
-        "id": "Llama-3.3-70B-MS-Nevoria",
-        "last_updated": "2024-12-06",
+        "id": "qwen/Qwen3-Next-80B-A3B-Instruct",
+        "last_updated": "2025-09-11",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
+          "context": 256000,
+          "input": 256000,
+          "output": 262144
         },
         "modalities": {
           "input": [
@@ -26210,10 +27789,69 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 70B MS Nevoria",
+        "name": "Qwen3 Next 80B A3B (Instruct)",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-12-06",
+        "release_date": "2025-09-11",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "Qwen3.5-27B-Queen-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Queen-Derestricted",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Queen Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "zai-org/glm-4.6v": {
+        "attachment": true,
+        "cost": {
+          "input": 0.3,
+          "output": 0.9
+        },
+        "id": "zai-org/glm-4.6v",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 24000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.6V",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-12-11",
         "structured_output": false,
         "tool_call": false
       },
@@ -26272,6 +27910,35 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-09-18",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "tencent/hy3-preview": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.029,
+          "input": 0.066,
+          "output": 0.26
+        },
+        "id": "tencent/hy3-preview",
+        "last_updated": "2026-04-23",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Tencent: Hy3 preview",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-04-23",
         "structured_output": false,
         "tool_call": false
       },
@@ -26361,6 +28028,37 @@
         "structured_output": false,
         "tool_call": false
       },
+      "ernie-5.1:thinking": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.75,
+          "input": 0.75,
+          "output": 3
+        },
+        "id": "ernie-5.1:thinking",
+        "last_updated": "2026-05-10",
+        "limit": {
+          "context": 119000,
+          "input": 119000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "ERNIE 5.1 Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-10",
+        "structured_output": false,
+        "tool_call": false
+      },
       "inflection/inflection-3-pi": {
         "attachment": false,
         "cost": {
@@ -26447,6 +28145,35 @@
         "structured_output": false,
         "tool_call": false
       },
+      "qwen3.7-max:thinking": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.25,
+          "input": 2.5,
+          "output": 7.5
+        },
+        "id": "qwen3.7-max:thinking",
+        "last_updated": "2026-05-21",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7 Max Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-21",
+        "structured_output": false,
+        "tool_call": false
+      },
       "amazon/nova-pro-v1": {
         "attachment": false,
         "cost": {
@@ -26476,6 +28203,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "inclusionai/ling-2.6-flash": {
+        "attachment": false,
+        "cost": {
+          "input": 0.08,
+          "output": 0.24
+        },
+        "id": "inclusionai/ling-2.6-flash",
+        "last_updated": "2026-04-21",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Ling 2.6 Flash",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-04-21",
+        "structured_output": true,
+        "tool_call": true
+      },
       "doubao-seed-1-8-251215": {
         "attachment": false,
         "cost": {
@@ -26501,63 +28256,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-12-15",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Gemma-3-27B-it-Abliterated": {
-        "attachment": false,
-        "cost": {
-          "input": 0.42,
-          "output": 0.42
-        },
-        "id": "Gemma-3-27B-it-Abliterated",
-        "last_updated": "2025-07-03",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 96000
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Gemma 3 27B IT Abliterated",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-07-03",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "tngtech/DeepSeek-TNG-R1T2-Chimera": {
-        "attachment": false,
-        "cost": {
-          "input": 0.31,
-          "output": 0.31
-        },
-        "family": "tngtech",
-        "id": "tngtech/DeepSeek-TNG-R1T2-Chimera",
-        "last_updated": "2025-09-05",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "DeepSeek TNG R1T2 Chimera",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-09-05",
         "structured_output": false,
         "tool_call": false
       },
@@ -26621,6 +28319,125 @@
         "structured_output": false,
         "tool_call": false
       },
+      "z-ai/glm-5v-turbo:thinking": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.24,
+          "input": 1.2,
+          "output": 4
+        },
+        "id": "z-ai/glm-5v-turbo:thinking",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 202800,
+          "input": 202800,
+          "output": 131100
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 5V Turbo Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "x-ai/grok-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 1.25,
+          "output": 2.5
+        },
+        "id": "x-ai/grok-latest",
+        "last_updated": "2026-05-03",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 1000000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Grok Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-03",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "deepseek/deepseek-v4-pro-cheaper": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.003625,
+          "input": 0.435,
+          "output": 0.87
+        },
+        "id": "deepseek/deepseek-v4-pro-cheaper",
+        "last_updated": "2026-04-25",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro Cheaper",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-25",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted",
+        "last_updated": "2026-05-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Omega Evolution v2.2 Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-02",
+        "structured_output": false,
+        "tool_call": false
+      },
       "THUDM/GLM-Z1-9B-0414": {
         "attachment": false,
         "cost": {
@@ -26679,35 +28496,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "TEE/kimi-k2-thinking": {
-        "attachment": false,
-        "cost": {
-          "input": 2,
-          "output": 2
-        },
-        "family": "kimi-thinking",
-        "id": "TEE/kimi-k2-thinking",
-        "last_updated": "2025-11-06",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 65535
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Kimi K2 Thinking TEE",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-11-06",
-        "structured_output": false,
-        "tool_call": false
-      },
       "glm-4-airx": {
         "attachment": false,
         "cost": {
@@ -26761,6 +28549,34 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-10-16",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "TheDrummer/Cydonia-24B-v4.1": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1003,
+          "output": 0.1207
+        },
+        "id": "TheDrummer/Cydonia-24B-v4.1",
+        "last_updated": "2025-08-19",
+        "limit": {
+          "context": 16384,
+          "input": 16384,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "The Drummer Cydonia 24B v4.1",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-08-19",
         "structured_output": false,
         "tool_call": false
       },
@@ -26849,6 +28665,95 @@
         "structured_output": false,
         "tool_call": false
       },
+      "perceptron/perceptron-mk1": {
+        "attachment": true,
+        "cost": {
+          "input": 0.15,
+          "output": 1.5
+        },
+        "id": "perceptron/perceptron-mk1",
+        "last_updated": "2026-05-12",
+        "limit": {
+          "context": 32768,
+          "input": 32768,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Perceptron Mk1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-12",
+        "structured_output": true,
+        "tool_call": false
+      },
+      "anthropic/claude-sonnet-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2992,
+          "input": 2.992,
+          "output": 14.994
+        },
+        "id": "anthropic/claude-sonnet-latest",
+        "last_updated": "2026-03-01",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-01",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "mirothinker-1-7-deepresearch": {
+        "attachment": false,
+        "cost": {
+          "input": 4,
+          "output": 25
+        },
+        "id": "mirothinker-1-7-deepresearch",
+        "last_updated": "2026-05-11",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiroThinker 1.7 Deep Research",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-11",
+        "structured_output": false,
+        "tool_call": false
+      },
       "huihui-ai/Llama-3.3-70B-Instruct-abliterated": {
         "attachment": false,
         "cost": {
@@ -26910,91 +28815,65 @@
         "structured_output": true,
         "tool_call": true
       },
-      "TheDrummer 2/Cydonia-24B-v4.3": {
-        "attachment": false,
+      "Gemma-4-31B-GarnetV2": {
+        "attachment": true,
         "cost": {
-          "input": 0.1003,
-          "output": 0.1207
+          "input": 0.306,
+          "output": 0.306
         },
-        "family": "llama",
-        "id": "TheDrummer 2/Cydonia-24B-v4.3",
-        "last_updated": "2025-12-25",
+        "id": "Gemma-4-31B-GarnetV2",
+        "last_updated": "2026-05-01",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 32768
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "The Drummer Cydonia 24B v4.3",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-12-25",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "grok-3-mini-fast-beta": {
-        "attachment": false,
-        "cost": {
-          "input": 0.6,
-          "output": 4
-        },
-        "id": "grok-3-mini-fast-beta",
-        "last_updated": "2025-02-17",
-        "limit": {
-          "context": 131072,
-          "input": 131072,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Grok 3 Mini Fast Beta",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-02-17",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "baidu/ernie-4.5-300b-a47b": {
-        "attachment": false,
-        "cost": {
-          "input": 0.35,
-          "output": 1.15
-        },
-        "family": "ernie",
-        "id": "baidu/ernie-4.5-300b-a47b",
-        "last_updated": "2025-06-30",
-        "limit": {
-          "context": 131072,
-          "input": 131072,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "ERNIE 4.5 300B",
+        "name": "Gemma 4 31B Garnet V2",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-06-30",
+        "reasoning": true,
+        "release_date": "2026-05-01",
         "structured_output": false,
         "tool_call": false
+      },
+      "google/gemini-3.1-pro-preview-customtools": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 2,
+          "output": 12
+        },
+        "id": "google/gemini-3.1-pro-preview-customtools",
+        "last_updated": "2026-02-27",
+        "limit": {
+          "context": 1048756,
+          "input": 1048756,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Pro (Preview Custom Tools)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-27",
+        "structured_output": true,
+        "tool_call": true
       },
       "auto-model-premium": {
         "attachment": false,
@@ -27053,19 +28932,48 @@
         "structured_output": false,
         "tool_call": false
       },
-      "x-ai/grok-4.1-fast-reasoning": {
+      "deepseek/deepseek-v4-flash": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.028,
+          "input": 0.14,
+          "output": 0.28
+        },
+        "id": "deepseek/deepseek-v4-flash",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "moonshotai/kimi-latest": {
         "attachment": true,
         "cost": {
-          "input": 0.2,
-          "output": 0.5
+          "cache_read": 0.125,
+          "input": 0.5,
+          "output": 2.6
         },
-        "family": "grok",
-        "id": "x-ai/grok-4.1-fast-reasoning",
-        "last_updated": "2025-11-20",
+        "id": "moonshotai/kimi-latest",
+        "last_updated": "2026-05-03",
         "limit": {
-          "context": 2000000,
-          "input": 2000000,
-          "output": 131072
+          "context": 256000,
+          "input": 256000,
+          "output": 65536
         },
         "modalities": {
           "input": [
@@ -27076,12 +28984,12 @@
             "text"
           ]
         },
-        "name": "Grok 4.1 Fast Reasoning",
+        "name": "Kimi Latest",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-11-20",
+        "release_date": "2026-05-03",
         "structured_output": false,
-        "tool_call": false
+        "tool_call": true
       },
       "Gryphe/MythoMax-L2-13b": {
         "attachment": false,
@@ -27141,19 +29049,19 @@
         "structured_output": false,
         "tool_call": false
       },
-      "ReadyArt/The-Omega-Abomination-L-70B-v1.0": {
+      "deepseek/deepseek-latest": {
         "attachment": false,
         "cost": {
-          "input": 0.7,
-          "output": 0.95
+          "cache_read": 0.11,
+          "input": 1.1,
+          "output": 2.2
         },
-        "family": "llama",
-        "id": "ReadyArt/The-Omega-Abomination-L-70B-v1.0",
-        "last_updated": "2024-12-01",
+        "id": "deepseek/deepseek-latest",
+        "last_updated": "2026-05-03",
         "limit": {
-          "context": 16384,
-          "input": 16384,
-          "output": 16384
+          "context": 1048576,
+          "input": 1048576,
+          "output": 384000
         },
         "modalities": {
           "input": [
@@ -27163,25 +29071,26 @@
             "text"
           ]
         },
-        "name": "The Omega Abomination V1",
+        "name": "DeepSeek Latest",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-01",
-        "structured_output": false,
-        "tool_call": false
+        "reasoning": true,
+        "release_date": "2026-05-03",
+        "structured_output": true,
+        "tool_call": true
       },
-      "GLM-4.5-Air-Derestricted-Iceblink": {
+      "aion-labs/aion-2.5": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "cache_read": 0.35,
+          "input": 1,
+          "output": 3
         },
-        "id": "GLM-4.5-Air-Derestricted-Iceblink",
-        "last_updated": "2025-07-28",
+        "id": "aion-labs/aion-2.5",
+        "last_updated": "2026-03-20",
         "limit": {
           "context": 131072,
           "input": 131072,
-          "output": 98304
+          "output": 32768
         },
         "modalities": {
           "input": [
@@ -27191,10 +29100,38 @@
             "text"
           ]
         },
-        "name": "GLM 4.5 Air Derestricted Iceblink",
+        "name": "AionLabs: Aion-2.5",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-07-28",
+        "release_date": "2026-03-20",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "qwen/qwen3-30b-a3b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.3
+        },
+        "id": "qwen/qwen3-30b-a3b",
+        "last_updated": "2025-02-27",
+        "limit": {
+          "context": 41000,
+          "input": 41000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3 30B A3B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-02-27",
         "structured_output": false,
         "tool_call": false
       },
@@ -27287,6 +29224,93 @@
         "structured_output": false,
         "tool_call": false
       },
+      "NousResearch/hermes-4-70b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.2006,
+          "output": 0.3995
+        },
+        "id": "NousResearch/hermes-4-70b",
+        "last_updated": "2025-07-03",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Hermes 4 Medium",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-07-03",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "TEE/gemma4-31b:thinking": {
+        "attachment": false,
+        "cost": {
+          "input": 0.45,
+          "output": 1
+        },
+        "id": "TEE/gemma4-31b:thinking",
+        "last_updated": "2026-05-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B Thinking TEE",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-02",
+        "structured_output": true,
+        "tool_call": false
+      },
+      "openai/gpt-5.5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "input": 5,
+          "output": 30
+        },
+        "id": "openai/gpt-5.5",
+        "last_updated": "2026-04-23",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT 5.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-23",
+        "structured_output": true,
+        "tool_call": true
+      },
       "openai/o1-pro": {
         "attachment": true,
         "cost": {
@@ -27317,6 +29341,36 @@
         "release_date": "2025-01-25",
         "structured_output": false,
         "tool_call": false
+      },
+      "nvidia/nemotron-3-super-120b-a12b:thinking": {
+        "attachment": false,
+        "cost": {
+          "input": 0.05,
+          "output": 0.25
+        },
+        "family": "nemotron",
+        "id": "nvidia/nemotron-3-super-120b-a12b:thinking",
+        "last_updated": "2026-03-01",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nvidia Nemotron 3 Super 120B Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-01",
+        "structured_output": false,
+        "temperature": true,
+        "tool_call": true
       },
       "exa-answer": {
         "attachment": false,
@@ -27377,6 +29431,37 @@
         "structured_output": true,
         "tool_call": true
       },
+      "qwen/qwen3.5-plus": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.04,
+          "input": 0.4,
+          "output": 2.4
+        },
+        "id": "qwen/qwen3.5-plus",
+        "last_updated": "2026-02-16",
+        "limit": {
+          "context": 983616,
+          "input": 983616,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 Plus",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-02-16",
+        "structured_output": false,
+        "tool_call": false
+      },
       "dmind/dmind-1": {
         "attachment": false,
         "cost": {
@@ -27403,36 +29488,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-06-01",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "x-ai/grok-4-07-09": {
-        "attachment": true,
-        "cost": {
-          "input": 3,
-          "output": 15
-        },
-        "family": "grok",
-        "id": "x-ai/grok-4-07-09",
-        "last_updated": "2025-07-09",
-        "limit": {
-          "context": 256000,
-          "input": 256000,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Grok 4",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-07-09",
         "structured_output": false,
         "tool_call": false
       },
@@ -27523,30 +29578,6 @@
         "release_date": "2025-05-22",
         "structured_output": true,
         "tool_call": true
-      },
-      "hidream": {
-        "attachment": true,
-        "id": "hidream",
-        "last_updated": "2024-01-01",
-        "limit": {
-          "context": 0,
-          "output": 0
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "image"
-          ]
-        },
-        "name": "Hidream",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-01-01",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
       },
       "hunyuan-turbos-20250226": {
         "attachment": false,
@@ -27721,6 +29752,35 @@
         "structured_output": false,
         "tool_call": false
       },
+      "zai-org/glm-4.7-original:thinking": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.11,
+          "input": 0.6,
+          "output": 2.2
+        },
+        "id": "zai-org/glm-4.7-original:thinking",
+        "last_updated": "2025-12-22",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 65535
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.7 Original Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-22",
+        "structured_output": true,
+        "tool_call": true
+      },
       "azure-gpt-4o-mini": {
         "attachment": true,
         "cost": {
@@ -27780,46 +29840,48 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Electra-R1": {
-        "attachment": false,
+      "Gemma-4-31B-Musica-v1": {
+        "attachment": true,
         "cost": {
           "input": 0.306,
           "output": 0.306
         },
-        "id": "Llama-3.3-70B-Electra-R1",
-        "last_updated": "2024-12-06",
+        "id": "Gemma-4-31B-Musica-v1",
+        "last_updated": "2026-05-01",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Electra R1",
+        "name": "Gemma 4 31B Musica v1",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
+        "reasoning": true,
+        "release_date": "2026-05-01",
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Legion-V2.1": {
+      "zai-org/GLM-4.5-Air:thinking": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 0.12,
+          "output": 0.8
         },
-        "id": "Llama-3.3-70B-Legion-V2.1",
-        "last_updated": "2024-12-06",
+        "id": "zai-org/GLM-4.5-Air:thinking",
+        "last_updated": "2024-01-01",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
+          "context": 128000,
+          "input": 128000,
+          "output": 98304
         },
         "modalities": {
           "input": [
@@ -27829,12 +29891,12 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Legion V2.1",
+        "name": "GLM 4.5 Air (Thinking)",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
+        "reasoning": true,
+        "release_date": "2024-01-01",
+        "structured_output": true,
+        "tool_call": true
       },
       "claude-opus-4-thinking:1024": {
         "attachment": true,
@@ -27866,6 +29928,64 @@
         "structured_output": true,
         "tool_call": true
       },
+      "Qwen3.5-27B-Marvin-DPO-V2-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Marvin-DPO-V2-Derestricted",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Marvin DPO V2 Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "zai-org/GLM-4.6-turbo": {
+        "attachment": false,
+        "cost": {
+          "input": 1,
+          "output": 3
+        },
+        "id": "zai-org/GLM-4.6-turbo",
+        "last_updated": "2025-10-02",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 204800
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.6 Turbo",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-10-02",
+        "structured_output": false,
+        "tool_call": false
+      },
       "Alibaba-NLP/Tongyi-DeepResearch-30B-A3B": {
         "attachment": false,
         "cost": {
@@ -27895,64 +30015,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "TheDrummer 2/Cydonia-24B-v4": {
-        "attachment": false,
-        "cost": {
-          "input": 0.2006,
-          "output": 0.2414
-        },
-        "family": "llama",
-        "id": "TheDrummer 2/Cydonia-24B-v4",
-        "last_updated": "2025-07-22",
-        "limit": {
-          "context": 16384,
-          "input": 16384,
-          "output": 32768
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "The Drummer Cydonia 24B v4",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-07-22",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "NousResearch 2/hermes-4-405b": {
-        "attachment": false,
-        "cost": {
-          "input": 0.3,
-          "output": 1.2
-        },
-        "family": "nousresearch",
-        "id": "NousResearch 2/hermes-4-405b",
-        "last_updated": "2025-08-26",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Hermes 4 Large",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-08-26",
-        "structured_output": true,
-        "tool_call": true
-      },
       "jamba-large": {
         "attachment": false,
         "cost": {
@@ -27978,34 +30040,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-07-09",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-ArliAI-RPMax-v1.4": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-ArliAI-RPMax-v1.4",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B RPMax v1.4",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -28067,34 +30101,35 @@
         "structured_output": false,
         "tool_call": false
       },
-      "allenai/olmo-3.1-32b-instruct": {
-        "attachment": false,
+      "z-ai/glm-5v-turbo": {
+        "attachment": true,
         "cost": {
-          "input": 0.2,
-          "output": 0.6
+          "cache_read": 0.24,
+          "input": 1.2,
+          "output": 4
         },
-        "family": "allenai",
-        "id": "allenai/olmo-3.1-32b-instruct",
-        "last_updated": "2026-01-25",
+        "id": "z-ai/glm-5v-turbo",
+        "last_updated": "2026-04-01",
         "limit": {
-          "context": 65536,
-          "input": 65536,
-          "output": 8192
+          "context": 202800,
+          "input": 202800,
+          "output": 131100
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Olmo 3.1 32B Instruct",
+        "name": "GLM 5V Turbo",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2026-01-25",
-        "structured_output": false,
-        "tool_call": false
+        "release_date": "2026-04-01",
+        "structured_output": true,
+        "tool_call": true
       },
       "Salesforce/Llama-xLAM-2-70b-fc-r": {
         "attachment": false,
@@ -28124,6 +30159,36 @@
         "release_date": "2025-04-13",
         "structured_output": false,
         "tool_call": false
+      },
+      "x-ai/grok-build-0.1": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 1,
+          "output": 2
+        },
+        "id": "x-ai/grok-build-0.1",
+        "last_updated": "2026-05-20",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 256000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Grok Build 0.1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-20",
+        "structured_output": true,
+        "tool_call": true
       },
       "yi-large": {
         "attachment": false,
@@ -28213,17 +30278,48 @@
         "structured_output": false,
         "tool_call": false
       },
-      "qwen/Qwen3.6-35B-A3B:thinking": {
-        "attachment": false,
+      "google/gemini-3.1-flash-lite": {
+        "attachment": true,
         "cost": {
-          "input": 0.29,
-          "output": 1.74
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 1.5
         },
-        "family": "qwen3.6",
+        "id": "google/gemini-3.1-flash-lite",
+        "last_updated": "2026-03-03",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Flash Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-03",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "qwen/Qwen3.6-35B-A3B:thinking": {
+        "attachment": true,
+        "cost": {
+          "input": 0.112,
+          "output": 0.8
+        },
         "id": "qwen/Qwen3.6-35B-A3B:thinking",
-        "last_updated": "2026-04-21",
+        "last_updated": "2026-04-19",
         "limit": {
           "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
@@ -28237,7 +30333,7 @@
           ]
         },
         "name": "Qwen3.6 35B A3B Thinking",
-        "open_weights": true,
+        "open_weights": false,
         "reasoning": true,
         "release_date": "2026-04-19",
         "structured_output": false,
@@ -28300,6 +30396,37 @@
         "structured_output": false,
         "tool_call": false
       },
+      "google/gemini-flash-lite-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 1.5
+        },
+        "id": "google/gemini-flash-lite-latest",
+        "last_updated": "2026-03-29",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Flash Lite Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-29",
+        "structured_output": true,
+        "tool_call": true
+      },
       "qwen-turbo": {
         "attachment": false,
         "cost": {
@@ -28328,6 +30455,35 @@
         "structured_output": false,
         "tool_call": false
       },
+      "nanogpt/coding-router:medium": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.028,
+          "input": 0.14,
+          "output": 0.28
+        },
+        "id": "nanogpt/coding-router:medium",
+        "last_updated": "2026-05-12",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Coding Router Medium",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-12",
+        "structured_output": true,
+        "tool_call": true
+      },
       "doubao-seed-2-0-code-preview-260215": {
         "attachment": false,
         "cost": {
@@ -28353,35 +30509,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2026-02-14",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "x-ai/grok-code-fast-1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.2,
-          "output": 1.5
-        },
-        "family": "grok",
-        "id": "x-ai/grok-code-fast-1",
-        "last_updated": "2025-08-28",
-        "limit": {
-          "context": 256000,
-          "input": 256000,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Grok Code Fast 1",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-08-28",
         "structured_output": false,
         "tool_call": false
       },
@@ -28412,6 +30539,94 @@
         "release_date": "2025-07-09",
         "structured_output": false,
         "tool_call": false
+      },
+      "qwen/qwen3-235b-a22b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.3,
+          "output": 0.5
+        },
+        "id": "qwen/qwen3-235b-a22b",
+        "last_updated": "2025-04-29",
+        "limit": {
+          "context": 41000,
+          "input": 41000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen 3 235b A22B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-29",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "anthropic/claude-haiku-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "input": 1,
+          "output": 5
+        },
+        "id": "anthropic/claude-haiku-latest",
+        "last_updated": "2026-03-29",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-29",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "qwen/Qwen3-235B-A22B-Instruct-2507-TEE": {
+        "attachment": false,
+        "cost": {
+          "input": 0.13,
+          "output": 0.5
+        },
+        "id": "qwen/Qwen3-235B-A22B-Instruct-2507-TEE",
+        "last_updated": "2025-07-25",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen 3 235b A22B 2507 (TEE)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-07-25",
+        "structured_output": true,
+        "tool_call": true
       },
       "gemini-2.0-pro-exp-02-05": {
         "attachment": true,
@@ -28502,6 +30717,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "mistral-code-agent-latest": {
+        "attachment": false,
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "id": "mistral-code-agent-latest",
+        "last_updated": "2026-06-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Code Agent Latest",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-06-02",
+        "structured_output": true,
+        "tool_call": true
+      },
       "auto-model": {
         "attachment": false,
         "cost": {
@@ -28530,34 +30773,36 @@
         "structured_output": false,
         "tool_call": false
       },
-      "TheDrummer 2/Cydonia-24B-v4.1": {
-        "attachment": false,
+      "openai/gpt-chat-latest": {
+        "attachment": true,
         "cost": {
-          "input": 0.1003,
-          "output": 0.1207
+          "cache_read": 0.5,
+          "input": 5,
+          "output": 30
         },
-        "family": "llama",
-        "id": "TheDrummer 2/Cydonia-24B-v4.1",
-        "last_updated": "2025-08-19",
+        "id": "openai/gpt-chat-latest",
+        "last_updated": "2026-05-03",
         "limit": {
-          "context": 16384,
-          "input": 16384,
-          "output": 32768
+          "context": 400000,
+          "input": 400000,
+          "output": 128000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "The Drummer Cydonia 24B v4.1",
+        "name": "GPT Chat Latest",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-08-19",
-        "structured_output": false,
-        "tool_call": false
+        "release_date": "2026-05-03",
+        "structured_output": true,
+        "tool_call": true
       },
       "jamba-mini": {
         "attachment": false,
@@ -28642,6 +30887,66 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-08-05",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-Queen-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Queen-Derestricted-Lite",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Queen Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-BlueStar-v2-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-BlueStar-v2-Derestricted",
+        "last_updated": "2026-04-06",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B BlueStar v2 Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -28731,30 +31036,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "chroma": {
-        "attachment": true,
-        "id": "chroma",
-        "last_updated": "2025-08-12",
-        "limit": {
-          "context": 0,
-          "output": 0
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "image"
-          ]
-        },
-        "name": "Chroma",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-08-12",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
       "brave-pro": {
         "attachment": false,
         "cost": {
@@ -28811,36 +31092,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "claude-3-7-sonnet-thinking:128000": {
-        "attachment": true,
-        "cost": {
-          "input": 2.992,
-          "output": 14.994
-        },
-        "id": "claude-3-7-sonnet-thinking:128000",
-        "last_updated": "2025-02-24",
-        "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 64000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Claude 3.7 Sonnet Thinking (128K)",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-02-24",
-        "structured_output": true,
-        "tool_call": true
-      },
       "meta-llama/llama-3.1-8b-instruct": {
         "attachment": false,
         "cost": {
@@ -28870,6 +31121,62 @@
         "structured_output": false,
         "tool_call": false
       },
+      "minimax/minimax-m2.7-turbo": {
+        "attachment": false,
+        "cost": {
+          "input": 0.6,
+          "output": 2.4
+        },
+        "id": "minimax/minimax-m2.7-turbo",
+        "last_updated": "2026-03-18",
+        "limit": {
+          "context": 204800,
+          "input": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax M2.7 Turbo",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-18",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "TEE/qwen3.5-122b-a10b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.46,
+          "output": 3.68
+        },
+        "id": "TEE/qwen3.5-122b-a10b",
+        "last_updated": "2026-05-26",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 122B A10B TEE",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-26",
+        "structured_output": false,
+        "tool_call": true
+      },
       "cohere/command-r-plus-08-2024": {
         "attachment": false,
         "cost": {
@@ -28897,6 +31204,34 @@
         "reasoning": false,
         "release_date": "2024-08-30",
         "structured_output": false,
+        "tool_call": true
+      },
+      "zai-org/GLM-4.5-Air": {
+        "attachment": false,
+        "cost": {
+          "input": 0.12,
+          "output": 0.8
+        },
+        "id": "zai-org/GLM-4.5-Air",
+        "last_updated": "2025-04-15",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 98304
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.5 Air",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-15",
+        "structured_output": true,
         "tool_call": true
       },
       "TEE/glm-4.7-flash": {
@@ -28955,6 +31290,35 @@
         "release_date": "2024-06-01",
         "structured_output": false,
         "tool_call": false
+      },
+      "nanogpt/coding-router:high": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.11,
+          "input": 1.1,
+          "output": 2.2
+        },
+        "id": "nanogpt/coding-router:high",
+        "last_updated": "2026-05-12",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Coding Router High",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-12",
+        "structured_output": true,
+        "tool_call": true
       },
       "doubao-seed-1-6-250615": {
         "attachment": false,
@@ -29041,6 +31405,36 @@
         "release_date": "2024-07-01",
         "structured_output": false,
         "tool_call": false
+      },
+      "nvidia/nemotron-3-super-120b-a12b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.05,
+          "output": 0.25
+        },
+        "family": "nemotron",
+        "id": "nvidia/nemotron-3-super-120b-a12b",
+        "last_updated": "2026-03-01",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nvidia Nemotron 3 Super 120B",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-01",
+        "structured_output": false,
+        "temperature": true,
+        "tool_call": true
       },
       "claude-sonnet-4-20250514": {
         "attachment": true,
@@ -29131,18 +31525,18 @@
         "structured_output": false,
         "tool_call": true
       },
-      "hunyuan-t1-latest": {
+      "TEE/gemma-4-31b-it": {
         "attachment": false,
         "cost": {
-          "input": 0.17,
-          "output": 0.66
+          "input": 0.15,
+          "output": 0.46
         },
-        "id": "hunyuan-t1-latest",
-        "last_updated": "2025-03-22",
+        "id": "TEE/gemma-4-31b-it",
+        "last_updated": "2026-05-26",
         "limit": {
-          "context": 256000,
-          "input": 256000,
-          "output": 16384
+          "context": 262144,
+          "input": 262144,
+          "output": 262144
         },
         "modalities": {
           "input": [
@@ -29152,11 +31546,40 @@
             "text"
           ]
         },
-        "name": "Hunyuan T1",
+        "name": "Gemma 4 31B IT TEE",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-03-22",
+        "reasoning": true,
+        "release_date": "2026-05-26",
         "structured_output": false,
+        "tool_call": true
+      },
+      "command-a-plus-05-2026": {
+        "attachment": true,
+        "cost": {
+          "input": 2.5,
+          "output": 10
+        },
+        "id": "command-a-plus-05-2026",
+        "last_updated": "2026-05-22",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Cohere Command A+ (05/2026)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-22",
+        "structured_output": true,
         "tool_call": false
       },
       "deepclaude": {
@@ -29214,6 +31637,36 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-09-29",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted",
+        "last_updated": "2026-04-06",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Omega Evolution v2.0 Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -29306,6 +31759,34 @@
         "structured_output": true,
         "tool_call": true
       },
+      "zai-org/glm-4.5": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 1.3
+        },
+        "id": "zai-org/glm-4.5",
+        "last_updated": "2025-04-15",
+        "limit": {
+          "context": 128000,
+          "input": 128000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.5",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-15",
+        "structured_output": false,
+        "tool_call": false
+      },
       "venice-uncensored": {
         "attachment": false,
         "cost": {
@@ -29392,63 +31873,6 @@
         "structured_output": true,
         "tool_call": true
       },
-      "study_gpt-chatgpt-4o-latest": {
-        "attachment": true,
-        "cost": {
-          "input": 4.998,
-          "output": 14.994
-        },
-        "id": "study_gpt-chatgpt-4o-latest",
-        "last_updated": "2024-05-13",
-        "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Study Mode",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-05-13",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Shakudo": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Shakudo",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Shakudo",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
       "openai/gpt-4-turbo-preview": {
         "attachment": false,
         "cost": {
@@ -29506,6 +31930,37 @@
         "structured_output": false,
         "tool_call": false
       },
+      "openai/gpt-5.4-nano": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.02,
+          "input": 0.2,
+          "output": 1.25
+        },
+        "id": "openai/gpt-5.4-nano",
+        "last_updated": "2026-03-17",
+        "limit": {
+          "context": 400000,
+          "input": 400000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT 5.4 Nano",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-17",
+        "structured_output": true,
+        "tool_call": true
+      },
       "deepseek-ai/deepseek-v3.2-exp-thinking": {
         "attachment": false,
         "cost": {
@@ -29535,33 +31990,91 @@
         "structured_output": false,
         "tool_call": false
       },
-      "TheDrummer 2/skyfall-36b-v2": {
-        "attachment": true,
+      "NousResearch/hermes-3-llama-3.1-70b": {
+        "attachment": false,
         "cost": {
-          "input": 0.49299999999999994,
-          "output": 0.49299999999999994
+          "input": 0.408,
+          "output": 0.408
         },
-        "family": "llama",
-        "id": "TheDrummer 2/skyfall-36b-v2",
-        "last_updated": "2025-03-10",
+        "id": "NousResearch/hermes-3-llama-3.1-70b",
+        "last_updated": "2026-01-07",
         "limit": {
-          "context": 64000,
-          "input": 64000,
-          "output": 32768
+          "context": 65536,
+          "input": 65536,
+          "output": 8192
         },
         "modalities": {
           "input": [
-            "text",
-            "pdf"
+            "text"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "TheDrummer Skyfall 36B V2",
+        "name": "Hermes 3 70B",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-03-10",
+        "release_date": "2026-01-07",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-Musica-v1": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Musica-v1",
+        "last_updated": "2026-03-27",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Musica v1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-27",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-Writer-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Writer-Derestricted",
+        "last_updated": "2026-04-06",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Writer Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -29594,6 +32107,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "mistral-code-latest": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 0.9
+        },
+        "id": "mistral-code-latest",
+        "last_updated": "2026-06-02",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Code Latest",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-06-02",
+        "structured_output": true,
+        "tool_call": true
+      },
       "essentialai/rnj-1-instruct": {
         "attachment": false,
         "cost": {
@@ -29620,36 +32161,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-12-13",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "openai/gpt-5.2-chat": {
-        "attachment": true,
-        "cost": {
-          "input": 1.75,
-          "output": 14
-        },
-        "family": "gpt",
-        "id": "openai/gpt-5.2-chat",
-        "last_updated": "2026-01-01",
-        "limit": {
-          "context": 400000,
-          "input": 400000,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT 5.2 Chat",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2026-01-01",
         "structured_output": false,
         "tool_call": false
       },
@@ -29709,60 +32220,63 @@
         "structured_output": false,
         "tool_call": false
       },
-      "gemini-3-pro-preview": {
+      "alibaba/qwen3.6-27b:thinking": {
         "attachment": true,
         "cost": {
-          "input": 2,
-          "output": 12
+          "input": 0.203,
+          "output": 2.24
         },
-        "id": "gemini-3-pro-preview",
-        "last_updated": "2025-11-18",
+        "id": "alibaba/qwen3.6-27b:thinking",
+        "last_updated": "2026-04-23",
         "limit": {
-          "context": 1048756,
-          "input": 1048756,
+          "context": 260096,
+          "input": 260096,
           "output": 65536
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Gemini 3 Pro",
+        "name": "Qwen3.6 27B Thinking",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-11-18",
-        "structured_output": true,
-        "tool_call": true
+        "release_date": "2026-04-23",
+        "structured_output": false,
+        "tool_call": false
       },
-      "Llama-3.3-70B-Fallen-R1-v1": {
-        "attachment": false,
+      "Qwen3.5-27B-earica-Derestricted-Lite": {
+        "attachment": true,
         "cost": {
           "input": 0.306,
           "output": 0.306
         },
-        "id": "Llama-3.3-70B-Fallen-R1-v1",
-        "last_updated": "2024-12-06",
+        "id": "Qwen3.5-27B-earica-Derestricted-Lite",
+        "last_updated": "2026-04-30",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Fallen R1 v1",
+        "name": "Qwen3.5 27B earica Derestricted Lite",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
+        "reasoning": true,
+        "release_date": "2026-04-30",
         "structured_output": false,
         "tool_call": false
       },
@@ -29793,6 +32307,34 @@
         "release_date": "2025-08-19",
         "structured_output": false,
         "tool_call": false
+      },
+      "qwen/qwen3-coder": {
+        "attachment": false,
+        "cost": {
+          "input": 0.13,
+          "output": 0.5
+        },
+        "id": "qwen/qwen3-coder",
+        "last_updated": "2026-03-17",
+        "limit": {
+          "context": 262000,
+          "input": 262000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen 3 Coder 480B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-17",
+        "structured_output": true,
+        "tool_call": true
       },
       "qvq-max": {
         "attachment": true,
@@ -29851,30 +32393,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "z-image-turbo": {
-        "attachment": true,
-        "id": "z-image-turbo",
-        "last_updated": "2025-11-27",
-        "limit": {
-          "context": 0,
-          "output": 0
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "image"
-          ]
-        },
-        "name": "Z Image Turbo",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-11-27",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
       "gemini-3-pro-image-preview": {
         "attachment": true,
         "cost": {
@@ -29904,36 +32422,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "mistralai/mistral-7b-instruct": {
-        "attachment": true,
-        "cost": {
-          "input": 0.0544,
-          "output": 0.0544
-        },
-        "family": "mistral",
-        "id": "mistralai/mistral-7b-instruct",
-        "last_updated": "2024-05-27",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Mistral 7B Instruct",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-05-27",
-        "structured_output": false,
-        "tool_call": false
-      },
       "glm-zero-preview": {
         "attachment": false,
         "cost": {
@@ -29960,31 +32448,6 @@
         "reasoning": false,
         "release_date": "2024-12-01",
         "structured_output": false,
-        "tool_call": false
-      },
-      "qwen-image": {
-        "attachment": true,
-        "id": "qwen-image",
-        "last_updated": "2025-08-07",
-        "limit": {
-          "context": 0,
-          "output": 0
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "image"
-          ]
-        },
-        "name": "Qwen Image",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-08-07",
-        "structured_output": false,
-        "temperature": true,
         "tool_call": false
       },
       "claude-sonnet-4-thinking": {
@@ -30076,33 +32539,34 @@
         "structured_output": true,
         "tool_call": true
       },
-      "Gemma-3-27B-it": {
-        "attachment": false,
+      "x-ai/grok-4.20-multi-agent": {
+        "attachment": true,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 2,
+          "output": 6
         },
-        "id": "Gemma-3-27B-it",
-        "last_updated": "2025-03-10",
+        "id": "x-ai/grok-4.20-multi-agent",
+        "last_updated": "2026-03-31",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
+          "context": 2000000,
+          "input": 2000000,
+          "output": 131072
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Gemma 3 27B IT",
+        "name": "Grok 4.20 Multi-Agent",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-03-10",
-        "structured_output": false,
-        "tool_call": false
+        "reasoning": true,
+        "release_date": "2026-03-31",
+        "structured_output": true,
+        "tool_call": true
       },
       "qwen-3.6-plus": {
         "attachment": false,
@@ -30134,33 +32598,31 @@
         "structured_output": false,
         "tool_call": false
       },
-      "openai/gpt-5.1-chat-latest": {
-        "attachment": true,
+      "zai-org/GLM-4.5:thinking": {
+        "attachment": false,
         "cost": {
-          "input": 1.25,
-          "output": 10
+          "input": 0.3,
+          "output": 1.3
         },
-        "family": "gpt",
-        "id": "openai/gpt-5.1-chat-latest",
-        "last_updated": "2025-11-13",
+        "id": "zai-org/GLM-4.5:thinking",
+        "last_updated": "2024-01-01",
         "limit": {
-          "context": 400000,
-          "input": 400000,
-          "output": 16384
+          "context": 128000,
+          "input": 128000,
+          "output": 65536
         },
         "modalities": {
           "input": [
-            "text",
-            "image"
+            "text"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "GPT 5.1 Chat (Latest)",
+        "name": "GLM 4.5 (Thinking)",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-11-13",
+        "release_date": "2024-01-01",
         "structured_output": false,
         "tool_call": false
       },
@@ -30193,33 +32655,36 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-Damascus-R1": {
-        "attachment": false,
+      "anthropic/claude-opus-4.7": {
+        "attachment": true,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "cache_read": 0.4998,
+          "input": 4.998,
+          "output": 25.007
         },
-        "id": "Llama-3.3-70B-Damascus-R1",
-        "last_updated": "2024-12-06",
+        "id": "anthropic/claude-opus-4.7",
+        "last_updated": "2026-04-16",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Damascus R1",
+        "name": "Claude 4.7 Opus",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
+        "reasoning": true,
+        "release_date": "2026-04-16",
+        "structured_output": true,
+        "tool_call": true
       },
       "fastgpt": {
         "attachment": false,
@@ -30274,34 +32739,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2026-01-26",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Magnum-v4-SE": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Magnum-v4-SE",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Magnum v4 SE",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -30363,36 +32800,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "claude-3-5-sonnet-20240620": {
-        "attachment": true,
-        "cost": {
-          "input": 2.992,
-          "output": 14.994
-        },
-        "id": "claude-3-5-sonnet-20240620",
-        "last_updated": "2024-06-20",
-        "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Claude 3.5 Sonnet Old",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-06-20",
-        "structured_output": true,
-        "tool_call": true
-      },
       "glm-z1-airx": {
         "attachment": false,
         "cost": {
@@ -30418,6 +32825,63 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-04-15",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "zai-org/GLM-4.6-turbo:thinking": {
+        "attachment": false,
+        "cost": {
+          "input": 1,
+          "output": 3
+        },
+        "id": "zai-org/GLM-4.6-turbo:thinking",
+        "last_updated": "2025-10-02",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 204800
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.6 Turbo (Thinking)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-10-02",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "zai-org/glm-4.7-original": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.11,
+          "input": 0.6,
+          "output": 2.2
+        },
+        "id": "zai-org/glm-4.7-original",
+        "last_updated": "2025-12-22",
+        "limit": {
+          "context": 200000,
+          "input": 200000,
+          "output": 65535
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM 4.7 Original",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-22",
         "structured_output": true,
         "tool_call": true
       },
@@ -30507,6 +32971,125 @@
         "structured_output": false,
         "tool_call": false
       },
+      "deepseek/deepseek-v4-flash:thinking": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.028,
+          "input": 0.14,
+          "output": 0.28
+        },
+        "id": "deepseek/deepseek-v4-flash:thinking",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Flash (Thinking)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "Qwen3.5-27B-BlueStar-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-BlueStar-Derestricted-Lite",
+        "last_updated": "2026-04-06",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B BlueStar Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-06",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
+        "attachment": true,
+        "cost": {
+          "input": 0.105,
+          "output": 0.42
+        },
+        "family": "nemotron",
+        "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+        "last_updated": "2026-04-28",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nvidia Nemotron 3 Nano Omni",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-28",
+        "structured_output": false,
+        "temperature": true,
+        "tool_call": true
+      },
+      "sarvam-105b": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.028,
+          "input": 0.045,
+          "output": 0.177
+        },
+        "id": "sarvam-105b",
+        "last_updated": "2026-05-12",
+        "limit": {
+          "context": 131072,
+          "input": 131072,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Sarvam 105B",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-12",
+        "structured_output": false,
+        "tool_call": true
+      },
       "jamba-large-1.6": {
         "attachment": false,
         "cost": {
@@ -30532,35 +33115,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-03-12",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "stepfun-ai/step-3.5-flash:thinking": {
-        "attachment": false,
-        "cost": {
-          "input": 0.2,
-          "output": 0.5
-        },
-        "family": "step",
-        "id": "stepfun-ai/step-3.5-flash:thinking",
-        "last_updated": "2026-02-02",
-        "limit": {
-          "context": 256000,
-          "input": 256000,
-          "output": 256000
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Step 3.5 Flash Thinking",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2026-02-02",
         "structured_output": false,
         "tool_call": false
       },
@@ -30677,6 +33231,7 @@
         "reasoning": false,
         "release_date": "2025-08-18",
         "structured_output": false,
+        "temperature": true,
         "tool_call": false
       },
       "gemini-2.5-flash-nothinking": {
@@ -30737,6 +33292,35 @@
         "release_date": "2024-07-23",
         "structured_output": false,
         "tool_call": false
+      },
+      "deepseek/deepseek-v4-pro:thinking": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.11,
+          "input": 1.1,
+          "output": 2.2
+        },
+        "id": "deepseek/deepseek-v4-pro:thinking",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro (Thinking)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "tool_call": true
       },
       "auto-model-standard": {
         "attachment": false,
@@ -30854,36 +33438,6 @@
         "structured_output": true,
         "tool_call": true
       },
-      "allenai/molmo-2-8b": {
-        "attachment": true,
-        "cost": {
-          "input": 0.2,
-          "output": 0.2
-        },
-        "family": "allenai",
-        "id": "allenai/molmo-2-8b",
-        "last_updated": "2026-02-14",
-        "limit": {
-          "context": 36864,
-          "input": 36864,
-          "output": 36864
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Molmo 2 8B",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2026-02-14",
-        "structured_output": false,
-        "tool_call": false
-      },
       "cohere/command-r": {
         "attachment": false,
         "cost": {
@@ -30913,59 +33467,63 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Gemma-3-27B-CardProjector-v4": {
-        "attachment": false,
+      "Gemma-4-31B-Queen": {
+        "attachment": true,
         "cost": {
           "input": 0.306,
           "output": 0.306
         },
-        "id": "Gemma-3-27B-CardProjector-v4",
-        "last_updated": "2025-03-10",
+        "id": "Gemma-4-31B-Queen",
+        "last_updated": "2026-05-01",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Gemma 3 27B CardProjector v4",
+        "name": "Gemma 4 31B Queen",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-03-10",
+        "reasoning": true,
+        "release_date": "2026-05-01",
         "structured_output": false,
         "tool_call": false
       },
-      "Gemma-3-27B-Glitter": {
-        "attachment": false,
+      "Qwen3.5-27B-Derestricted": {
+        "attachment": true,
         "cost": {
           "input": 0.306,
           "output": 0.306
         },
-        "id": "Gemma-3-27B-Glitter",
-        "last_updated": "2025-03-10",
+        "id": "Qwen3.5-27B-Derestricted",
+        "last_updated": "2026-03-17",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Gemma 3 27B Glitter",
+        "name": "Qwen3.5 27B Derestricted",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-03-10",
+        "reasoning": true,
+        "release_date": "2026-03-17",
         "structured_output": false,
         "tool_call": false
       },
@@ -31027,6 +33585,36 @@
         "structured_output": false,
         "tool_call": false
       },
+      "Qwen3.5-27B-Marvin-DPO-V2-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Marvin-DPO-V2-Derestricted-Lite",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Marvin DPO V2 Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
+        "structured_output": false,
+        "tool_call": false
+      },
       "anthropic/claude-opus-4.6": {
         "attachment": true,
         "cost": {
@@ -31058,6 +33646,36 @@
         "structured_output": true,
         "tool_call": true
       },
+      "Qwen3.5-27B-BlueStar-v2-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-BlueStar-v2-Derestricted-Lite",
+        "last_updated": "2026-04-06",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B BlueStar v2 Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-06",
+        "structured_output": false,
+        "tool_call": false
+      },
       "ernie-x1.1-preview": {
         "attachment": true,
         "cost": {
@@ -31084,6 +33702,36 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-09-10",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-Marvin-V2-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Marvin-V2-Derestricted-Lite",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Marvin V2 Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
         "structured_output": false,
         "tool_call": false
       },
@@ -31232,6 +33880,34 @@
         "structured_output": true,
         "tool_call": true
       },
+      "qwen/qwen-2.5-72b-instruct": {
+        "attachment": false,
+        "cost": {
+          "input": 0.357,
+          "output": 0.408
+        },
+        "id": "qwen/qwen-2.5-72b-instruct",
+        "last_updated": "2025-07-03",
+        "limit": {
+          "context": 131072,
+          "input": 131072,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen2.5 72B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-07-03",
+        "structured_output": false,
+        "tool_call": false
+      },
       "openai/gpt-oss-120b": {
         "attachment": false,
         "cost": {
@@ -31260,64 +33936,6 @@
         "release_date": "2025-08-05",
         "structured_output": true,
         "tool_call": true
-      },
-      "claude-3-7-sonnet-20250219": {
-        "attachment": true,
-        "cost": {
-          "input": 2.992,
-          "output": 14.994
-        },
-        "id": "claude-3-7-sonnet-20250219",
-        "last_updated": "2025-02-19",
-        "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 16000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Claude 3.7 Sonnet",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-02-19",
-        "structured_output": true,
-        "tool_call": true
-      },
-      "Llama-3.3-70B-StrawberryLemonade-v1.0": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-StrawberryLemonade-v1.0",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B StrawberryLemonade v1.0",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
       },
       "z-ai/glm-4.6:thinking": {
         "attachment": false,
@@ -31405,19 +34023,19 @@
         "structured_output": false,
         "tool_call": false
       },
-      "THUDM/GLM-Z1-Rumination-32B-0414": {
+      "zai-org/glm-5-original": {
         "attachment": false,
         "cost": {
-          "input": 0.2,
-          "output": 0.2
+          "cache_read": 0.2,
+          "input": 1,
+          "output": 3.2
         },
-        "family": "glm-z",
-        "id": "THUDM/GLM-Z1-Rumination-32B-0414",
-        "last_updated": "2025-04-15",
+        "id": "zai-org/glm-5-original",
+        "last_updated": "2026-02-11",
         "limit": {
-          "context": 32000,
-          "input": 32000,
-          "output": 65536
+          "context": 200000,
+          "input": 200000,
+          "output": 128000
         },
         "modalities": {
           "input": [
@@ -31427,12 +34045,40 @@
             "text"
           ]
         },
-        "name": "GLM Z1 Rumination 32B 0414",
+        "name": "GLM 5 Original",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-04-15",
-        "structured_output": false,
-        "tool_call": false
+        "reasoning": true,
+        "release_date": "2026-02-11",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "TEE/minimax-m2.5": {
+        "attachment": false,
+        "cost": {
+          "input": 0.2,
+          "output": 1.38
+        },
+        "id": "TEE/minimax-m2.5",
+        "last_updated": "2026-04-20",
+        "limit": {
+          "context": 196608,
+          "input": 196608,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax M2.5 TEE",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-20",
+        "structured_output": true,
+        "tool_call": true
       },
       "TEE/glm-4.7": {
         "attachment": false,
@@ -31549,6 +34195,126 @@
         "structured_output": false,
         "tool_call": false
       },
+      "openai/gpt-5.4": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.25,
+          "input": 2.5,
+          "output": 15
+        },
+        "id": "openai/gpt-5.4",
+        "last_updated": "2026-03-05",
+        "limit": {
+          "context": 922000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT 5.4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "hermes-low": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 1.5
+        },
+        "id": "hermes-low",
+        "last_updated": "2026-05-11",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Hermes Low",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-11",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "google/gemma-4-26b-a4b-it:thinking": {
+        "attachment": true,
+        "cost": {
+          "input": 0.13,
+          "output": 0.4
+        },
+        "id": "google/gemma-4-26b-a4b-it:thinking",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 26B A4B Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "structured_output": true,
+        "tool_call": false
+      },
+      "mistral/mistral-medium-3.5:thinking": {
+        "attachment": true,
+        "cost": {
+          "input": 1.5,
+          "output": 7.5
+        },
+        "id": "mistral/mistral-medium-3.5:thinking",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Medium 3.5 Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
+        "structured_output": true,
+        "tool_call": true
+      },
       "openai/o3-mini": {
         "attachment": false,
         "cost": {
@@ -31609,6 +34375,36 @@
         "structured_output": true,
         "tool_call": true
       },
+      "gemma-4-31B-Larkspur-v0.5": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "gemma-4-31B-Larkspur-v0.5",
+        "last_updated": "2026-05-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B Larkspur v0.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-02",
+        "structured_output": false,
+        "tool_call": false
+      },
       "brave": {
         "attachment": false,
         "cost": {
@@ -31637,6 +34433,36 @@
         "structured_output": false,
         "tool_call": false
       },
+      "Qwen3.5-27B-Anko": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Anko",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Anko",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
+        "structured_output": false,
+        "tool_call": false
+      },
       "exa-research": {
         "attachment": false,
         "cost": {
@@ -31662,63 +34488,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-06-04",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "TheDrummer 2/Anubis-70B-v1.1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.31,
-          "output": 0.31
-        },
-        "family": "llama",
-        "id": "TheDrummer 2/Anubis-70B-v1.1",
-        "last_updated": "2024-07-01",
-        "limit": {
-          "context": 131072,
-          "input": 131072,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Anubis 70B v1.1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-07-01",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Cu-Mai-R1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Cu-Mai-R1",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Cu Mai R1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -31752,18 +34521,18 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Llama-3.3-70B-GeneticLemonade-Opus": {
+      "NousResearch/hermes-4-405b": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 0.3,
+          "output": 1.2
         },
-        "id": "Llama-3.3-70B-GeneticLemonade-Opus",
-        "last_updated": "2024-12-06",
+        "id": "NousResearch/hermes-4-405b",
+        "last_updated": "2025-08-26",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
+          "context": 128000,
+          "input": 128000,
+          "output": 8192
         },
         "modalities": {
           "input": [
@@ -31773,10 +34542,40 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 70B GeneticLemonade Opus",
+        "name": "Hermes 4 Large",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-12-06",
+        "release_date": "2025-08-26",
+        "structured_output": true,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-earica-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-earica-Derestricted",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B earica Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
         "structured_output": false,
         "tool_call": false
       },
@@ -31921,36 +34720,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "claude-3-7-sonnet-thinking:8192": {
-        "attachment": true,
-        "cost": {
-          "input": 2.992,
-          "output": 14.994
-        },
-        "id": "claude-3-7-sonnet-thinking:8192",
-        "last_updated": "2025-02-24",
-        "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 64000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Claude 3.7 Sonnet Thinking (8K)",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-02-24",
-        "structured_output": true,
-        "tool_call": true
-      },
       "v0-1.5-lg": {
         "attachment": false,
         "cost": {
@@ -31976,6 +34745,64 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-07-04",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "qwen3.5-27b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.27,
+          "output": 2.16
+        },
+        "id": "qwen3.5-27b",
+        "last_updated": "2026-02-24",
+        "limit": {
+          "context": 260096,
+          "input": 260096,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-02-24",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "kwaipilot/kat-coder-pro-v2": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "id": "kwaipilot/kat-coder-pro-v2",
+        "last_updated": "2026-03-28",
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 80000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "KAT Coder Pro V2",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-28",
         "structured_output": false,
         "tool_call": false
       },
@@ -32008,34 +34835,6 @@
         "structured_output": true,
         "tool_call": true
       },
-      "Llama-3.3+(3v3.3)-70B-TenyxChat-DaybreakStorywriter": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3+(3v3.3)-70B-TenyxChat-DaybreakStorywriter",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3+ 70B TenyxChat DaybreakStorywriter",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
       "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF": {
         "attachment": false,
         "cost": {
@@ -32063,6 +34862,7 @@
         "reasoning": false,
         "release_date": "2025-04-15",
         "structured_output": false,
+        "temperature": true,
         "tool_call": false
       },
       "meta-llama/llama-4-maverick": {
@@ -32121,91 +34921,6 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-05-28",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Mokume-Gane-R1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Mokume-Gane-R1",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Mokume Gane R1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "TEE/qwen3-coder": {
-        "attachment": false,
-        "cost": {
-          "input": 1.5,
-          "output": 2
-        },
-        "family": "qwen",
-        "id": "TEE/qwen3-coder",
-        "last_updated": "2025-07-23",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 32768
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Qwen3 Coder 480B TEE",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-07-23",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Predatorial-Extasy": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Predatorial-Extasy",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Predatorial Extasy",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -32298,6 +35013,34 @@
         "structured_output": false,
         "tool_call": false
       },
+      "qwen/qwq-32b-preview": {
+        "attachment": false,
+        "cost": {
+          "input": 0.2,
+          "output": 0.2
+        },
+        "id": "qwen/qwq-32b-preview",
+        "last_updated": "2025-02-27",
+        "limit": {
+          "context": 32768,
+          "input": 32768,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen QwQ 32B Preview",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-02-27",
+        "structured_output": false,
+        "tool_call": false
+      },
       "gemini-2.5-flash-lite-preview-09-2025": {
         "attachment": true,
         "cost": {
@@ -32355,7 +35098,38 @@
         "reasoning": false,
         "release_date": "2025-08-08",
         "structured_output": false,
+        "temperature": true,
         "tool_call": false
+      },
+      "hermes-high": {
+        "attachment": true,
+        "cost": {
+          "input": 4.998,
+          "output": 25.007
+        },
+        "id": "hermes-high",
+        "last_updated": "2026-05-11",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Hermes High",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-11",
+        "structured_output": true,
+        "tool_call": true
       },
       "moonshotai/kimi-k2-instruct": {
         "attachment": false,
@@ -32386,33 +35160,33 @@
         "structured_output": true,
         "tool_call": true
       },
-      "claude-3-7-sonnet-thinking:32768": {
+      "google/gemini-3.1-pro-preview-low": {
         "attachment": true,
         "cost": {
-          "input": 2.992,
-          "output": 14.994
+          "cache_read": 0.2,
+          "input": 2,
+          "output": 12
         },
-        "id": "claude-3-7-sonnet-thinking:32768",
-        "last_updated": "2025-07-15",
+        "id": "google/gemini-3.1-pro-preview-low",
+        "last_updated": "2026-02-21",
         "limit": {
-          "context": 200000,
-          "input": 200000,
-          "output": 64000
+          "context": 1048756,
+          "input": 1048756,
+          "output": 65536
         },
         "modalities": {
           "input": [
             "text",
-            "image",
-            "pdf"
+            "image"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Claude 3.7 Sonnet Thinking (32K)",
+        "name": "Gemini 3.1 Pro (Preview Low)",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-07-15",
+        "release_date": "2026-02-21",
         "structured_output": true,
         "tool_call": true
       },
@@ -32443,34 +35217,6 @@
         "release_date": "2025-03-24",
         "structured_output": true,
         "tool_call": true
-      },
-      "Llama-3.3-70B-Incandescent-Malevolence": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Incandescent-Malevolence",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Incandescent Malevolence",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
       },
       "learnlm-1.5-pro-experimental": {
         "attachment": false,
@@ -32557,36 +35303,6 @@
         "release_date": "2025-04-30",
         "structured_output": false,
         "tool_call": false
-      },
-      "x-ai/grok-4-fast:thinking": {
-        "attachment": true,
-        "cost": {
-          "input": 0.2,
-          "output": 0.5
-        },
-        "family": "grok",
-        "id": "x-ai/grok-4-fast:thinking",
-        "last_updated": "2025-07-09",
-        "limit": {
-          "context": 2000000,
-          "input": 2000000,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Grok 4 Fast Thinking",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-07-09",
-        "structured_output": true,
-        "tool_call": true
       },
       "claude-opus-4-1-thinking:32000": {
         "attachment": true,
@@ -32732,6 +35448,7 @@
         "reasoning": false,
         "release_date": "2025-12-15",
         "structured_output": false,
+        "temperature": true,
         "tool_call": false
       },
       "gemini-2.5-pro": {
@@ -32763,18 +35480,18 @@
         "structured_output": false,
         "tool_call": false
       },
-      "GLM-4.5-Air-Derestricted-Iceblink-v2": {
+      "qwen/Qwen3-235B-A22B-Instruct-2507": {
         "attachment": false,
         "cost": {
-          "input": 0.306,
-          "output": 0.306
+          "input": 0.13,
+          "output": 0.5
         },
-        "id": "GLM-4.5-Air-Derestricted-Iceblink-v2",
-        "last_updated": "2025-07-28",
+        "id": "qwen/Qwen3-235B-A22B-Instruct-2507",
+        "last_updated": "2025-07-25",
         "limit": {
-          "context": 158600,
-          "input": 158600,
-          "output": 65536
+          "context": 256000,
+          "input": 256000,
+          "output": 262144
         },
         "modalities": {
           "input": [
@@ -32784,12 +35501,41 @@
             "text"
           ]
         },
-        "name": "GLM 4.5 Air Derestricted Iceblink v2",
+        "name": "Qwen 3 235b A22B 2507",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-07-28",
-        "structured_output": false,
-        "tool_call": false
+        "release_date": "2025-07-25",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "deepseek/deepseek-v4-pro": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.11,
+          "input": 1.1,
+          "output": 2.2
+        },
+        "id": "deepseek/deepseek-v4-pro",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "tool_call": true
       },
       "moonshotai/kimi-k2.6:thinking": {
         "attachment": true,
@@ -32938,6 +35684,37 @@
         "structured_output": false,
         "tool_call": false
       },
+      "anthropic/claude-opus-4.7:thinking": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.4998,
+          "input": 4.998,
+          "output": 25.007
+        },
+        "id": "anthropic/claude-opus-4.7:thinking",
+        "last_updated": "2026-04-16",
+        "limit": {
+          "context": 1000000,
+          "input": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude 4.7 Opus Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-16",
+        "structured_output": true,
+        "tool_call": true
+      },
       "anthropic/claude-opus-4.6:thinking:low": {
         "attachment": true,
         "cost": {
@@ -32969,34 +35746,6 @@
         "structured_output": true,
         "tool_call": true
       },
-      "Llama-3.3-70B-Electranova-v1.0": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Electranova-v1.0",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Electranova v1.0",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
-        "structured_output": false,
-        "tool_call": false
-      },
       "aion-labs/aion-rp-llama-3.1-8b": {
         "attachment": false,
         "cost": {
@@ -33023,6 +35772,124 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-07-23",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "qwen/qwen3-32b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.1,
+          "output": 0.3
+        },
+        "id": "qwen/qwen3-32b",
+        "last_updated": "2024-01-01",
+        "limit": {
+          "context": 41000,
+          "input": 41000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen 3 32b",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-01-01",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "google/gemma-4-26b-a4b-it": {
+        "attachment": true,
+        "cost": {
+          "input": 0.13,
+          "output": 0.4
+        },
+        "id": "google/gemma-4-26b-a4b-it",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 26B A4B",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "structured_output": true,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-Writer-V2-Derestricted": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Writer-V2-Derestricted",
+        "last_updated": "2026-04-06",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Writer V2 Derestricted",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-06",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "gemma-4-31B-MeroMero": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "gemma-4-31B-MeroMero",
+        "last_updated": "2026-05-02",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B MeroMero",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-02",
         "structured_output": false,
         "tool_call": false
       },
@@ -33084,6 +35951,36 @@
         "structured_output": false,
         "tool_call": false
       },
+      "alibaba/qwen3.6-27b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.203,
+          "output": 2.24
+        },
+        "id": "alibaba/qwen3.6-27b",
+        "last_updated": "2026-04-23",
+        "limit": {
+          "context": 260096,
+          "input": 260096,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.6 27B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-04-23",
+        "structured_output": false,
+        "tool_call": false
+      },
       "meganova-ai/manta-flash-1.0": {
         "attachment": false,
         "cost": {
@@ -33142,6 +36039,38 @@
         "structured_output": false,
         "tool_call": false
       },
+      "xiaomi/mimo-v2-omni": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.08,
+          "input": 0.4,
+          "output": 2
+        },
+        "id": "xiaomi/mimo-v2-omni",
+        "last_updated": "2026-03-19",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiMo V2 Omni",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-19",
+        "structured_output": false,
+        "tool_call": true
+      },
       "v0-1.0-md": {
         "attachment": false,
         "cost": {
@@ -33199,18 +36128,77 @@
         "structured_output": true,
         "tool_call": true
       },
-      "Llama-3.3-70B-Magnum-v4-SE-Cirrus-x1-SLERP": {
-        "attachment": false,
+      "TEE/qwen3.6-35b-a3b-uncensored": {
+        "attachment": true,
+        "cost": {
+          "input": 0.3,
+          "output": 1.5
+        },
+        "id": "TEE/qwen3.6-35b-a3b-uncensored",
+        "last_updated": "2026-05-23",
+        "limit": {
+          "context": 131072,
+          "input": 131072,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.6 35B A3B Uncensored TEE",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-23",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "Gemma-4-31B-Gemopus": {
+        "attachment": true,
         "cost": {
           "input": 0.306,
           "output": 0.306
         },
-        "id": "Llama-3.3-70B-Magnum-v4-SE-Cirrus-x1-SLERP",
-        "last_updated": "2025-07-26",
+        "id": "Gemma-4-31B-Gemopus",
+        "last_updated": "2026-05-01",
         "limit": {
-          "context": 32768,
-          "input": 32768,
+          "context": 262144,
+          "input": 262144,
           "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B Gemopus",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-01",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "TheDrummer/Cydonia-24B-v2": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1003,
+          "output": 0.1207
+        },
+        "id": "TheDrummer/Cydonia-24B-v2",
+        "last_updated": "2025-02-17",
+        "limit": {
+          "context": 16384,
+          "input": 16384,
+          "output": 32768
         },
         "modalities": {
           "input": [
@@ -33220,10 +36208,10 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 70B Magnum v4 SE Cirrus x1 SLERP",
+        "name": "The Drummer Cydonia 24B v2",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-07-26",
+        "release_date": "2025-02-17",
         "structured_output": false,
         "tool_call": false
       },
@@ -33284,35 +36272,33 @@
         "structured_output": false,
         "tool_call": false
       },
-      "x-ai/grok-4-fast": {
-        "attachment": true,
+      "qwen/Qwen3-8B": {
+        "attachment": false,
         "cost": {
-          "input": 0.2,
-          "output": 0.5
+          "input": 0.47,
+          "output": 0.47
         },
-        "family": "grok",
-        "id": "x-ai/grok-4-fast",
-        "last_updated": "2025-09-20",
+        "id": "qwen/Qwen3-8B",
+        "last_updated": "2024-01-01",
         "limit": {
-          "context": 2000000,
-          "input": 2000000,
-          "output": 131072
+          "context": 41000,
+          "input": 41000,
+          "output": 32768
         },
         "modalities": {
           "input": [
-            "text",
-            "image"
+            "text"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Grok 4 Fast",
+        "name": "Qwen 3 8B",
         "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-09-20",
-        "structured_output": true,
-        "tool_call": true
+        "reasoning": false,
+        "release_date": "2024-01-01",
+        "structured_output": false,
+        "tool_call": false
       },
       "qwen3-30b-a3b-instruct-2507": {
         "attachment": false,
@@ -33339,6 +36325,67 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-02-20",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "qwen3.5-omni-plus": {
+        "attachment": true,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "id": "qwen3.5-omni-plus",
+        "last_updated": "2026-03-30",
+        "limit": {
+          "context": 983616,
+          "input": 983616,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 Omni Plus",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-30",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-BlueStar-v3-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-BlueStar-v3-Derestricted-Lite",
+        "last_updated": "2026-04-30",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B BlueStar v3 Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-30",
         "structured_output": false,
         "tool_call": false
       },
@@ -33400,60 +36447,33 @@
         "structured_output": false,
         "tool_call": false
       },
-      "grok-3-fast-beta": {
+      "qwen3.5-122b-a10b:thinking": {
         "attachment": true,
         "cost": {
-          "input": 5,
-          "output": 25
+          "input": 0.36,
+          "output": 2.88
         },
-        "id": "grok-3-fast-beta",
-        "last_updated": "2025-02-17",
+        "id": "qwen3.5-122b-a10b:thinking",
+        "last_updated": "2026-02-24",
         "limit": {
-          "context": 131072,
-          "input": 131072,
-          "output": 131072
+          "context": 260096,
+          "input": 260096,
+          "output": 65536
         },
         "modalities": {
           "input": [
             "text",
-            "pdf"
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Grok 3 Fast Beta",
+        "name": "Qwen3.5 122B A10B Thinking",
         "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-02-17",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-Nova": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-Nova",
-        "last_updated": "2024-12-06",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B Nova",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-12-06",
+        "reasoning": true,
+        "release_date": "2026-02-24",
         "structured_output": false,
         "tool_call": false
       },
@@ -33485,6 +36505,37 @@
         "release_date": "2025-06-17",
         "structured_output": false,
         "tool_call": false
+      },
+      "claw-low": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 1.5
+        },
+        "id": "claw-low",
+        "last_updated": "2026-05-11",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claw Low",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-11",
+        "structured_output": true,
+        "tool_call": true
       },
       "mistralai/mistral-large-3-675b-instruct-2512": {
         "attachment": true,
@@ -33546,64 +36597,6 @@
         "structured_output": true,
         "tool_call": true
       },
-      "NeverSleep/Llama-3-Lumimaid-70B-v0.1": {
-        "attachment": true,
-        "cost": {
-          "input": 2.006,
-          "output": 2.006
-        },
-        "family": "llama",
-        "id": "NeverSleep/Llama-3-Lumimaid-70B-v0.1",
-        "last_updated": "2024-07-01",
-        "limit": {
-          "context": 16384,
-          "input": 16384,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Lumimaid 70b",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-07-01",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "Llama-3.3-70B-ArliAI-RPMax-v2": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Llama-3.3-70B-ArliAI-RPMax-v2",
-        "last_updated": "2025-08-08",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.3 70B ArliAI RPMax v2",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-08-08",
-        "structured_output": false,
-        "tool_call": false
-      },
       "aion-labs/aion-1.0-mini": {
         "attachment": false,
         "cost": {
@@ -33630,6 +36623,36 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-02-20",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted-Lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.306,
+          "output": 0.306
+        },
+        "id": "Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted-Lite",
+        "last_updated": "2026-04-06",
+        "limit": {
+          "context": 262144,
+          "input": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5 27B Omega Evolution v2.0 Derestricted Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-06",
         "structured_output": false,
         "tool_call": false
       },
@@ -33662,148 +36685,123 @@
         "structured_output": false,
         "tool_call": false
       },
-      "Gemma-3-27B-Big-Tiger-v3": {
-        "attachment": false,
-        "cost": {
-          "input": 0.306,
-          "output": 0.306
-        },
-        "id": "Gemma-3-27B-Big-Tiger-v3",
-        "last_updated": "2025-08-08",
-        "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Gemma 3 27B Big Tiger v3",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-08-08",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "NousResearch 2/DeepHermes-3-Mistral-24B-Preview": {
-        "attachment": false,
-        "cost": {
-          "input": 0.3,
-          "output": 0.3
-        },
-        "family": "nousresearch",
-        "id": "NousResearch 2/DeepHermes-3-Mistral-24B-Preview",
-        "last_updated": "2025-05-10",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 32768
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "DeepHermes-3 Mistral 24B (Preview)",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-05-10",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "mistralai/mistral-tiny": {
-        "attachment": false,
-        "cost": {
-          "input": 0.25499999999999995,
-          "output": 0.25499999999999995
-        },
-        "family": "mistral",
-        "id": "mistralai/mistral-tiny",
-        "last_updated": "2024-01-01",
-        "limit": {
-          "context": 32000,
-          "input": 32000,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Mistral Tiny",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2023-12-11",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "NousResearch 2/hermes-4-70b": {
-        "attachment": false,
-        "cost": {
-          "input": 0.2006,
-          "output": 0.39949999999999997
-        },
-        "family": "nousresearch",
-        "id": "NousResearch 2/hermes-4-70b",
-        "last_updated": "2025-07-03",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Hermes 4 Medium",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-07-03",
-        "structured_output": false,
-        "tool_call": false
-      },
-      "raifle/sorcererlm-8x22b": {
+      "stepfun/step-3.7-flash:thinking": {
         "attachment": true,
         "cost": {
-          "input": 4.505,
-          "output": 4.505
+          "cache_read": 0.04,
+          "input": 0.2,
+          "output": 1.15
         },
-        "family": "mixtral",
-        "id": "raifle/sorcererlm-8x22b",
-        "last_updated": "2025-01-01",
+        "id": "stepfun/step-3.7-flash:thinking",
+        "last_updated": "2026-05-29",
         "limit": {
-          "context": 16000,
-          "input": 16000,
-          "output": 8192
+          "context": 256000,
+          "input": 256000,
+          "output": 256000
         },
         "modalities": {
           "input": [
             "text",
-            "pdf"
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "SorcererLM 8x22B",
+        "name": "Step 3.7 Flash Thinking",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-29",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "claw-medium": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "id": "claw-medium",
+        "last_updated": "2026-05-11",
+        "limit": {
+          "context": 204800,
+          "input": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claw Medium",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-11",
+        "structured_output": true,
+        "tool_call": true
+      },
+      "qwen3.7-plus": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.04,
+          "input": 0.4,
+          "output": 1.6
+        },
+        "id": "qwen3.7-plus",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 991808,
+          "input": 991808,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7 Plus",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-01-01",
+        "release_date": "2026-06-01",
+        "structured_output": false,
+        "tool_call": false
+      },
+      "google/gemini-flash-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.15,
+          "input": 1.5,
+          "output": 9
+        },
+        "id": "google/gemini-flash-latest",
+        "last_updated": "2026-03-29",
+        "limit": {
+          "context": 1048756,
+          "input": 1048756,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Flash Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-29",
         "structured_output": false,
         "tool_call": false
       },
@@ -33953,34 +36951,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "grok-3-mini-beta": {
-        "attachment": false,
-        "cost": {
-          "input": 0.3,
-          "output": 0.5
-        },
-        "id": "grok-3-mini-beta",
-        "last_updated": "2025-02-17",
-        "limit": {
-          "context": 131072,
-          "input": 131072,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Grok 3 Mini Beta",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-02-17",
-        "structured_output": false,
-        "tool_call": false
-      },
       "mistralai/ministral-8b-2512": {
         "attachment": false,
         "cost": {
@@ -34039,34 +37009,6 @@
         "structured_output": false,
         "tool_call": false
       },
-      "KAT-Coder-Pro-V1": {
-        "attachment": false,
-        "cost": {
-          "input": 1.5,
-          "output": 6
-        },
-        "id": "KAT-Coder-Pro-V1",
-        "last_updated": "2025-10-28",
-        "limit": {
-          "context": 256000,
-          "input": 256000,
-          "output": 32768
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "KAT Coder Pro V1",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-10-28",
-        "structured_output": false,
-        "tool_call": false
-      },
       "deepseek-ai/DeepSeek-V3.1:thinking": {
         "attachment": false,
         "cost": {
@@ -34096,33 +37038,33 @@
         "structured_output": false,
         "tool_call": false
       },
-      "moonshotai/Kimi-Dev-72B": {
+      "zai-org/glm-4.6v-flash-original": {
         "attachment": true,
         "cost": {
-          "input": 0.4,
+          "input": 0.1,
           "output": 0.4
         },
-        "family": "kimi",
-        "id": "moonshotai/Kimi-Dev-72B",
-        "last_updated": "2025-04-15",
+        "id": "zai-org/glm-4.6v-flash-original",
+        "last_updated": "2025-12-08",
         "limit": {
           "context": 128000,
           "input": 128000,
-          "output": 131072
+          "output": 24000
         },
         "modalities": {
           "input": [
             "text",
-            "pdf"
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Kimi Dev 72B",
+        "name": "GLM 4.6V Flash",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-04-15",
+        "release_date": "2025-12-08",
         "structured_output": false,
         "tool_call": false
       },
@@ -34272,19 +37214,19 @@
         "structured_output": false,
         "tool_call": false
       },
-      "mistralai/mistral-small-creative": {
+      "TEE/glm-5.1": {
         "attachment": false,
         "cost": {
-          "input": 0.1,
-          "output": 0.3
+          "cache_read": 0.3,
+          "input": 1.5,
+          "output": 5.25
         },
-        "family": "mistral-small",
-        "id": "mistralai/mistral-small-creative",
-        "last_updated": "2025-12-16",
+        "id": "TEE/glm-5.1",
+        "last_updated": "2026-04-20",
         "limit": {
-          "context": 32768,
-          "input": 32768,
-          "output": 32768
+          "context": 202752,
+          "input": 202752,
+          "output": 65535
         },
         "modalities": {
           "input": [
@@ -34294,12 +37236,12 @@
             "text"
           ]
         },
-        "name": "Mistral Small Creative",
+        "name": "GLM 5.1 TEE",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-12-16",
-        "structured_output": true,
-        "tool_call": true
+        "release_date": "2026-04-20",
+        "structured_output": false,
+        "tool_call": false
       },
       "azure-gpt-4-turbo": {
         "attachment": false,
@@ -34328,6 +37270,37 @@
         "release_date": "2023-11-06",
         "structured_output": false,
         "tool_call": false
+      },
+      "google/gemini-3.5-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.15,
+          "input": 1.5,
+          "output": 9
+        },
+        "id": "google/gemini-3.5-flash",
+        "last_updated": "2026-05-19",
+        "limit": {
+          "context": 1048576,
+          "input": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.5 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-19",
+        "structured_output": true,
+        "tool_call": true
       }
     },
     "name": "NanoGPT",
@@ -38119,7 +41092,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -40466,7 +43439,7 @@
         "release_date": "2024-10-16",
         "structured_output": false,
         "temperature": true,
-        "tool_call": true
+        "tool_call": false
       },
       "meta-llama/llama-3-70b-instruct": {
         "attachment": false,
@@ -40497,6 +43470,35 @@
         "structured_output": true,
         "temperature": true,
         "tool_call": false
+      },
+      "nvidia/nemotron-3-ultra-550b-a55b:free": {
+        "attachment": false,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "nemotron",
+        "id": "nvidia/nemotron-3-ultra-550b-a55b:free",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nemotron 3 Ultra (free)",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-06-04",
+        "structured_output": false,
+        "temperature": true,
+        "tool_call": true
       },
       "nousresearch/hermes-3-llama-3.1-405b": {
         "attachment": false,
@@ -40538,8 +43540,8 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3-coder-plus",
-        "knowledge": "2025-06-30",
-        "last_updated": "2025-09-23",
+        "knowledge": "2025-04",
+        "last_updated": "2025-07-23",
         "limit": {
           "context": 1000000,
           "output": 65536
@@ -40555,7 +43557,7 @@
         "name": "Qwen3 Coder Plus",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-09-23",
+        "release_date": "2025-07-23",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -40563,16 +43565,17 @@
       "qwen/qwen3-235b-a22b-thinking-2507": {
         "attachment": false,
         "cost": {
-          "input": 0.1495,
-          "output": 1.495
+          "cache_read": 0.1,
+          "input": 0.1,
+          "output": 0.1
         },
         "family": "qwen",
         "id": "qwen/qwen3-235b-a22b-thinking-2507",
         "knowledge": "2025-06-30",
         "last_updated": "2025-07-25",
         "limit": {
-          "context": 131072,
-          "output": 81920
+          "context": 262144,
+          "output": 262144
         },
         "modalities": {
           "input": [
@@ -40600,8 +43603,8 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3-coder-flash",
-        "knowledge": "2025-06-30",
-        "last_updated": "2025-09-17",
+        "knowledge": "2025-04",
+        "last_updated": "2025-07-28",
         "limit": {
           "context": 1000000,
           "output": 65536
@@ -40617,7 +43620,7 @@
         "name": "Qwen3 Coder Flash",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-09-17",
+        "release_date": "2025-07-28",
         "structured_output": false,
         "temperature": true,
         "tool_call": true
@@ -40662,7 +43665,7 @@
         "last_updated": "2026-03-18",
         "limit": {
           "context": 196608,
-          "output": 131072
+          "output": 196608
         },
         "modalities": {
           "input": [
@@ -40719,8 +43722,8 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3-next-80b-a3b-thinking",
-        "knowledge": "2025-09-30",
-        "last_updated": "2025-09-11",
+        "knowledge": "2025-04",
+        "last_updated": "2025-09",
         "limit": {
           "context": 131072,
           "output": 32768
@@ -40733,13 +43736,37 @@
             "text"
           ]
         },
-        "name": "Qwen3 Next 80B A3B Thinking",
+        "name": "Qwen3-Next 80B-A3B (Thinking)",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-09-11",
+        "release_date": "2025-09",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
+      },
+      "openrouter/fusion": {
+        "attachment": false,
+        "id": "openrouter/fusion",
+        "last_updated": "2026-05-12",
+        "limit": {
+          "context": 128000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Fusion",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-05-12",
+        "structured_output": false,
+        "temperature": false,
+        "tool_call": false
       },
       "openai/gpt-4o-mini": {
         "attachment": true,
@@ -40780,9 +43807,9 @@
           "input": 0.26,
           "output": 2.08
         },
-        "family": "qwen3.5",
+        "family": "qwen",
         "id": "qwen/qwen3.5-122b-a10b",
-        "last_updated": "2026-02-25",
+        "last_updated": "2026-02-23",
         "limit": {
           "context": 262144,
           "output": 262144
@@ -40797,10 +43824,10 @@
             "text"
           ]
         },
-        "name": "Qwen3.5-122B-A10B",
+        "name": "Qwen3.5 122B-A10B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-02-25",
+        "release_date": "2026-02-23",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -40889,69 +43916,6 @@
         "temperature": true,
         "tool_call": true
       },
-      "openai/gpt-4-0314": {
-        "attachment": false,
-        "cost": {
-          "input": 30,
-          "output": 60
-        },
-        "family": "gpt",
-        "id": "openai/gpt-4-0314",
-        "knowledge": "2021-09-30",
-        "last_updated": "2023-05-28",
-        "limit": {
-          "context": 8191,
-          "output": 4096
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT-4 (older v0314)",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2023-05-28",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
-      "deepseek/deepseek-v4-flash:free": {
-        "attachment": false,
-        "cost": {
-          "input": 0,
-          "output": 0
-        },
-        "family": "deepseek-flash",
-        "id": "deepseek/deepseek-v4-flash:free",
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "knowledge": "2025-05",
-        "last_updated": "2026-04-24",
-        "limit": {
-          "context": 1048576,
-          "output": 384000
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "DeepSeek V4 Flash (free)",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2026-04-24",
-        "structured_output": false,
-        "temperature": false,
-        "tool_call": true
-      },
       "qwen/qwen-plus-2025-07-28": {
         "attachment": false,
         "cost": {
@@ -41023,6 +43987,7 @@
         "last_updated": "2025-12-11",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -41090,9 +44055,9 @@
         },
         "modalities": {
           "input": [
-            "pdf",
+            "text",
             "image",
-            "text"
+            "pdf"
           ],
           "output": [
             "text"
@@ -41175,11 +44140,11 @@
         },
         "modalities": {
           "input": [
-            "audio",
-            "pdf",
-            "image",
             "text",
-            "video"
+            "image",
+            "video",
+            "audio",
+            "pdf"
           ],
           "output": [
             "text"
@@ -41227,9 +44192,9 @@
       "moonshotai/kimi-k2.6": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.25,
-          "input": 0.73,
-          "output": 3.49
+          "cache_read": 0.34,
+          "input": 0.68,
+          "output": 3.41
         },
         "family": "kimi-k2.6",
         "id": "moonshotai/kimi-k2.6",
@@ -41389,8 +44354,8 @@
       "deepseek/deepseek-chat": {
         "attachment": false,
         "cost": {
-          "input": 0.2288,
-          "output": 0.9144
+          "input": 0.2002,
+          "output": 0.8001
         },
         "family": "deepseek",
         "id": "deepseek/deepseek-chat",
@@ -41446,9 +44411,9 @@
           "input": 0.195,
           "output": 1.56
         },
-        "family": "qwen3.5",
+        "family": "qwen",
         "id": "qwen/qwen3.5-27b",
-        "last_updated": "2026-02-25",
+        "last_updated": "2026-02-23",
         "limit": {
           "context": 262144,
           "output": 65536
@@ -41463,10 +44428,10 @@
             "text"
           ]
         },
-        "name": "Qwen3.5-27B",
+        "name": "Qwen3.5 27B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-02-25",
+        "release_date": "2026-02-23",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -41593,6 +44558,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-12-09",
+        "status": "deprecated",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -41605,8 +44571,8 @@
         },
         "family": "deepseek-thinking",
         "id": "deepseek/deepseek-r1",
-        "knowledge": "2024-07-31",
-        "last_updated": "2025-01-20",
+        "knowledge": "2024-07",
+        "last_updated": "2025-05-29",
         "limit": {
           "context": 64000,
           "output": 16000
@@ -41619,7 +44585,7 @@
             "text"
           ]
         },
-        "name": "R1",
+        "name": "DeepSeek-R1",
         "open_weights": true,
         "reasoning": true,
         "release_date": "2025-01-20",
@@ -41672,6 +44638,7 @@
         "last_updated": "2025-10-06",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -41736,12 +44703,13 @@
         "last_updated": "2025-11-13",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 100000
         },
         "modalities": {
           "input": [
-            "image",
-            "text"
+            "text",
+            "image"
           ],
           "output": [
             "text"
@@ -41751,6 +44719,39 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4.8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4.8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
         "structured_output": true,
         "temperature": false,
         "tool_call": true
@@ -41776,8 +44777,8 @@
         "modalities": {
           "input": [
             "text",
-            "audio",
             "image",
+            "audio",
             "video"
           ],
           "output": [
@@ -41792,38 +44793,6 @@
         "temperature": true,
         "tool_call": true
       },
-      "mistralai/devstral-medium": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0.04,
-          "input": 0.4,
-          "output": 2
-        },
-        "family": "devstral",
-        "id": "mistralai/devstral-medium",
-        "knowledge": "2025-06-30",
-        "last_updated": "2025-07-10",
-        "limit": {
-          "context": 131072,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Devstral Medium",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-07-10",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
       "qwen/qwen-plus": {
         "attachment": false,
         "cost": {
@@ -41834,8 +44803,8 @@
         },
         "family": "qwen",
         "id": "qwen/qwen-plus",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-02-01",
+        "knowledge": "2024-04",
+        "last_updated": "2025-09-11",
         "limit": {
           "context": 1000000,
           "output": 32768
@@ -41848,10 +44817,10 @@
             "text"
           ]
         },
-        "name": "Qwen-Plus",
+        "name": "Qwen Plus",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-02-01",
+        "release_date": "2024-01-25",
         "structured_output": false,
         "temperature": true,
         "tool_call": true
@@ -41989,6 +44958,7 @@
         "last_updated": "2025-12-11",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -42058,7 +45028,7 @@
         "last_updated": "2026-02-11",
         "limit": {
           "context": 202752,
-          "output": 131000
+          "output": 16384
         },
         "modalities": {
           "input": [
@@ -42079,7 +45049,7 @@
       "meta-llama/llama-4-scout": {
         "attachment": true,
         "cost": {
-          "input": 0.08,
+          "input": 0.1,
           "output": 0.3
         },
         "family": "llama",
@@ -42233,38 +45203,6 @@
         "temperature": false,
         "tool_call": true
       },
-      "mistralai/devstral-small": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0.01,
-          "input": 0.1,
-          "output": 0.3
-        },
-        "family": "devstral",
-        "id": "mistralai/devstral-small",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-07-10",
-        "limit": {
-          "context": 131072,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Devstral Small 1.1",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2025-07-10",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
       "qwen/qwen3.6-flash": {
         "attachment": true,
         "cost": {
@@ -42300,9 +45238,9 @@
       "~moonshotai/kimi-latest": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.25,
-          "input": 0.73,
-          "output": 3.49
+          "cache_read": 0.34,
+          "input": 0.68,
+          "output": 3.41
         },
         "family": "kimi",
         "id": "~moonshotai/kimi-latest",
@@ -42407,8 +45345,8 @@
             "text"
           ],
           "output": [
-            "image",
-            "text"
+            "text",
+            "image"
           ]
         },
         "name": "Nano Banana 2",
@@ -42513,45 +45451,15 @@
         "temperature": true,
         "tool_call": true
       },
-      "baidu/ernie-4.5-21b-a3b": {
-        "attachment": false,
-        "cost": {
-          "input": 0.07,
-          "output": 0.28
-        },
-        "family": "ernie",
-        "id": "baidu/ernie-4.5-21b-a3b",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-08-12",
-        "limit": {
-          "context": 120000,
-          "output": 8000
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "ERNIE 4.5 21B A3B",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2025-08-12",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": true
-      },
       "qwen/qwen3.6-35b-a3b": {
         "attachment": true,
         "cost": {
           "input": 0.14,
           "output": 1
         },
-        "family": "qwen3.6",
+        "family": "qwen",
         "id": "qwen/qwen3.6-35b-a3b",
-        "last_updated": "2026-04-27",
+        "last_updated": "2026-04-17",
         "limit": {
           "context": 262140,
           "output": 262140
@@ -42566,10 +45474,10 @@
             "text"
           ]
         },
-        "name": "Qwen3.6 35B A3B",
+        "name": "Qwen3.6 35B-A3B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-04-27",
+        "release_date": "2026-04-17",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -42617,6 +45525,7 @@
         "last_updated": "2026-03-17",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -42680,6 +45589,7 @@
         "last_updated": "2025-08-07",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -42961,6 +45871,7 @@
         "last_updated": "2025-11-13",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -42983,7 +45894,7 @@
       "qwen/qwen3.5-9b": {
         "attachment": true,
         "cost": {
-          "input": 0.04,
+          "input": 0.1,
           "output": 0.15
         },
         "family": "qwen3.5",
@@ -42991,7 +45902,7 @@
         "last_updated": "2026-03-10",
         "limit": {
           "context": 262144,
-          "output": 81920
+          "output": 262144
         },
         "modalities": {
           "input": [
@@ -43104,6 +46015,36 @@
         "temperature": true,
         "tool_call": true
       },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.15,
+          "input": 0.5,
+          "output": 2.5
+        },
+        "family": "nemotron",
+        "id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nemotron 3 Ultra 550B A55B",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-06-04",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
       "qwen/qwen3.5-plus-20260420": {
         "attachment": true,
         "cost": {
@@ -43144,8 +46085,8 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3-next-80b-a3b-instruct",
-        "knowledge": "2025-09-30",
-        "last_updated": "2025-09-11",
+        "knowledge": "2025-04",
+        "last_updated": "2025-09",
         "limit": {
           "context": 262144,
           "output": 16384
@@ -43158,10 +46099,10 @@
             "text"
           ]
         },
-        "name": "Qwen3 Next 80B A3B Instruct",
+        "name": "Qwen3-Next 80B-A3B Instruct",
         "open_weights": true,
         "reasoning": false,
-        "release_date": "2025-09-11",
+        "release_date": "2025-09",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -43234,15 +46175,16 @@
       "google/gemma-4-31b-it": {
         "attachment": true,
         "cost": {
+          "cache_read": 0.09,
           "input": 0.12,
-          "output": 0.37
+          "output": 0.36
         },
         "family": "gemma",
         "id": "google/gemma-4-31b-it",
         "last_updated": "2026-04-02",
         "limit": {
-          "context": 262144,
-          "output": 16384
+          "context": 256000,
+          "output": 8192
         },
         "modalities": {
           "input": [
@@ -43272,7 +46214,7 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3-max",
-        "knowledge": "2025-06-30",
+        "knowledge": "2025-04",
         "last_updated": "2025-09-23",
         "limit": {
           "context": 262144,
@@ -43328,38 +46270,6 @@
         "reasoning": true,
         "release_date": "2025-09-25",
         "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
-      "minimax/minimax-m2.5:free": {
-        "attachment": false,
-        "cost": {
-          "input": 0,
-          "output": 0
-        },
-        "family": "minimax",
-        "id": "minimax/minimax-m2.5:free",
-        "interleaved": {
-          "field": "reasoning_details"
-        },
-        "last_updated": "2026-02-12",
-        "limit": {
-          "context": 262144,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "MiniMax M2.5 (free)",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2026-02-12",
-        "structured_output": false,
         "temperature": true,
         "tool_call": true
       },
@@ -43472,6 +46382,7 @@
         "last_updated": "2025-09-15",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -43550,38 +46461,6 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-02-26",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
-      "mistralai/mistral-large-2411": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0.2,
-          "input": 2,
-          "output": 6
-        },
-        "family": "mistral-large",
-        "id": "mistralai/mistral-large-2411",
-        "knowledge": "2024-11",
-        "last_updated": "2024-11-04",
-        "limit": {
-          "context": 131072,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Mistral Large 2.1",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2024-11-01",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -43750,40 +46629,6 @@
         "temperature": true,
         "tool_call": true
       },
-      "xiaomi/mimo-v2-pro": {
-        "attachment": false,
-        "cost": {
-          "cache_read": 0.2,
-          "input": 1,
-          "output": 3
-        },
-        "family": "mimo",
-        "id": "xiaomi/mimo-v2-pro",
-        "interleaved": {
-          "field": "reasoning_details"
-        },
-        "knowledge": "2024-12",
-        "last_updated": "2026-03-18",
-        "limit": {
-          "context": 1048576,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "MiMo-V2-Pro",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2026-03-18",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": true
-      },
       "qwen/qwen3.5-397b-a17b": {
         "attachment": true,
         "cost": {
@@ -43792,8 +46637,7 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3.5-397b-a17b",
-        "knowledge": "2025-04",
-        "last_updated": "2026-02-16",
+        "last_updated": "2026-02-15",
         "limit": {
           "context": 262144,
           "output": 65536
@@ -43808,10 +46652,10 @@
             "text"
           ]
         },
-        "name": "Qwen3.5 397B A17B",
+        "name": "Qwen3.5 397B-A17B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-02-16",
+        "release_date": "2026-02-15",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -44157,39 +47001,6 @@
         "temperature": false,
         "tool_call": true
       },
-      "mistralai/pixtral-large-2411": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0.2,
-          "input": 2,
-          "output": 6
-        },
-        "family": "mistral",
-        "id": "mistralai/pixtral-large-2411",
-        "knowledge": "2024-07-31",
-        "last_updated": "2024-11-19",
-        "limit": {
-          "context": 131072,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Pixtral Large 2411",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-11-19",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
       "arcee-ai/virtuoso-large": {
         "attachment": false,
         "cost": {
@@ -44377,37 +47188,6 @@
         "temperature": true,
         "tool_call": true
       },
-      "deepseek/deepseek-v3.2-speciale": {
-        "attachment": false,
-        "cost": {
-          "cache_read": 0.058,
-          "input": 0.287,
-          "output": 0.431
-        },
-        "family": "deepseek",
-        "id": "deepseek/deepseek-v3.2-speciale",
-        "knowledge": "2024-07",
-        "last_updated": "2025-12-01",
-        "limit": {
-          "context": 163840,
-          "output": 163840
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "DeepSeek V3.2 Speciale",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2025-12-01",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": false
-      },
       "perplexity/sonar-reasoning-pro": {
         "attachment": true,
         "cost": {
@@ -44511,8 +47291,7 @@
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-nano-9b-v2:free",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-09-05",
+        "last_updated": "2025-08-18",
         "limit": {
           "context": 128000,
           "output": 128000
@@ -44528,7 +47307,7 @@
         "name": "Nemotron Nano 9B V2 (free)",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-09-05",
+        "release_date": "2025-08-18",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -44640,8 +47419,8 @@
         },
         "modalities": {
           "input": [
-            "image",
             "text",
+            "image",
             "pdf"
           ],
           "output": [
@@ -44752,8 +47531,8 @@
       "meta-llama/llama-3-8b-instruct": {
         "attachment": false,
         "cost": {
-          "input": 0.04,
-          "output": 0.04
+          "input": 0.14,
+          "output": 0.14
         },
         "family": "llama",
         "id": "meta-llama/llama-3-8b-instruct",
@@ -44819,8 +47598,7 @@
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-nano-9b-v2",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-09-05",
+        "last_updated": "2025-08-18",
         "limit": {
           "context": 131072,
           "output": 16384
@@ -44833,10 +47611,10 @@
             "text"
           ]
         },
-        "name": "Nemotron Nano 9B V2",
+        "name": "Nemotron Nano 9B v2",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-09-05",
+        "release_date": "2025-08-18",
         "structured_output": false,
         "temperature": true,
         "tool_call": true
@@ -44936,38 +47714,6 @@
         "temperature": true,
         "tool_call": true
       },
-      "openai/gpt-4o-audio-preview": {
-        "attachment": true,
-        "cost": {
-          "input": 2.5,
-          "output": 10
-        },
-        "family": "gpt",
-        "id": "openai/gpt-4o-audio-preview",
-        "knowledge": "2023-10-31",
-        "last_updated": "2025-08-15",
-        "limit": {
-          "context": 128000,
-          "output": 16384
-        },
-        "modalities": {
-          "input": [
-            "audio",
-            "text"
-          ],
-          "output": [
-            "text",
-            "audio"
-          ]
-        },
-        "name": "GPT-4o Audio",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-08-15",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
       "openai/gpt-5.1-codex": {
         "attachment": true,
         "cost": {
@@ -44981,6 +47727,7 @@
         "last_updated": "2025-11-13",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -44998,6 +47745,39 @@
         "release_date": "2025-11-13",
         "structured_output": true,
         "temperature": false,
+        "tool_call": true
+      },
+      "qwen/qwen3.7-plus": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.08,
+          "cache_write": 0.5,
+          "input": 0.4,
+          "output": 1.6
+        },
+        "family": "qwen",
+        "id": "qwen/qwen3.7-plus",
+        "knowledge": "2025-04",
+        "last_updated": "2026-06-02",
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7 Plus",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-02",
+        "structured_output": true,
+        "temperature": true,
         "tool_call": true
       },
       "minimax/minimax-01": {
@@ -45044,6 +47824,7 @@
         "last_updated": "2026-02-05",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -45312,11 +48093,43 @@
         "temperature": true,
         "tool_call": true
       },
+      "minimax/minimax-m3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.06,
+          "input": 0.3,
+          "output": 1.2
+        },
+        "family": "minimax",
+        "id": "minimax/minimax-m3",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 524288,
+          "output": 512000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-01",
+        "structured_output": false,
+        "temperature": true,
+        "tool_call": true
+      },
       "google/gemma-3-12b-it": {
         "attachment": true,
         "cost": {
-          "input": 0.04,
-          "output": 0.13
+          "input": 0.05,
+          "output": 0.15
         },
         "family": "gemma",
         "id": "google/gemma-3-12b-it",
@@ -45502,35 +48315,6 @@
         "temperature": true,
         "tool_call": false
       },
-      "nex-agi/deepseek-v3.1-nex-n1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.135,
-          "output": 0.5
-        },
-        "family": "deepseek",
-        "id": "nex-agi/deepseek-v3.1-nex-n1",
-        "last_updated": "2025-12-08",
-        "limit": {
-          "context": 131072,
-          "output": 163840
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "DeepSeek V3.1 Nex N1",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2025-12-08",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
       "minimax/minimax-m2.1": {
         "attachment": false,
         "cost": {
@@ -45647,8 +48431,8 @@
             "text",
             "image",
             "video",
-            "pdf",
-            "audio"
+            "audio",
+            "pdf"
           ],
           "output": [
             "text"
@@ -45658,36 +48442,6 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-03",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
-      "openai/gpt-4-1106-preview": {
-        "attachment": false,
-        "cost": {
-          "input": 10,
-          "output": 30
-        },
-        "family": "gpt",
-        "id": "openai/gpt-4-1106-preview",
-        "knowledge": "2023-04-30",
-        "last_updated": "2023-11-06",
-        "limit": {
-          "context": 128000,
-          "output": 4096
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT-4 Turbo (older v1106)",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2023-11-06",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -45825,7 +48579,7 @@
         },
         "family": "Hy",
         "id": "tencent/hy3-preview",
-        "last_updated": "2026-04-22",
+        "last_updated": "2026-04-20",
         "limit": {
           "context": 262144,
           "output": 262144
@@ -45841,7 +48595,7 @@
         "name": "Hy3 preview",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-04-22",
+        "release_date": "2026-04-20",
         "structured_output": false,
         "temperature": true,
         "tool_call": true
@@ -46238,8 +48992,8 @@
         },
         "modalities": {
           "input": [
-            "image",
             "text",
+            "image",
             "pdf"
           ],
           "output": [
@@ -46368,11 +49122,11 @@
         },
         "modalities": {
           "input": [
-            "pdf",
-            "image",
             "text",
+            "image",
             "audio",
-            "video"
+            "video",
+            "pdf"
           ],
           "output": [
             "text"
@@ -46447,35 +49201,37 @@
         "temperature": true,
         "tool_call": false
       },
-      "nousresearch/hermes-2-pro-llama-3-8b": {
-        "attachment": false,
+      "stepfun/step-3.7-flash": {
+        "attachment": true,
         "cost": {
-          "input": 0.14,
-          "output": 0.14
+          "cache_read": 0.04,
+          "input": 0.2,
+          "output": 1.15
         },
-        "family": "nousresearch",
-        "id": "nousresearch/hermes-2-pro-llama-3-8b",
-        "knowledge": "2023-12-31",
-        "last_updated": "2024-05-27",
+        "family": "step",
+        "id": "stepfun/step-3.7-flash",
+        "last_updated": "2026-05-28",
         "limit": {
-          "context": 8192,
-          "output": 8192
+          "context": 256000,
+          "output": 256000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Hermes 2 Pro - Llama-3 8B",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2024-05-27",
+        "name": "Step 3.7 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
         "structured_output": true,
         "temperature": true,
-        "tool_call": false
+        "tool_call": true
       },
       "google/gemini-2.5-pro-preview": {
         "attachment": true,
@@ -46753,9 +49509,9 @@
         "modalities": {
           "input": [
             "text",
-            "audio",
             "image",
             "video",
+            "audio",
             "pdf"
           ],
           "output": [
@@ -46800,36 +49556,6 @@
         "temperature": true,
         "tool_call": false
       },
-      "baidu/ernie-4.5-300b-a47b": {
-        "attachment": false,
-        "cost": {
-          "input": 0.28,
-          "output": 1.1
-        },
-        "family": "ernie",
-        "id": "baidu/ernie-4.5-300b-a47b",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-06-30",
-        "limit": {
-          "context": 123000,
-          "output": 12000
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "ERNIE 4.5 300B A47B ",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2025-06-30",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
       "mistralai/mistral-small-24b-instruct-2501": {
         "attachment": false,
         "cost": {
@@ -46863,9 +49589,9 @@
       "deepseek/deepseek-v4-flash": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.02,
-          "input": 0.1,
-          "output": 0.2
+          "cache_read": 0.0197,
+          "input": 0.0983,
+          "output": 0.1966
         },
         "family": "deepseek-flash",
         "id": "deepseek/deepseek-v4-flash",
@@ -46876,7 +49602,7 @@
         "last_updated": "2026-04-24",
         "limit": {
           "context": 1048576,
-          "output": 16384
+          "output": 131072
         },
         "modalities": {
           "input": [
@@ -46894,11 +49620,44 @@
         "temperature": true,
         "tool_call": true
       },
+      "anthropic/claude-opus-4.8-fast": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1,
+          "cache_write": 12.5,
+          "input": 10,
+          "output": 50
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4.8-fast",
+        "last_updated": "2026-05-27",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8 (Fast)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-27",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
       "qwen/qwen3-30b-a3b": {
         "attachment": false,
         "cost": {
-          "input": 0.09,
-          "output": 0.45
+          "input": 0.12,
+          "output": 0.5
         },
         "family": "qwen",
         "id": "qwen/qwen3-30b-a3b",
@@ -46906,7 +49665,7 @@
         "last_updated": "2025-04-28",
         "limit": {
           "context": 40960,
-          "output": 20000
+          "output": 16384
         },
         "modalities": {
           "input": [
@@ -46931,9 +49690,10 @@
           "input": 1.04,
           "output": 6.24
         },
-        "family": "qwen3.6",
+        "family": "qwen",
         "id": "qwen/qwen3.6-max-preview",
-        "last_updated": "2026-04-27",
+        "knowledge": "2025-04",
+        "last_updated": "2026-04-20",
         "limit": {
           "context": 262144,
           "output": 65536
@@ -46949,7 +49709,7 @@
         "name": "Qwen3.6 Max Preview",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2026-04-27",
+        "release_date": "2026-04-20",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -46987,15 +49747,16 @@
       "qwen/qwen3.5-35b-a3b": {
         "attachment": true,
         "cost": {
-          "input": 0.139,
+          "cache_read": 0.05,
+          "input": 0.14,
           "output": 1
         },
-        "family": "qwen3.5",
+        "family": "qwen",
         "id": "qwen/qwen3.5-35b-a3b",
-        "last_updated": "2026-02-25",
+        "last_updated": "2026-02-23",
         "limit": {
           "context": 262144,
-          "output": 81920
+          "output": 262144
         },
         "modalities": {
           "input": [
@@ -47007,10 +49768,10 @@
             "text"
           ]
         },
-        "name": "Qwen3.5-35B-A3B",
+        "name": "Qwen3.5 35B-A3B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-02-25",
+        "release_date": "2026-02-23",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -47065,13 +49826,14 @@
         "last_updated": "2026-04-23",
         "limit": {
           "context": 1050000,
+          "input": 922000,
           "output": 128000
         },
         "modalities": {
           "input": [
-            "pdf",
+            "text",
             "image",
-            "text"
+            "pdf"
           ],
           "output": [
             "text"
@@ -47316,8 +50078,8 @@
         },
         "modalities": {
           "input": [
-            "image",
             "text",
+            "image",
             "pdf"
           ],
           "output": [
@@ -47524,8 +50286,8 @@
       "google/gemma-3-4b-it": {
         "attachment": true,
         "cost": {
-          "input": 0.04,
-          "output": 0.08
+          "input": 0.05,
+          "output": 0.1
         },
         "family": "gemma",
         "id": "google/gemma-3-4b-it",
@@ -47574,8 +50336,8 @@
             "text",
             "image",
             "video",
-            "pdf",
-            "audio"
+            "audio",
+            "pdf"
           ],
           "output": [
             "text"
@@ -47685,16 +50447,16 @@
       "qwen/qwen3-30b-a3b-instruct-2507": {
         "attachment": false,
         "cost": {
-          "input": 0.09,
-          "output": 0.3
+          "input": 0.04815,
+          "output": 0.19305
         },
         "family": "qwen",
         "id": "qwen/qwen3-30b-a3b-instruct-2507",
         "knowledge": "2025-06-30",
         "last_updated": "2025-07-29",
         "limit": {
-          "context": 262144,
-          "output": 262144
+          "context": 128000,
+          "output": 32000
         },
         "modalities": {
           "input": [
@@ -47720,7 +50482,6 @@
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-3-super-120b-a12b:free",
-        "knowledge": "2024-04",
         "last_updated": "2026-03-11",
         "limit": {
           "context": 262144,
@@ -47750,8 +50511,8 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3-235b-a22b",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-04-28",
+        "knowledge": "2025-04",
+        "last_updated": "2025-04",
         "limit": {
           "context": 131072,
           "output": 8192
@@ -47764,10 +50525,10 @@
             "text"
           ]
         },
-        "name": "Qwen3 235B A22B",
+        "name": "Qwen3 235B-A22B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-04-28",
+        "release_date": "2025-04",
         "structured_output": false,
         "temperature": true,
         "tool_call": true
@@ -47870,7 +50631,7 @@
       "openai/gpt-oss-20b": {
         "attachment": false,
         "cost": {
-          "input": 0.03,
+          "input": 0.029,
           "output": 0.14
         },
         "family": "gpt-oss",
@@ -47931,14 +50692,14 @@
         "attachment": false,
         "cost": {
           "input": 0.02,
-          "output": 0.05
+          "output": 0.03
         },
         "family": "llama",
         "id": "meta-llama/llama-3.1-8b-instruct",
         "knowledge": "2023-12-31",
         "last_updated": "2024-07-23",
         "limit": {
-          "context": 16384,
+          "context": 131072,
           "output": 16384
         },
         "modalities": {
@@ -47984,6 +50745,36 @@
         "reasoning": false,
         "release_date": "2024-08-13",
         "structured_output": true,
+        "temperature": true,
+        "tool_call": false
+      },
+      "nvidia/nemotron-3.5-content-safety:free": {
+        "attachment": true,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "nemotron",
+        "id": "nvidia/nemotron-3.5-content-safety:free",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 128000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nemotron 3.5 Content Safety (free)",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-06-04",
+        "structured_output": false,
         "temperature": true,
         "tool_call": false
       },
@@ -48049,36 +50840,6 @@
         "temperature": true,
         "tool_call": true
       },
-      "alfredpros/codellama-7b-instruct-solidity": {
-        "attachment": false,
-        "cost": {
-          "input": 0.8,
-          "output": 1.2
-        },
-        "family": "llama",
-        "id": "alfredpros/codellama-7b-instruct-solidity",
-        "knowledge": "2023-06-30",
-        "last_updated": "2025-04-14",
-        "limit": {
-          "context": 4096,
-          "output": 4096
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "CodeLLaMa 7B Instruct Solidity",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2025-04-14",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
       "nvidia/nemotron-3-super-120b-a12b": {
         "attachment": false,
         "cost": {
@@ -48087,7 +50848,6 @@
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-3-super-120b-a12b",
-        "knowledge": "2024-04",
         "last_updated": "2026-03-11",
         "limit": {
           "context": 262144,
@@ -48101,7 +50861,7 @@
             "text"
           ]
         },
-        "name": "Nemotron 3 Super",
+        "name": "Nemotron 3 Super 120B A12B",
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-11",
@@ -48152,13 +50912,14 @@
         "last_updated": "2026-04-23",
         "limit": {
           "context": 1050000,
+          "input": 922000,
           "output": 128000
         },
         "modalities": {
           "input": [
-            "pdf",
+            "text",
             "image",
-            "text"
+            "pdf"
           ],
           "output": [
             "text"
@@ -48261,9 +51022,9 @@
           "input": [
             "text",
             "image",
-            "pdf",
+            "video",
             "audio",
-            "video"
+            "pdf"
           ],
           "output": [
             "text"
@@ -48384,6 +51145,7 @@
         "last_updated": "2026-03-17",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -48707,41 +51469,11 @@
         "temperature": true,
         "tool_call": true
       },
-      "sao10k/l3-euryale-70b": {
-        "attachment": false,
-        "cost": {
-          "input": 1.48,
-          "output": 1.48
-        },
-        "family": "llama",
-        "id": "sao10k/l3-euryale-70b",
-        "knowledge": "2023-12-31",
-        "last_updated": "2024-06-18",
-        "limit": {
-          "context": 8192,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3 Euryale 70B v2.1",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2024-06-18",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": true
-      },
       "meta-llama/llama-3.2-11b-vision-instruct": {
         "attachment": true,
         "cost": {
-          "input": 0.245,
-          "output": 0.245
+          "input": 0.345,
+          "output": 0.345
         },
         "family": "llama",
         "id": "meta-llama/llama-3.2-11b-vision-instruct",
@@ -48920,8 +51652,8 @@
       "nousresearch/hermes-3-llama-3.1-70b": {
         "attachment": false,
         "cost": {
-          "input": 0.3,
-          "output": 0.3
+          "input": 0.7,
+          "output": 0.7
         },
         "family": "nousresearch",
         "id": "nousresearch/hermes-3-llama-3.1-70b",
@@ -49065,36 +51797,6 @@
         "temperature": true,
         "tool_call": false
       },
-      "baidu/ernie-4.5-21b-a3b-thinking": {
-        "attachment": false,
-        "cost": {
-          "input": 0.07,
-          "output": 0.28
-        },
-        "family": "ernie",
-        "id": "baidu/ernie-4.5-21b-a3b-thinking",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-10-09",
-        "limit": {
-          "context": 131072,
-          "output": 65536
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "ERNIE 4.5 21B A3B Thinking",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2025-10-09",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
       "openai/o3": {
         "attachment": true,
         "cost": {
@@ -49112,8 +51814,8 @@
         },
         "modalities": {
           "input": [
-            "image",
             "text",
+            "image",
             "pdf"
           ],
           "output": [
@@ -49126,42 +51828,6 @@
         "release_date": "2025-04-16",
         "structured_output": true,
         "temperature": false,
-        "tool_call": true
-      },
-      "google/gemini-2.0-flash-001": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0.025,
-          "cache_write": 0.083333,
-          "input": 0.1,
-          "output": 0.4
-        },
-        "family": "gemini-flash",
-        "id": "google/gemini-2.0-flash-001",
-        "knowledge": "2024-08-31",
-        "last_updated": "2025-02-05",
-        "limit": {
-          "context": 1000000,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf",
-            "audio",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Gemini 2.0 Flash",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-02-05",
-        "structured_output": true,
-        "temperature": true,
         "tool_call": true
       },
       "openai/gpt-5-image": {
@@ -49206,7 +51872,6 @@
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-nano-12b-v2-vl:free",
-        "knowledge": "2025-11",
         "last_updated": "2025-10-28",
         "limit": {
           "context": 128000,
@@ -49214,8 +51879,8 @@
         },
         "modalities": {
           "input": [
-            "image",
             "text",
+            "image",
             "video"
           ],
           "output": [
@@ -49238,8 +51903,8 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3-coder-30b-a3b-instruct",
-        "knowledge": "2025-06-30",
-        "last_updated": "2025-07-31",
+        "knowledge": "2025-04",
+        "last_updated": "2025-04",
         "limit": {
           "context": 160000,
           "output": 32768
@@ -49252,58 +51917,27 @@
             "text"
           ]
         },
-        "name": "Qwen3 Coder 30B A3B Instruct",
+        "name": "Qwen3-Coder 30B-A3B Instruct",
         "open_weights": true,
         "reasoning": false,
-        "release_date": "2025-07-31",
+        "release_date": "2025-04",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
-      "mistralai/mistral-7b-instruct-v0.1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.11,
-          "output": 0.19
-        },
-        "family": "mistral",
-        "id": "mistralai/mistral-7b-instruct-v0.1",
-        "knowledge": "2023-09-30",
-        "last_updated": "2023-09-28",
-        "limit": {
-          "context": 2824,
-          "output": 2824
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Mistral 7B Instruct v0.1",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2023-09-28",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
       "deepseek/deepseek-v3.2": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.0252,
-          "input": 0.252,
-          "output": 0.378
+          "input": 0.2288,
+          "output": 0.3432
         },
         "family": "deepseek",
         "id": "deepseek/deepseek-v3.2",
         "knowledge": "2024-07",
         "last_updated": "2025-12-01",
         "limit": {
-          "context": 131072,
-          "output": 65536
+          "context": 128000,
+          "output": 64000
         },
         "modalities": {
           "input": [
@@ -49339,12 +51973,12 @@
         },
         "modalities": {
           "input": [
-            "image",
-            "text"
+            "text",
+            "image"
           ],
           "output": [
-            "image",
-            "text"
+            "text",
+            "image"
           ]
         },
         "name": "Nano Banana",
@@ -49383,40 +52017,6 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2024-04-17",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
-      "google/gemini-2.0-flash-lite-001": {
-        "attachment": true,
-        "cost": {
-          "input": 0.075,
-          "output": 0.3
-        },
-        "family": "gemini",
-        "id": "google/gemini-2.0-flash-lite-001",
-        "knowledge": "2024-08-31",
-        "last_updated": "2025-02-25",
-        "limit": {
-          "context": 1048576,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf",
-            "audio",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Gemini 2.0 Flash Lite",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-02-25",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -49559,37 +52159,6 @@
         "temperature": true,
         "tool_call": true
       },
-      "baidu/ernie-4.5-vl-28b-a3b": {
-        "attachment": true,
-        "cost": {
-          "input": 0.14,
-          "output": 0.56
-        },
-        "family": "ernie",
-        "id": "baidu/ernie-4.5-vl-28b-a3b",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-08-12",
-        "limit": {
-          "context": 30000,
-          "output": 8000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "ERNIE 4.5 VL 28B A3B",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2025-08-12",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": true
-      },
       "openai/o3-mini-high": {
         "attachment": true,
         "cost": {
@@ -49685,7 +52254,7 @@
       "qwen/qwen3-235b-a22b-2507": {
         "attachment": false,
         "cost": {
-          "input": 0.071,
+          "input": 0.09,
           "output": 0.1
         },
         "family": "qwen",
@@ -49759,8 +52328,8 @@
         },
         "modalities": {
           "input": [
-            "image",
             "text",
+            "image",
             "video"
           ],
           "output": [
@@ -49782,10 +52351,9 @@
           "input": 0.09,
           "output": 0.3
         },
-        "family": "step",
         "id": "stepfun/step-3.5-flash",
         "knowledge": "2025-01",
-        "last_updated": "2026-01-29",
+        "last_updated": "2026-02-13",
         "limit": {
           "context": 262144,
           "output": 16384
@@ -49879,6 +52447,7 @@
         "last_updated": "2026-03-05",
         "limit": {
           "context": 1050000,
+          "input": 922000,
           "output": 128000
         },
         "modalities": {
@@ -49972,6 +52541,7 @@
         "last_updated": "2025-12-11",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -50038,7 +52608,7 @@
         "last_updated": "2026-03-27",
         "limit": {
           "context": 202752,
-          "output": 202800
+          "output": 131072
         },
         "modalities": {
           "input": [
@@ -50049,7 +52619,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -50107,9 +52677,9 @@
           "input": [
             "text",
             "image",
-            "pdf",
             "audio",
-            "video"
+            "video",
+            "pdf"
           ],
           "output": [
             "text"
@@ -50182,7 +52752,7 @@
         "release_date": "2025-04-05",
         "structured_output": true,
         "temperature": true,
-        "tool_call": false
+        "tool_call": true
       },
       "mistralai/mistral-medium-3-5": {
         "attachment": true,
@@ -50228,6 +52798,7 @@
         "last_updated": "2025-11-13",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -50261,6 +52832,7 @@
         "last_updated": "2025-08-07",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -50302,9 +52874,9 @@
           "input": [
             "text",
             "image",
-            "pdf",
             "audio",
-            "video"
+            "video",
+            "pdf"
           ],
           "output": [
             "text"
@@ -50420,7 +52992,7 @@
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-3-nano-30b-a3b",
-        "last_updated": "2025-12-14",
+        "last_updated": "2025-12-15",
         "limit": {
           "context": 262144,
           "output": 228000
@@ -50436,7 +53008,7 @@
         "name": "Nemotron 3 Nano 30B A3B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-12-14",
+        "release_date": "2025-12-15",
         "structured_output": false,
         "temperature": true,
         "tool_call": true
@@ -50510,13 +53082,12 @@
       "nvidia/llama-3.3-nemotron-super-49b-v1.5": {
         "attachment": false,
         "cost": {
-          "input": 0.1,
+          "input": 0.4,
           "output": 0.4
         },
         "family": "nemotron",
         "id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-        "knowledge": "2024-03-31",
-        "last_updated": "2025-10-10",
+        "last_updated": "2025-07-25",
         "limit": {
           "context": 131072,
           "output": 16384
@@ -50529,10 +53100,10 @@
             "text"
           ]
         },
-        "name": "Llama 3.3 Nemotron Super 49B V1.5",
+        "name": "Llama 3.3 Nemotron Super 49B v1.5",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-10-10",
+        "release_date": "2025-07-25",
         "structured_output": false,
         "temperature": true,
         "tool_call": true
@@ -50583,6 +53154,7 @@
         "last_updated": "2025-08-07",
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "modalities": {
@@ -50611,8 +53183,7 @@
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-3-nano-30b-a3b:free",
-        "knowledge": "2025-11",
-        "last_updated": "2025-12-14",
+        "last_updated": "2025-12-15",
         "limit": {
           "context": 256000,
           "output": 256000
@@ -50628,7 +53199,7 @@
         "name": "Nemotron 3 Nano 30B A3B (free)",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-12-14",
+        "release_date": "2025-12-15",
         "structured_output": false,
         "temperature": true,
         "tool_call": true
@@ -50671,8 +53242,8 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3-32b",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-04-28",
+        "knowledge": "2025-04",
+        "last_updated": "2025-04",
         "limit": {
           "context": 40960,
           "output": 16384
@@ -50688,7 +53259,7 @@
         "name": "Qwen3 32B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-04-28",
+        "release_date": "2025-04",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -50874,43 +53445,6 @@
         "temperature": true,
         "tool_call": false
       },
-      "xiaomi/mimo-v2-omni": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0.08,
-          "input": 0.4,
-          "output": 2
-        },
-        "family": "mimo",
-        "id": "xiaomi/mimo-v2-omni",
-        "interleaved": {
-          "field": "reasoning_details"
-        },
-        "knowledge": "2024-12",
-        "last_updated": "2026-03-18",
-        "limit": {
-          "context": 262144,
-          "output": 65536
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "audio",
-            "image",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "MiMo-V2-Omni",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2026-03-18",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": true
-      },
       "openrouter/auto": {
         "attachment": true,
         "family": "auto",
@@ -50950,8 +53484,9 @@
           "output": 12,
           "reasoning": 12
         },
-        "family": "gemini",
+        "family": "gemini-pro",
         "id": "google/gemini-3-pro-image-preview",
+        "knowledge": "2025-01",
         "last_updated": "2025-11-20",
         "limit": {
           "context": 65536,
@@ -50959,15 +53494,15 @@
         },
         "modalities": {
           "input": [
-            "image",
-            "text"
+            "text",
+            "image"
           ],
           "output": [
-            "image",
-            "text"
+            "text",
+            "image"
           ]
         },
-        "name": "Nano Banana Pro (Gemini 3 Pro Image Preview)",
+        "name": "Nano Banana Pro",
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-11-20",
@@ -51004,36 +53539,6 @@
         "structured_output": false,
         "temperature": true,
         "tool_call": true
-      },
-      "arcee-ai/spotlight": {
-        "attachment": true,
-        "cost": {
-          "input": 0.18,
-          "output": 0.18
-        },
-        "id": "arcee-ai/spotlight",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-05-05",
-        "limit": {
-          "context": 131072,
-          "output": 65537
-        },
-        "modalities": {
-          "input": [
-            "image",
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Spotlight",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2025-05-05",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
       },
       "nousresearch/hermes-3-llama-3.1-405b:free": {
         "attachment": false,
@@ -51292,16 +53797,16 @@
         "modalities": {
           "input": [
             "text",
-            "audio",
             "image",
-            "video"
+            "video",
+            "audio"
           ],
           "output": [
             "text"
           ]
         },
         "name": "Nemotron 3 Nano Omni (free)",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-04-28",
         "structured_output": false,
@@ -51440,8 +53945,8 @@
         },
         "family": "qwen",
         "id": "qwen/qwen3-next-80b-a3b-instruct:free",
-        "knowledge": "2025-09-30",
-        "last_updated": "2025-09-11",
+        "knowledge": "2025-04",
+        "last_updated": "2025-09",
         "limit": {
           "context": 262144,
           "output": 262144
@@ -51457,7 +53962,7 @@
         "name": "Qwen3 Next 80B A3B Instruct (free)",
         "open_weights": true,
         "reasoning": false,
-        "release_date": "2025-09-11",
+        "release_date": "2025-09",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -51526,15 +54031,15 @@
       "qwen/qwen3.6-27b": {
         "attachment": true,
         "cost": {
-          "input": 0.29,
-          "output": 3.2
+          "input": 0.289,
+          "output": 2.4
         },
-        "family": "qwen3.6",
+        "family": "qwen",
         "id": "qwen/qwen3.6-27b",
-        "last_updated": "2026-04-27",
+        "last_updated": "2026-04-22",
         "limit": {
-          "context": 262140,
-          "output": 262140
+          "context": 131072,
+          "output": 131072
         },
         "modalities": {
           "input": [
@@ -51549,7 +54054,7 @@
         "name": "Qwen3.6 27B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-04-27",
+        "release_date": "2026-04-22",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -51636,8 +54141,8 @@
             "text",
             "image",
             "video",
-            "pdf",
-            "audio"
+            "audio",
+            "pdf"
           ],
           "output": [
             "text"
@@ -51759,7 +54264,7 @@
         "last_updated": "2025-07-30",
         "limit": {
           "context": 40960,
-          "output": 40960
+          "output": 4096
         },
         "modalities": {
           "input": [
@@ -52100,6 +54605,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-12-11",
+        "status": "deprecated",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -52134,6 +54640,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-12-11",
+        "status": "deprecated",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -52169,6 +54676,16 @@
         "name": "Gemini 2.5 Flash",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "max": 24576,
+            "min": 0,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-03-20",
         "structured_output": true,
         "temperature": true,
@@ -52237,6 +54754,16 @@
         "name": "Gemini 2.5 Flash-Lite",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "max": 24576,
+            "min": 512,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-06-17",
         "structured_output": true,
         "temperature": true,
@@ -52317,6 +54844,13 @@
         "name": "Gemini 2.5 Pro",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "max": 32768,
+            "min": 128,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-03-20",
         "structured_output": true,
         "temperature": true,
@@ -52382,10 +54916,52 @@
         "name": "Gemini 3 Flash Preview",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2025-12-17",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
+      },
+      "gemini-3-pro-image-preview": {
+        "attachment": true,
+        "cost": {
+          "input": 2,
+          "output": 120
+        },
+        "family": "gemini-pro",
+        "id": "gemini-3-pro-image-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2025-11-20",
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "name": "Nano Banana Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-20",
+        "temperature": true,
+        "tool_call": false
       },
       "gemini-3-pro-preview": {
         "attachment": true,
@@ -52433,7 +55009,17 @@
         "name": "Gemini 3 Pro Preview",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2025-11-18",
+        "status": "deprecated",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -52501,6 +55087,17 @@
         "name": "Gemini 3.1 Flash Lite",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-05-07",
         "structured_output": true,
         "temperature": true,
@@ -52538,6 +55135,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-03",
+        "status": "deprecated",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -52588,6 +55186,16 @@
         "name": "Gemini 3.1 Pro Preview",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-02-19",
         "structured_output": true,
         "temperature": true,
@@ -52675,6 +55283,17 @@
         "name": "Gemini 3.5 Flash",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-05-19",
         "structured_output": true,
         "temperature": true,
@@ -52960,6 +55579,15 @@
         "name": "Step 3.5 Flash 2603",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-04-02",
         "temperature": true,
         "tool_call": true
@@ -53140,6 +55768,903 @@
       }
     },
     "name": "D.Run (China)",
+    "npm": "@ai-sdk/openai-compatible"
+  },
+  "anyapi": {
+    "api": "https://api.anyapi.ai/v1",
+    "doc": "https://docs.anyapi.ai",
+    "env": [
+      "ANYAPI_API_KEY"
+    ],
+    "id": "anyapi",
+    "models": {
+      "anthropic/claude-haiku-4-5": {
+        "attachment": true,
+        "family": "claude-haiku",
+        "id": "anthropic/claude-haiku-4-5",
+        "knowledge": "2025-02-28",
+        "last_updated": "2025-10-15",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 4.5 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-10-15",
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4-6": {
+        "attachment": true,
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 3,
+                "cache_write": 37.5,
+                "input": 30,
+                "output": 150
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4-6",
+        "knowledge": "2025-05-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.6",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4-7": {
+        "attachment": true,
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 3,
+                "cache_write": 37.5,
+                "input": 30,
+                "output": 150
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4-7",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-04-16",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.7",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-16",
+        "temperature": false,
+        "tool_call": true
+      },
+      "anthropic/claude-sonnet-4-5": {
+        "attachment": true,
+        "family": "claude-sonnet",
+        "id": "anthropic/claude-sonnet-4-5",
+        "knowledge": "2025-07-31",
+        "last_updated": "2025-09-29",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.5 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-29",
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "attachment": true,
+        "family": "claude-sonnet",
+        "id": "anthropic/claude-sonnet-4-6",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.6",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "cohere/command-r-plus-08-2024": {
+        "attachment": false,
+        "family": "command-r",
+        "id": "cohere/command-r-plus-08-2024",
+        "knowledge": "2024-06-01",
+        "last_updated": "2024-08-30",
+        "limit": {
+          "context": 128000,
+          "output": 4000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Command R+",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-08-30",
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek/deepseek-chat": {
+        "attachment": true,
+        "family": "deepseek",
+        "id": "deepseek/deepseek-chat",
+        "knowledge": "2025-09",
+        "last_updated": "2026-02-28",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek Chat",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-12-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek/deepseek-r1": {
+        "attachment": true,
+        "family": "deepseek-thinking",
+        "id": "deepseek/deepseek-r1",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-09",
+        "last_updated": "2026-02-28",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek Reasoner",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-12-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek/deepseek-v4-flash": {
+        "attachment": false,
+        "family": "deepseek-flash",
+        "id": "deepseek/deepseek-v4-flash",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-05",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Flash",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek/deepseek-v4-pro": {
+        "attachment": false,
+        "family": "deepseek-thinking",
+        "id": "deepseek/deepseek-v4-pro",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-05",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-2.5-flash": {
+        "attachment": true,
+        "family": "gemini-flash",
+        "id": "google/gemini-2.5-flash",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-05",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-03-20",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-2.5-flash-lite": {
+        "attachment": true,
+        "family": "gemini-flash-lite",
+        "id": "google/gemini-2.5-flash-lite",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash-Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-17",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-2.5-pro": {
+        "attachment": true,
+        "family": "gemini-pro",
+        "id": "google/gemini-2.5-pro",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-05",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-03-20",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-3-flash-preview": {
+        "attachment": true,
+        "family": "gemini-flash",
+        "id": "google/gemini-3-flash-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2025-12-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3 Flash Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-17",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-3-pro-preview": {
+        "attachment": true,
+        "family": "gemini-pro",
+        "id": "google/gemini-3-pro-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2025-11-18",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3 Pro Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-18",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistralai/devstral-2512": {
+        "attachment": false,
+        "family": "devstral",
+        "id": "mistralai/devstral-2512",
+        "knowledge": "2025-12",
+        "last_updated": "2025-12-09",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Devstral 2",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-12-09",
+        "status": "deprecated",
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistralai/mistral-large-2512": {
+        "attachment": true,
+        "family": "mistral-large",
+        "id": "mistralai/mistral-large-2512",
+        "knowledge": "2024-11",
+        "last_updated": "2025-12-02",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Large 3",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-11-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4.1": {
+        "attachment": true,
+        "family": "gpt",
+        "id": "openai/gpt-4.1",
+        "knowledge": "2024-04",
+        "last_updated": "2025-04-14",
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4.1",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-14",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4.1-mini": {
+        "attachment": true,
+        "family": "gpt-mini",
+        "id": "openai/gpt-4.1-mini",
+        "knowledge": "2024-04",
+        "last_updated": "2025-04-14",
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4.1 mini",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-14",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5": {
+        "attachment": true,
+        "family": "gpt",
+        "id": "openai/gpt-5",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/gpt-5-mini": {
+        "attachment": true,
+        "family": "gpt-mini",
+        "id": "openai/gpt-5-mini",
+        "knowledge": "2024-05-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/gpt-5.1": {
+        "attachment": true,
+        "family": "gpt",
+        "id": "openai/gpt-5.1",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/gpt-5.2": {
+        "attachment": true,
+        "family": "gpt",
+        "id": "openai/gpt-5.2",
+        "knowledge": "2025-08-31",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.2",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-11",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/gpt-5.4": {
+        "attachment": true,
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 0.5,
+                "input": 5,
+                "output": 30
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "family": "gpt",
+        "id": "openai/gpt-5.4",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-05",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/o3": {
+        "attachment": true,
+        "family": "o",
+        "id": "openai/o3",
+        "knowledge": "2024-05",
+        "last_updated": "2025-04-16",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-04-16",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/o3-mini": {
+        "attachment": false,
+        "family": "o-mini",
+        "id": "openai/o3-mini",
+        "knowledge": "2024-05",
+        "last_updated": "2025-01-29",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o3-mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-12-20",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/o4-mini": {
+        "attachment": true,
+        "family": "o-mini",
+        "id": "openai/o4-mini",
+        "knowledge": "2024-05",
+        "last_updated": "2025-04-16",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o4-mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-04-16",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "perplexity/sonar-pro": {
+        "attachment": true,
+        "family": "sonar-pro",
+        "id": "perplexity/sonar-pro",
+        "knowledge": "2025-09-01",
+        "last_updated": "2025-09-01",
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Sonar Pro",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-01-01",
+        "temperature": true,
+        "tool_call": false
+      },
+      "perplexity/sonar-reasoning-pro": {
+        "attachment": true,
+        "family": "sonar-reasoning",
+        "id": "perplexity/sonar-reasoning-pro",
+        "knowledge": "2025-09-01",
+        "last_updated": "2025-09-01",
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Sonar Reasoning Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-01-01",
+        "temperature": true,
+        "tool_call": false
+      },
+      "xai/grok-4.3": {
+        "attachment": true,
+        "family": "grok",
+        "id": "xai/grok-4.3",
+        "last_updated": "2026-04-17",
+        "limit": {
+          "context": 1000000,
+          "output": 30000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Grok 4.3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-17",
+        "temperature": true,
+        "tool_call": true
+      }
+    },
+    "name": "AnyAPI",
     "npm": "@ai-sdk/openai-compatible"
   },
   "helicone": {
@@ -56178,6 +59703,30 @@
         "temperature": true,
         "tool_call": true
       },
+      "deepseek-4-flash": {
+        "attachment": false,
+        "family": "deepseek",
+        "id": "deepseek-4-flash",
+        "last_updated": "2026-05-29",
+        "limit": {
+          "context": 262144,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Deepseek V4 Flash",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-05-27",
+        "temperature": true,
+        "tool_call": true
+      },
       "openai-gpt-4o-mini": {
         "attachment": true,
         "cost": {
@@ -57057,6 +60606,37 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-05-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic-claude-opus-4.8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "anthropic-claude-opus-4.8",
+        "last_updated": "2026-05-29",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
         "temperature": true,
         "tool_call": true
       },
@@ -61919,7 +65499,7 @@
           ]
         },
         "name": "GLM 5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -61932,7 +65512,7 @@
   },
   "kimi-for-coding": {
     "api": "https://api.kimi.com/coding/v1",
-    "doc": "https://www.kimi.com/coding/docs/en/third-party-agents.html",
+    "doc": "https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html",
     "env": [
       "KIMI_API_KEY"
     ],
@@ -61967,6 +65547,11 @@
         "name": "Kimi K2.5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-01",
         "structured_output": true,
         "temperature": true,
@@ -62001,6 +65586,11 @@
         "name": "Kimi K2.6",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-04",
         "structured_output": true,
         "temperature": true,
@@ -62400,7 +65990,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -62783,6 +66373,77 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-11",
+        "status": "deprecated",
+        "temperature": true,
+        "tool_call": true
+      },
+      "minimax-m3-free": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "minimax-m3-free",
+        "id": "minimax-m3-free",
+        "knowledge": "2025-01",
+        "last_updated": "2026-05-31",
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax M3 Free",
+        "open_weights": true,
+        "provider": {
+          "npm": "@ai-sdk/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2026-05-31",
+        "status": "deprecated",
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek-v4-flash": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.03,
+          "input": 0.14,
+          "output": 0.28
+        },
+        "family": "deepseek-flash",
+        "id": "deepseek-v4-flash",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-05",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Flash",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -64149,6 +67810,39 @@
         "temperature": true,
         "tool_call": true
       },
+      "nemotron-3-ultra-free": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "nemotron-free",
+        "id": "nemotron-3-ultra-free",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2026-02",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nemotron 3 Ultra Free",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-06-04",
+        "temperature": true,
+        "tool_call": true
+      },
       "claude-opus-4-7": {
         "attachment": true,
         "cost": {
@@ -64323,6 +68017,41 @@
         "reasoning": true,
         "release_date": "2026-02-05",
         "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
         "tool_call": true
       },
       "gemini-3.1-pro": {
@@ -64930,8 +68659,8 @@
         "knowledge": "2024-12",
         "last_updated": "2026-04-24",
         "limit": {
-          "context": 1000000,
-          "output": 128000
+          "context": 200000,
+          "output": 32000
         },
         "modalities": {
           "input": [
@@ -68136,6 +71865,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-10-22",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -68202,6 +71932,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-06-20",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -68235,6 +71966,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-10-22",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -68267,7 +71999,14 @@
         "name": "Claude Sonnet 3.7",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-02-19",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -68301,6 +72040,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-03-13",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -68334,6 +72074,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-02-29",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -68367,6 +72108,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-03-04",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -68399,6 +72141,12 @@
         "name": "Claude Haiku 4.5 (latest)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-10-15",
         "temperature": true,
         "tool_call": true
@@ -68432,6 +72180,12 @@
         "name": "Claude Haiku 4.5",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-10-15",
         "temperature": true,
         "tool_call": true
@@ -68465,6 +72219,12 @@
         "name": "Claude Opus 4 (latest)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-05-22",
         "temperature": true,
         "tool_call": true
@@ -68498,6 +72258,12 @@
         "name": "Claude Opus 4.1 (latest)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-08-05",
         "temperature": true,
         "tool_call": true
@@ -68531,6 +72297,12 @@
         "name": "Claude Opus 4.1",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-08-05",
         "temperature": true,
         "tool_call": true
@@ -68564,6 +72336,12 @@
         "name": "Claude Opus 4",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-05-22",
         "temperature": true,
         "tool_call": true
@@ -68597,6 +72375,20 @@
         "name": "Claude Opus 4.5 (latest)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-11-24",
         "temperature": true,
         "tool_call": true
@@ -68630,6 +72422,20 @@
         "name": "Claude Opus 4.5",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-11-01",
         "temperature": true,
         "tool_call": true
@@ -68683,6 +72489,21 @@
         "name": "Claude Opus 4.6",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-05",
         "temperature": true,
         "tool_call": true
@@ -68736,6 +72557,18 @@
         "name": "Claude Opus 4.7",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
         "release_date": "2026-04-16",
         "temperature": false,
         "tool_call": true
@@ -68788,6 +72621,18 @@
         "name": "Claude Opus 4.8",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
         "release_date": "2026-05-28",
         "temperature": false,
         "tool_call": true
@@ -68821,6 +72666,12 @@
         "name": "Claude Sonnet 4 (latest)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-05-22",
         "temperature": true,
         "tool_call": true
@@ -68854,6 +72705,12 @@
         "name": "Claude Sonnet 4",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-05-22",
         "temperature": true,
         "tool_call": true
@@ -68887,6 +72744,12 @@
         "name": "Claude Sonnet 4.5 (latest)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-09-29",
         "temperature": true,
         "tool_call": true
@@ -68920,6 +72783,12 @@
         "name": "Claude Sonnet 4.5",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-09-29",
         "temperature": true,
         "tool_call": true
@@ -68953,6 +72822,21 @@
         "name": "Claude Sonnet 4.6",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-17",
         "temperature": true,
         "tool_call": true
@@ -69142,6 +73026,42 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-18",
+        "temperature": true,
+        "tool_call": true
+      },
+      "MiniMax-M3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.12,
+          "input": 0.6,
+          "output": 2.4
+        },
+        "family": "minimax",
+        "id": "MiniMax-M3",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 512000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M3",
+        "open_weights": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "release_date": "2026-06-01",
         "temperature": true,
         "tool_call": true
       }
@@ -69344,6 +73264,11 @@
         "name": "Kimi K2.5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-01",
         "structured_output": true,
         "temperature": false,
@@ -69380,6 +73305,11 @@
         "name": "Kimi K2.6",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-04-21",
         "structured_output": true,
         "temperature": true,
@@ -69799,8 +73729,8 @@
       "qwen3-vl-30b-a3b-thinking": {
         "attachment": true,
         "cost": {
-          "input": 0.1,
-          "output": 0.1
+          "input": 0.2,
+          "output": 1
         },
         "family": "qwen",
         "id": "qwen3-vl-30b-a3b-thinking",
@@ -69921,8 +73851,8 @@
       "qwen-max-latest": {
         "attachment": true,
         "cost": {
-          "input": 1.6,
-          "output": 6.4
+          "input": 0.345,
+          "output": 1.377
         },
         "family": "qwen",
         "id": "qwen-max-latest",
@@ -70110,8 +74040,8 @@
       "qwen3-vl-235b-a22b-thinking": {
         "attachment": true,
         "cost": {
-          "input": 0.8,
-          "output": 2.4
+          "input": 0.5,
+          "output": 2
         },
         "family": "qwen",
         "id": "qwen3-vl-235b-a22b-thinking",
@@ -70140,7 +74070,7 @@
       "deepseek-v3.2": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.03,
+          "cache_read": 0.056,
           "input": 0.28,
           "output": 0.42
         },
@@ -70327,7 +74257,7 @@
           ]
         },
         "name": "GLM-4.5-Flash",
-        "open_weights": true,
+        "open_weights": false,
         "reasoning": true,
         "release_date": "2025-07-28",
         "temperature": true,
@@ -70470,6 +74400,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-07-10",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -70877,8 +74808,8 @@
       "qwen-coder-plus": {
         "attachment": false,
         "cost": {
-          "input": 0.5,
-          "output": 1
+          "input": 0.502,
+          "output": 1.004
         },
         "family": "qwen",
         "id": "qwen-coder-plus",
@@ -70994,6 +74925,37 @@
         "reasoning": false,
         "release_date": "2023-11-06",
         "structured_output": false,
+        "temperature": true,
+        "tool_call": true
+      },
+      "minimax-m3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.12,
+          "input": 0.6,
+          "output": 2.4
+        },
+        "family": "minimax",
+        "id": "minimax-m3",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 512000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-01",
         "temperature": true,
         "tool_call": true
       },
@@ -71154,8 +75116,8 @@
       "qwen3-235b-a22b-instruct-2507": {
         "attachment": false,
         "cost": {
-          "input": 0.8,
-          "output": 2.4
+          "input": 0.09,
+          "output": 0.58
         },
         "family": "qwen",
         "id": "qwen3-235b-a22b-instruct-2507",
@@ -71315,7 +75277,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -71812,7 +75774,7 @@
           ]
         },
         "name": "Qwen3 Coder Plus",
-        "open_weights": true,
+        "open_weights": false,
         "reasoning": false,
         "release_date": "2025-07-23",
         "temperature": true,
@@ -72131,8 +76093,8 @@
       "deepseek-r1-0528": {
         "attachment": false,
         "cost": {
-          "input": 0.8,
-          "output": 2.4
+          "input": 0.55,
+          "output": 2.19
         },
         "family": "deepseek",
         "id": "deepseek-r1-0528",
@@ -72194,9 +76156,9 @@
       "qwen3-vl-flash": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.01,
-          "input": 0.05,
-          "output": 0.4
+          "cache_read": 0.0044,
+          "input": 0.022,
+          "output": 0.215
         },
         "family": "qwen",
         "id": "qwen3-vl-flash",
@@ -72287,8 +76249,8 @@
       "gpt-oss-20b": {
         "attachment": false,
         "cost": {
-          "input": 0.1,
-          "output": 0.5
+          "input": 0.04,
+          "output": 0.15
         },
         "family": "gpt-oss",
         "id": "gpt-oss-20b",
@@ -72347,8 +76309,8 @@
       "qwen-plus-latest": {
         "attachment": true,
         "cost": {
-          "input": 0.3,
-          "output": 0.9
+          "input": 0.115,
+          "output": 0.287
         },
         "family": "qwen",
         "id": "qwen-plus-latest",
@@ -72476,9 +76438,9 @@
       "kimi-k2": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.5,
-          "input": 1,
-          "output": 3
+          "cache_read": 0.12,
+          "input": 0.6,
+          "output": 2.5
         },
         "family": "kimi",
         "id": "kimi-k2",
@@ -72886,8 +76848,8 @@
       "qwen3-235b-a22b-fp8": {
         "attachment": false,
         "cost": {
-          "input": 0.5,
-          "output": 2.5
+          "input": 0.2,
+          "output": 0.8
         },
         "family": "qwen",
         "id": "qwen3-235b-a22b-fp8",
@@ -73243,8 +77205,8 @@
       "qwen3-coder-next": {
         "attachment": false,
         "cost": {
-          "input": 0.8,
-          "output": 4
+          "input": 0.108,
+          "output": 0.675
         },
         "family": "qwen",
         "id": "qwen3-coder-next",
@@ -73598,6 +77560,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-12-09",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -73992,7 +77955,7 @@
       "deepseek-v3.1": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.11,
+          "cache_read": 0.07,
           "input": 0.56,
           "output": 1.68
         },
@@ -74206,12 +78169,44 @@
         "temperature": true,
         "tool_call": true
       },
+      "claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
       "qwen3-max-2026-01-23": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.6,
-          "input": 3,
-          "output": 15
+          "cache_read": 0.072,
+          "input": 0.359,
+          "output": 1.434
         },
         "family": "qwen",
         "id": "qwen3-max-2026-01-23",
@@ -74721,7 +78716,7 @@
         "attachment": false,
         "cost": {
           "input": 0.03,
-          "output": 0.05
+          "output": 0.03
         },
         "family": "qwen",
         "id": "qwen3-4b-fp8",
@@ -74780,8 +78775,8 @@
       "qwen3-vl-8b-instruct": {
         "attachment": true,
         "cost": {
-          "input": 0.1,
-          "output": 0.1
+          "input": 0.08,
+          "output": 0.5
         },
         "family": "qwen",
         "id": "qwen3-vl-8b-instruct",
@@ -74838,8 +78833,8 @@
       "qwen3-vl-235b-a22b-instruct": {
         "attachment": true,
         "cost": {
-          "input": 0.8,
-          "output": 2.4
+          "input": 0.3,
+          "output": 1.5
         },
         "family": "qwen",
         "id": "qwen3-vl-235b-a22b-instruct",
@@ -74897,8 +78892,8 @@
       "qwen3-vl-30b-a3b-instruct": {
         "attachment": true,
         "cost": {
-          "input": 0.1,
-          "output": 0.1
+          "input": 0.2,
+          "output": 0.7
         },
         "family": "qwen",
         "id": "qwen3-vl-30b-a3b-instruct",
@@ -74927,8 +78922,8 @@
       "qwen2-5-vl-32b-instruct": {
         "attachment": true,
         "cost": {
-          "input": 0.3,
-          "output": 0.3
+          "input": 1.4,
+          "output": 4.2
         },
         "family": "qwen",
         "id": "qwen2-5-vl-32b-instruct",
@@ -75073,8 +79068,8 @@
       "qwen3-235b-a22b-thinking-2507": {
         "attachment": false,
         "cost": {
-          "input": 0.8,
-          "output": 2.4
+          "input": 0.2,
+          "output": 0.6
         },
         "family": "qwen",
         "id": "qwen3-235b-a22b-thinking-2507",
@@ -75138,7 +79133,7 @@
       "seed-1-6-flash-250715": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.01,
+          "cache_read": 0.015,
           "input": 0.07,
           "output": 0.3
         },
@@ -75344,7 +79339,7 @@
         "attachment": false,
         "cost": {
           "input": 0.1,
-          "output": 0.1
+          "output": 0.3
         },
         "family": "qwen",
         "id": "qwen3-30b-a3b-instruct-2507",
@@ -75372,8 +79367,8 @@
       "gpt-oss-120b": {
         "attachment": false,
         "cost": {
-          "input": 0.15,
-          "output": 0.75
+          "input": 0.05,
+          "output": 0.25
         },
         "family": "gpt-oss",
         "id": "gpt-oss-120b",
@@ -75432,6 +79427,37 @@
         "temperature": false,
         "tool_call": true
       },
+      "qwen3.7-plus": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.08,
+          "cache_write": 0.5,
+          "input": 0.4,
+          "output": 1.6
+        },
+        "family": "qwen",
+        "id": "qwen3.7-plus",
+        "knowledge": "2025-04",
+        "last_updated": "2026-06-02",
+        "limit": {
+          "context": 131072,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7 Plus",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-02",
+        "temperature": true,
+        "tool_call": true
+      },
       "gpt-5.4": {
         "attachment": true,
         "cost": {
@@ -75469,7 +79495,7 @@
       "glm-4.6v-flashx": {
         "attachment": true,
         "cost": {
-          "cache_read": 0,
+          "cache_read": 0.004,
           "input": 0.04,
           "output": 0.4
         },
@@ -75563,6 +79589,37 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-12-09",
+        "status": "deprecated",
+        "temperature": true,
+        "tool_call": true
+      },
+      "devstral-latest": {
+        "attachment": false,
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "family": "devstral",
+        "id": "devstral-latest",
+        "knowledge": "2025-12",
+        "last_updated": "2025-12-09",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Devstral 2",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-12-09",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -75592,6 +79649,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-07-10",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -75621,6 +79679,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-12-02",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -75650,6 +79709,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-05-07",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -75679,6 +79739,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-07-10",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -75709,6 +79770,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-12-09",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -76030,6 +80092,15 @@
         "name": "Mistral Medium 3.5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-04-29",
         "structured_output": true,
         "temperature": true,
@@ -76038,12 +80109,13 @@
       "mistral-medium-latest": {
         "attachment": true,
         "cost": {
-          "input": 1.5,
-          "output": 7.5
+          "input": 0.4,
+          "output": 2
         },
         "family": "mistral-medium",
         "id": "mistral-medium-latest",
-        "last_updated": "2026-04-29",
+        "knowledge": "2025-05",
+        "last_updated": "2025-08-12",
         "limit": {
           "context": 262144,
           "output": 262144
@@ -76058,10 +80130,9 @@
           ]
         },
         "name": "Mistral Medium (latest)",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2026-04-29",
-        "structured_output": true,
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-08-12",
         "temperature": true,
         "tool_call": true
       },
@@ -76150,6 +80221,15 @@
         "name": "Mistral Small 4",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-03-16",
         "temperature": true,
         "tool_call": true
@@ -76180,6 +80260,15 @@
         "name": "Mistral Small (latest)",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-03-16",
         "temperature": true,
         "tool_call": true
@@ -76210,6 +80299,36 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2023-09-27",
+        "temperature": true,
+        "tool_call": true
+      },
+      "open-mistral-nemo": {
+        "attachment": false,
+        "cost": {
+          "input": 0.15,
+          "output": 0.15
+        },
+        "family": "mistral-nemo",
+        "id": "open-mistral-nemo",
+        "knowledge": "2024-07",
+        "last_updated": "2024-07-01",
+        "limit": {
+          "context": 128000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Open Mistral Nemo",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-07-01",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -76346,13 +80465,13 @@
       "claudinio": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.05,
+          "cache_read": 0.15,
           "input": 0.5,
           "output": 2
         },
         "id": "claudinio",
         "knowledge": "2026-05",
-        "last_updated": "2026-05-12",
+        "last_updated": "2026-06-02",
         "limit": {
           "context": 256000,
           "output": 64000
@@ -76360,7 +80479,9 @@
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "audio",
+            "video"
           ],
           "output": [
             "text"
@@ -76940,14 +81061,43 @@
         "temperature": true,
         "tool_call": true
       },
+      "qwen3.5-397b-a17b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.71,
+          "output": 4.25
+        },
+        "id": "qwen3.5-397b-a17b",
+        "last_updated": "2026-05-18",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5-397B-A17B",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-05-18",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
       "qwen3.5-9b": {
         "attachment": true,
         "cost": {
-          "input": 0.1,
-          "output": 0.15
+          "input": 0.12,
+          "output": 0.18
         },
         "id": "qwen3.5-9b",
-        "last_updated": "2026-02-15",
+        "last_updated": "2026-04-22",
         "limit": {
           "context": 262144,
           "output": 262144
@@ -76963,11 +81113,86 @@
         },
         "name": "Qwen3.5-9B",
         "open_weights": true,
-        "reasoning": false,
-        "release_date": "2026-02-15",
+        "reasoning": true,
+        "release_date": "2026-04-22",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
+      },
+      "qwen3.6-27b": {
+        "attachment": true,
+        "cost": {
+          "input": 0.47,
+          "output": 3.19
+        },
+        "id": "qwen3.6-27b",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.6-27B",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-06-01",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "qwen3guard-gen-0.6b": {
+        "attachment": false,
+        "id": "qwen3guard-gen-0.6b",
+        "last_updated": "2026-01-22",
+        "limit": {
+          "context": 32768,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3Guard-Gen-0.6B",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2026-01-22",
+        "temperature": true,
+        "tool_call": false
+      },
+      "qwen3guard-gen-8b": {
+        "attachment": false,
+        "id": "qwen3guard-gen-8b",
+        "last_updated": "2026-01-22",
+        "limit": {
+          "context": 32768,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3Guard-Gen-8B",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2026-01-22",
+        "temperature": true,
+        "tool_call": false
       }
     },
     "name": "OVHcloud AI Endpoints",
@@ -77407,6 +81632,41 @@
         "temperature": true,
         "tool_call": true
       },
+      "minimax-m3": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.06,
+          "input": 0.3,
+          "output": 1.2
+        },
+        "family": "minimax-m3",
+        "id": "minimax-m3",
+        "knowledge": "2025-01",
+        "last_updated": "2026-05-31",
+        "limit": {
+          "context": 512000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax M3",
+        "open_weights": true,
+        "provider": {
+          "npm": "@ai-sdk/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2026-05-31",
+        "temperature": true,
+        "tool_call": true
+      },
       "qwen3.5-plus": {
         "attachment": true,
         "cost": {
@@ -77440,6 +81700,7 @@
         },
         "reasoning": true,
         "release_date": "2026-02-16",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -77448,15 +81709,33 @@
         "cost": {
           "cache_read": 0.05,
           "cache_write": 0.625,
+          "context_over_200k": {
+            "cache_read": 0.2,
+            "cache_write": 2.5,
+            "input": 2,
+            "output": 6
+          },
           "input": 0.5,
-          "output": 3
+          "output": 3,
+          "tiers": [
+            {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "input": 2,
+              "output": 6,
+              "tier": {
+                "size": 256000,
+                "type": "context"
+              }
+            }
+          ]
         },
         "family": "qwen3.6",
         "id": "qwen3.6-plus",
         "knowledge": "2025-04",
         "last_updated": "2026-04-02",
         "limit": {
-          "context": 262144,
+          "context": 1000000,
           "output": 65536
         },
         "modalities": {
@@ -77509,6 +81788,59 @@
         },
         "reasoning": true,
         "release_date": "2026-05-21",
+        "temperature": true,
+        "tool_call": true
+      },
+      "qwen3.7-plus": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.04,
+          "cache_write": 0.5,
+          "context_over_200k": {
+            "cache_read": 0.12,
+            "cache_write": 1.5,
+            "input": 1.2,
+            "output": 4.8
+          },
+          "input": 0.4,
+          "output": 1.6,
+          "tiers": [
+            {
+              "cache_read": 0.12,
+              "cache_write": 1.5,
+              "input": 1.2,
+              "output": 4.8,
+              "tier": {
+                "size": 256000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "qwen3.7-plus",
+        "id": "qwen3.7-plus",
+        "last_updated": "2026-06-02",
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7 Plus",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2026-06-02",
         "temperature": true,
         "tool_call": true
       }
@@ -77699,6 +82031,42 @@
         "release_date": "2026-03-18",
         "temperature": true,
         "tool_call": true
+      },
+      "MiniMax-M3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.12,
+          "input": 0.6,
+          "output": 2.4
+        },
+        "family": "minimax",
+        "id": "MiniMax-M3",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 512000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M3",
+        "open_weights": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "release_date": "2026-06-01",
+        "temperature": true,
+        "tool_call": true
       }
     },
     "name": "MiniMax (minimaxi.com)",
@@ -77741,6 +82109,11 @@
         "name": "MiMo-V2-Flash",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-12-16",
         "temperature": true,
         "tool_call": true
@@ -77778,6 +82151,11 @@
         "name": "MiMo-V2-Omni",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-03-18",
         "temperature": true,
         "tool_call": true
@@ -77827,6 +82205,11 @@
         "name": "MiMo-V2-Pro",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-03-18",
         "temperature": true,
         "tool_call": true
@@ -77879,6 +82262,11 @@
         "name": "MiMo-V2.5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-04-22",
         "temperature": true,
         "tool_call": true
@@ -77928,12 +82316,506 @@
         "name": "MiMo-V2.5-Pro",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-04-22",
         "temperature": true,
         "tool_call": true
       }
     },
     "name": "Xiaomi",
+    "npm": "@ai-sdk/openai-compatible"
+  },
+  "alibaba-token-plan": {
+    "api": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/token-plan-overview",
+    "env": [
+      "ALIBABA_TOKEN_PLAN_API_KEY"
+    ],
+    "id": "alibaba-token-plan",
+    "models": {
+      "MiniMax-M2.5": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "minimax",
+        "id": "MiniMax-M2.5",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "last_updated": "2026-02-12",
+        "limit": {
+          "context": 196608,
+          "input": 196601,
+          "output": 24576
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M2.5",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-02-12",
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek-v3.2": {
+        "attachment": false,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "deepseek",
+        "id": "deepseek-v3.2",
+        "knowledge": "2025-01",
+        "last_updated": "2025-12-05",
+        "limit": {
+          "context": 131072,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V3.2",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-12-03",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek-v4-flash": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "deepseek-flash",
+        "id": "deepseek-v4-flash",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-05",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Flash",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek-v4-pro": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "deepseek-thinking",
+        "id": "deepseek-v4-pro",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-05",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "glm-5": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "glm",
+        "id": "glm-5",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "last_updated": "2026-02-11",
+        "limit": {
+          "context": 202752,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-11",
+        "temperature": true,
+        "tool_call": true
+      },
+      "glm-5.1": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "glm",
+        "id": "glm-5.1",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "last_updated": "2026-03-27",
+        "limit": {
+          "context": 202752,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-5.1",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-03-27",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "kimi-k2.5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "kimi",
+        "id": "kimi-k2.5",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-01",
+        "last_updated": "2026-01",
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Kimi K2.5",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "kimi-k2.6": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "kimi",
+        "id": "kimi-k2.6",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-01",
+        "last_updated": "2026-04-21",
+        "limit": {
+          "context": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Kimi K2.6",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-21",
+        "temperature": true,
+        "tool_call": true
+      },
+      "qwen-image-2.0": {
+        "attachment": false,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "qwen",
+        "id": "qwen-image-2.0",
+        "last_updated": "2026-03-03",
+        "limit": {
+          "context": 8192,
+          "output": 0
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "image"
+          ]
+        },
+        "name": "Qwen Image 2.0",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-03",
+        "temperature": true,
+        "tool_call": false
+      },
+      "qwen-image-2.0-pro": {
+        "attachment": false,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "qwen",
+        "id": "qwen-image-2.0-pro",
+        "last_updated": "2026-03-03",
+        "limit": {
+          "context": 8192,
+          "output": 0
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "image"
+          ]
+        },
+        "name": "Qwen Image 2.0 Pro",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-03",
+        "temperature": true,
+        "tool_call": false
+      },
+      "qwen3.6-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "qwen3.6",
+        "id": "qwen3.6-flash",
+        "last_updated": "2026-04-27",
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.6 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-27",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "qwen3.6-plus": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "qwen",
+        "id": "qwen3.6-plus",
+        "knowledge": "2025-04",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.6 Plus",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "temperature": true,
+        "tool_call": true
+      },
+      "qwen3.7-max": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "qwen",
+        "id": "qwen3.7-max",
+        "last_updated": "2026-05-21",
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7 Max",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-21",
+        "temperature": true,
+        "tool_call": true
+      },
+      "wan2.7-image": {
+        "attachment": false,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "id": "wan2.7-image",
+        "last_updated": "2026-05-29",
+        "limit": {
+          "context": 8192,
+          "output": 0
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "image"
+          ]
+        },
+        "name": "Wan2.7 Image",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-05-29",
+        "temperature": true,
+        "tool_call": false
+      },
+      "wan2.7-image-pro": {
+        "attachment": false,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "id": "wan2.7-image-pro",
+        "last_updated": "2026-05-29",
+        "limit": {
+          "context": 8192,
+          "output": 0
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "image"
+          ]
+        },
+        "name": "Wan2.7 Image Pro",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-05-29",
+        "temperature": true,
+        "tool_call": false
+      }
+    },
+    "name": "Alibaba Token Plan",
     "npm": "@ai-sdk/openai-compatible"
   },
   "xai": {
@@ -78246,6 +83128,7 @@
           "input": [
             "text",
             "image",
+            "video",
             "pdf"
           ],
           "output": [
@@ -78572,8 +83455,8 @@
         "id": "accounts/fireworks/models/qwen3p6-plus",
         "last_updated": "2026-04-04",
         "limit": {
-          "context": 128000,
-          "output": 8192
+          "context": 262144,
+          "output": 65536
         },
         "modalities": {
           "input": [
@@ -78620,6 +83503,39 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-04-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "accounts/fireworks/routers/kimi-k2p6-fast": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.3,
+          "input": 2,
+          "output": 8
+        },
+        "family": "kimi-thinking",
+        "id": "accounts/fireworks/routers/kimi-k2p6-fast",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "last_updated": "2026-06-05",
+        "limit": {
+          "context": 262000,
+          "output": 262000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Kimi K2.6 Fast",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-17",
         "temperature": true,
         "tool_call": true
       },
@@ -78671,7 +83587,7 @@
       "deepseek-chat": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.028,
+          "cache_read": 0.0028,
           "input": 0.14,
           "output": 0.28
         },
@@ -78701,7 +83617,7 @@
       "deepseek-reasoner": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.028,
+          "cache_read": 0.0028,
           "input": 0.14,
           "output": 0.28
         },
@@ -78760,6 +83676,18 @@
         "name": "DeepSeek V4 Flash",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "high",
+              "max"
+            ]
+          }
+        ],
         "release_date": "2026-04-24",
         "structured_output": true,
         "temperature": true,
@@ -78794,6 +83722,18 @@
         "name": "DeepSeek V4 Pro",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "high",
+              "max"
+            ]
+          }
+        ],
         "release_date": "2026-04-24",
         "structured_output": true,
         "temperature": true,
@@ -79255,6 +84195,337 @@
     },
     "name": "Baseten",
     "npm": "@ai-sdk/openai-compatible"
+  },
+  "freemodel": {
+    "api": "https://cc.freemodel.dev/v1",
+    "doc": "https://freemodel.dev",
+    "env": [
+      "FREEMODEL_API_KEY"
+    ],
+    "id": "freemodel",
+    "models": {
+      "claude-haiku-4-5-20251001": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "family": "claude-haiku",
+        "id": "claude-haiku-4-5-20251001",
+        "knowledge": "2025-02-28",
+        "last_updated": "2025-10-15",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 4.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-10-15",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-6": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-6",
+        "knowledge": "2025-05-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.6",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-7": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-7",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-04-16",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.7",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-16",
+        "temperature": false,
+        "tool_call": true
+      },
+      "claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
+      "claude-sonnet-4-6": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-6",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.6",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-5.3-codex": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "cache_write": 1.75,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5.3-codex",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-02-05",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.3 Codex",
+        "open_weights": false,
+        "provider": {
+          "api": "https://api.freemodel.dev/v1",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2026-02-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.4": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.25,
+          "cache_write": 2.5,
+          "input": 2.5,
+          "output": 15
+        },
+        "family": "gpt",
+        "id": "gpt-5.4",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-05",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4",
+        "open_weights": false,
+        "provider": {
+          "api": "https://api.freemodel.dev/v1",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.4-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "cache_write": 0.75,
+          "input": 0.75,
+          "output": 4.5
+        },
+        "family": "gpt-mini",
+        "id": "gpt-5.4-mini",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-17",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4 mini",
+        "open_weights": false,
+        "provider": {
+          "api": "https://api.freemodel.dev/v1",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2026-03-17",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 5,
+          "input": 5,
+          "output": 30
+        },
+        "family": "gpt",
+        "id": "gpt-5.5",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-04-23",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.5",
+        "open_weights": false,
+        "provider": {
+          "api": "https://api.freemodel.dev/v1",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2026-04-23",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      }
+    },
+    "name": "FreeModel",
+    "npm": "@ai-sdk/anthropic"
   },
   "orcarouter": {
     "api": "https://api.orcarouter.ai/v1",
@@ -81724,7 +86995,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -82321,6 +87592,15 @@
         "name": "Command A Reasoning",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "min": 1,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-08-21",
         "temperature": true,
         "tool_call": true
@@ -82967,6 +88247,39 @@
         "temperature": false,
         "tool_call": true
       },
+      "duo-chat-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "claude-opus",
+        "id": "duo-chat-opus-4-8",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Agentic Chat (Claude Opus 4.8)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
       "duo-chat-sonnet-4-5": {
         "attachment": true,
         "cost": {
@@ -83448,10 +88761,46 @@
             "text"
           ]
         },
-        "name": "Xpersona Frieren Coder",
+        "name": "Xpersona Frieren 1",
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-05-01",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "xpersona-gpt-5.5": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.3,
+          "input": 3,
+          "output": 18,
+          "reasoning": 18
+        },
+        "family": "gpt",
+        "id": "xpersona-gpt-5.5",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-12-30",
+        "last_updated": "2026-05-29",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-29",
         "structured_output": true,
         "temperature": false,
         "tool_call": true
@@ -87389,6 +92738,7 @@
           "input": 0.04,
           "output": 0.16
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-nano-9b-v2",
         "last_updated": "2025-08-18",
         "limit": {
@@ -90041,6 +95391,7 @@
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-3-super-120b-a12b:free",
         "last_updated": "2026-03-15",
         "limit": {
@@ -90347,6 +95698,7 @@
           "input": 0.1,
           "output": 0.5
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-3-super-120b-a12b",
         "last_updated": "2026-04-11",
         "limit": {
@@ -92301,6 +97653,7 @@
           "input": 0.05,
           "output": 0.2
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-3-nano-30b-a3b",
         "last_updated": "2026-02-04",
         "limit": {
@@ -92385,6 +97738,7 @@
           "input": 0.1,
           "output": 0.4
         },
+        "family": "nemotron",
         "id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
         "last_updated": "2025-03-16",
         "limit": {
@@ -93040,6 +98394,7 @@
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
         "last_updated": "2026-05-01",
         "limit": {
@@ -94322,6 +99677,11 @@
         "name": "GLM-4.5-Air",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-07-28",
         "temperature": true,
         "tool_call": true
@@ -94356,6 +99716,11 @@
         "name": "GLM-4.7",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-12-22",
         "temperature": true,
         "tool_call": true
@@ -94389,6 +99754,11 @@
         "name": "GLM-5-Turbo",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-03-16",
         "structured_output": true,
         "temperature": true,
@@ -94423,6 +99793,11 @@
         "name": "GLM-5.1",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-03-27",
         "structured_output": true,
         "temperature": true,
@@ -94503,7 +99878,48 @@
         "name": "GLM-4.5-Air",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-07-28",
+        "temperature": true,
+        "tool_call": true
+      },
+      "glm-4.6v": {
+        "attachment": true,
+        "cost": {
+          "input": 0.3,
+          "output": 0.9
+        },
+        "family": "glm",
+        "id": "glm-4.6v",
+        "knowledge": "2025-04",
+        "last_updated": "2025-12-08",
+        "limit": {
+          "context": 128000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-4.6V",
+        "open_weights": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "release_date": "2025-12-08",
         "temperature": true,
         "tool_call": true
       },
@@ -94537,6 +99953,11 @@
         "name": "GLM-4.7",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-12-22",
         "temperature": true,
         "tool_call": true
@@ -94570,6 +99991,11 @@
         "name": "GLM-5-Turbo",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-03-16",
         "structured_output": true,
         "temperature": true,
@@ -94604,6 +100030,11 @@
         "name": "GLM-5.1",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-03-27",
         "structured_output": true,
         "temperature": true,
@@ -94904,6 +100335,7 @@
           "input": 0.266,
           "output": 0.799
         },
+        "family": "nemotron",
         "id": "nemotron-3-super-120b-a12b",
         "knowledge": "2025-12",
         "last_updated": "2026-03-11",
@@ -96134,6 +101566,39 @@
         "release_date": "2025-08-05",
         "temperature": true,
         "tool_call": true
+      },
+      "gpt-5.4": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.25,
+          "input": 3,
+          "output": 16.13
+        },
+        "family": "gpt",
+        "id": "gpt-5.4",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-05",
+        "limit": {
+          "context": 1050000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
       }
     },
     "name": "Cortecs",
@@ -96322,6 +101787,43 @@
         "release_date": "2026-03-18",
         "temperature": true,
         "tool_call": true
+      },
+      "MiniMax-M3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "minimax",
+        "id": "MiniMax-M3",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 512000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M3",
+        "open_weights": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "release_date": "2026-06-01",
+        "temperature": true,
+        "tool_call": true
       }
     },
     "name": "MiniMax Token Plan (minimaxi.com)",
@@ -96486,13 +101988,13 @@
       "minimax/minimax-m2.5": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.014,
-          "input": 0.14,
-          "output": 0.56
+          "cache_read": 0.03,
+          "input": 0.3,
+          "output": 1.2
         },
         "family": "minimax-m2.5",
         "id": "minimax/minimax-m2.5",
-        "last_updated": "2026-03-25",
+        "last_updated": "2026-06-01",
         "limit": {
           "context": 1000000,
           "output": 131072
@@ -96516,9 +102018,9 @@
       "moonshotai/kimi-k2.5": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.03,
-          "input": 0.21,
-          "output": 1
+          "cache_read": 0.05,
+          "input": 0.3,
+          "output": 1.5
         },
         "family": "kimi",
         "id": "moonshotai/kimi-k2.5",
@@ -96526,7 +102028,7 @@
           "field": "reasoning_content"
         },
         "knowledge": "2025-01-01",
-        "last_updated": "2026-03-25",
+        "last_updated": "2026-06-01",
         "limit": {
           "context": 262144,
           "output": 262144
@@ -96552,16 +102054,16 @@
       "zai-org/glm-5.1": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.12,
-          "input": 0.66,
-          "output": 2
+          "cache_read": 0.133,
+          "input": 0.615,
+          "output": 2.46
         },
         "family": "glm",
         "id": "zai-org/glm-5.1",
         "interleaved": {
           "field": "reasoning_content"
         },
-        "last_updated": "2026-04-08",
+        "last_updated": "2026-06-01",
         "limit": {
           "context": 202000,
           "output": 202000
@@ -103123,6 +108625,2893 @@
     "name": "Tencent Coding Plan (China)",
     "npm": "@ai-sdk/openai-compatible"
   },
+  "merge-gateway": {
+    "doc": "https://docs.merge.dev/merge-gateway",
+    "env": [
+      "MERGE_GATEWAY_API_KEY"
+    ],
+    "id": "merge-gateway",
+    "models": {
+      "zai/glm-4.7": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.11,
+          "cache_write": 0,
+          "input": 0.6,
+          "output": 2.2
+        },
+        "family": "glm",
+        "id": "zai/glm-4.7",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-04",
+        "last_updated": "2025-12-22",
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-4.7",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-12-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "minimax/minimax-m2.7": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.06,
+          "cache_write": 0.375,
+          "input": 0.3,
+          "output": 1.2
+        },
+        "family": "minimax",
+        "id": "minimax/minimax-m2.7",
+        "last_updated": "2026-03-18",
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M2.7",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-03-18",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4o-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "gpt-mini",
+        "id": "openai/gpt-4o-mini",
+        "knowledge": "2023-09",
+        "last_updated": "2024-07-18",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o mini",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-07-18",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5.3-chat-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt",
+        "id": "openai/gpt-5.3-chat-latest",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-03",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.3 Chat (latest)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-03",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/mistral-small-latest": {
+        "attachment": true,
+        "cost": {
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "mistral-small",
+        "id": "mistral/mistral-small-latest",
+        "knowledge": "2025-06",
+        "last_updated": "2026-03-16",
+        "limit": {
+          "context": 256000,
+          "output": 256000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Small (latest)",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-03-16",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-3.1-pro-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12,
+          "tiers": [
+            {
+              "cache_read": 0.4,
+              "input": 4,
+              "output": 18,
+              "tier": {
+                "size": 200000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "gemini-pro",
+        "id": "google/gemini-3.1-pro-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-19",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Pro Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-19",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/devstral-medium-2507": {
+        "attachment": false,
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "family": "devstral",
+        "id": "mistral/devstral-medium-2507",
+        "knowledge": "2025-05",
+        "last_updated": "2025-07-10",
+        "limit": {
+          "context": 128000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Devstral Medium",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-07-10",
+        "status": "deprecated",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4o": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.25,
+          "input": 2.5,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "openai/gpt-4o",
+        "knowledge": "2023-09",
+        "last_updated": "2024-08-06",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-05-13",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "anthropic/claude-sonnet-4-6",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.6",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5.2": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt",
+        "id": "openai/gpt-5.2",
+        "knowledge": "2025-08-31",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.2",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-11",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "zai/glm-5-turbo": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.24,
+          "cache_write": 0,
+          "input": 1.2,
+          "output": 4
+        },
+        "family": "glm",
+        "id": "zai/glm-5-turbo",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "last_updated": "2026-03-16",
+        "limit": {
+          "context": 200000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-5-Turbo",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-16",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4-20250514": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4-20250514",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-05-22",
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "cohere/command-r-08-2024": {
+        "attachment": false,
+        "cost": {
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "command-r",
+        "id": "cohere/command-r-08-2024",
+        "knowledge": "2024-06-01",
+        "last_updated": "2024-08-30",
+        "limit": {
+          "context": 128000,
+          "output": 4000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Command R",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-08-30",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5.4-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "input": 0.75,
+          "output": 4.5
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 0.15,
+                "input": 1.5,
+                "output": 9
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "family": "gpt-mini",
+        "id": "openai/gpt-5.4-mini",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-17",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4 mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-17",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/gpt-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "openai/gpt-5",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/o1": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 7.5,
+          "input": 15,
+          "output": 60
+        },
+        "family": "o",
+        "id": "openai/o1",
+        "knowledge": "2023-09",
+        "last_updated": "2024-12-05",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-12-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/gpt-5-chat-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt-codex",
+        "id": "openai/gpt-5-chat-latest",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Chat (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": false
+      },
+      "mistral/magistral-medium-latest": {
+        "attachment": false,
+        "cost": {
+          "input": 2,
+          "output": 5
+        },
+        "family": "magistral-medium",
+        "id": "mistral/magistral-medium-latest",
+        "knowledge": "2025-06",
+        "last_updated": "2025-03-20",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Magistral Medium (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-03-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "minimax/minimax-m2.5": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.03,
+          "cache_write": 0.375,
+          "input": 0.3,
+          "output": 1.2
+        },
+        "family": "minimax",
+        "id": "minimax/minimax-m2.5",
+        "last_updated": "2026-02-12",
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M2.5",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-02-12",
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-haiku-4-5-20251001": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "family": "claude-haiku",
+        "id": "anthropic/claude-haiku-4-5-20251001",
+        "knowledge": "2025-02-28",
+        "last_updated": "2025-10-15",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 4.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-10-15",
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4-6": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 3,
+                "cache_write": 37.5,
+                "input": 30,
+                "output": 150
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4-6",
+        "knowledge": "2025-05-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.6",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemma-4-31b-it": {
+        "attachment": true,
+        "family": "gemma",
+        "id": "google/gemma-4-31b-it",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B IT",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/mistral-medium-latest": {
+        "attachment": true,
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "family": "mistral-medium",
+        "id": "mistral/mistral-medium-latest",
+        "knowledge": "2025-05",
+        "last_updated": "2025-08-12",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Medium (latest)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-08-12",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/o4-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.275,
+          "input": 1.1,
+          "output": 4.4
+        },
+        "family": "o-mini",
+        "id": "openai/o4-mini",
+        "knowledge": "2024-05",
+        "last_updated": "2025-04-16",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o4-mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-04-16",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "zai/glm-5": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.2,
+          "cache_write": 0,
+          "input": 1,
+          "output": 3.2
+        },
+        "family": "glm",
+        "id": "zai/glm-5",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "last_updated": "2026-02-11",
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-5",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-02-11",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4.1-nano": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gpt-nano",
+        "id": "openai/gpt-4.1-nano",
+        "knowledge": "2024-04",
+        "last_updated": "2025-04-14",
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4.1 nano",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-14",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "zai/glm-4.7-flashx": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.01,
+          "cache_write": 0,
+          "input": 0.07,
+          "output": 0.4
+        },
+        "family": "glm-flash",
+        "id": "zai/glm-4.7-flashx",
+        "knowledge": "2025-04",
+        "last_updated": "2026-01-19",
+        "limit": {
+          "context": 200000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-4.7-FlashX",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-01-19",
+        "temperature": true,
+        "tool_call": true
+      },
+      "zai/glm-5.1": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.26,
+          "cache_write": 0,
+          "input": 1.4,
+          "output": 4.4
+        },
+        "family": "glm",
+        "id": "zai/glm-5.1",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "last_updated": "2026-03-27",
+        "limit": {
+          "context": 200000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-5.1",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-03-27",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/codestral-latest": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 0.9
+        },
+        "family": "codestral",
+        "id": "mistral/codestral-latest",
+        "knowledge": "2024-10",
+        "last_updated": "2025-01-04",
+        "limit": {
+          "context": 256000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Codestral (latest)",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-05-29",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4o-2024-11-20": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.25,
+          "input": 2.5,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "openai/gpt-4o-2024-11-20",
+        "knowledge": "2023-09",
+        "last_updated": "2024-11-20",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o (2024-11-20)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-11-20",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "zai/glm-4.6": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.11,
+          "cache_write": 0,
+          "input": 0.6,
+          "output": 2.2
+        },
+        "family": "glm",
+        "id": "zai/glm-4.6",
+        "knowledge": "2025-04",
+        "last_updated": "2025-09-30",
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-4.6",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-09-30",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4.1": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "input": 2,
+          "output": 8
+        },
+        "family": "gpt",
+        "id": "openai/gpt-4.1",
+        "knowledge": "2024-04",
+        "last_updated": "2025-04-14",
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4.1",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-14",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-sonnet-4-20250514": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "anthropic/claude-sonnet-4-20250514",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-05-22",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/devstral-2512": {
+        "attachment": false,
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "family": "devstral",
+        "id": "mistral/devstral-2512",
+        "knowledge": "2025-12",
+        "last_updated": "2025-12-09",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Devstral 2",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-12-09",
+        "status": "deprecated",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-3-pro-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12,
+          "tiers": [
+            {
+              "cache_read": 0.4,
+              "input": 4,
+              "output": 18,
+              "tier": {
+                "size": 200000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "gemini-pro",
+        "id": "google/gemini-3-pro-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2025-11-18",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3 Pro Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-18",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4o-2024-08-06": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.25,
+          "input": 2.5,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "openai/gpt-4o-2024-08-06",
+        "knowledge": "2023-09",
+        "last_updated": "2024-08-06",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o (2024-08-06)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-08-06",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "xai/grok-4.3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 2.5,
+            "output": 5
+          },
+          "input": 1.25,
+          "output": 2.5,
+          "tiers": [
+            {
+              "cache_read": 0.4,
+              "input": 2.5,
+              "output": 5,
+              "tier": {
+                "size": 200000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "grok",
+        "id": "xai/grok-4.3",
+        "last_updated": "2026-04-17",
+        "limit": {
+          "context": 1000000,
+          "output": 30000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Grok 4.3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/mistral-large-2512": {
+        "attachment": true,
+        "cost": {
+          "input": 0.5,
+          "output": 1.5
+        },
+        "family": "mistral-large",
+        "id": "mistral/mistral-large-2512",
+        "knowledge": "2024-11",
+        "last_updated": "2025-12-02",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Large 3",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-11-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4-5-20251101": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4-5-20251101",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-11-01",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "minimax/minimax-m2.1": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "family": "minimax",
+        "id": "minimax/minimax-m2.1",
+        "last_updated": "2025-12-23",
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M2.1",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-12-23",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-3.1-flash-lite-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "input_audio": 0.5,
+          "output": 1.5
+        },
+        "family": "gemini-flash-lite",
+        "id": "google/gemini-3.1-flash-lite-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2026-03-03",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Flash Lite Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-03",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "zai/glm-4.5": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.11,
+          "cache_write": 0,
+          "input": 0.6,
+          "output": 2.2
+        },
+        "family": "glm",
+        "id": "zai/glm-4.5",
+        "knowledge": "2025-04",
+        "last_updated": "2025-07-28",
+        "limit": {
+          "context": 131072,
+          "output": 98304
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-4.5",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-07-28",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4o-2024-05-13": {
+        "attachment": true,
+        "cost": {
+          "input": 5,
+          "output": 15
+        },
+        "family": "gpt",
+        "id": "openai/gpt-4o-2024-05-13",
+        "knowledge": "2023-09",
+        "last_updated": "2024-05-13",
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o (2024-05-13)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-05-13",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-4.1-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "input": 0.4,
+          "output": 1.6
+        },
+        "family": "gpt-mini",
+        "id": "openai/gpt-4.1-mini",
+        "knowledge": "2024-04",
+        "last_updated": "2025-04-14",
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4.1 mini",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-14",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-2.5-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.03,
+          "input": 0.3,
+          "input_audio": 1,
+          "output": 2.5
+        },
+        "family": "gemini-flash",
+        "id": "google/gemini-2.5-flash",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-05",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-03-20",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/mistral-medium-2505": {
+        "attachment": true,
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "family": "mistral-medium",
+        "id": "mistral/mistral-medium-2505",
+        "knowledge": "2025-05",
+        "last_updated": "2025-05-07",
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Medium 3",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-05-07",
+        "temperature": true,
+        "tool_call": true
+      },
+      "xai/grok-4.20-0309-reasoning": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 2.5,
+            "output": 5
+          },
+          "input": 1.25,
+          "output": 2.5,
+          "tiers": [
+            {
+              "cache_read": 0.4,
+              "input": 2.5,
+              "output": 5,
+              "tier": {
+                "size": 200000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "grok",
+        "id": "xai/grok-4.20-0309-reasoning",
+        "last_updated": "2026-03-09",
+        "limit": {
+          "context": 2000000,
+          "output": 30000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Grok 4.20 (Reasoning)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-09",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-3.1-pro-preview-customtools": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12,
+          "tiers": [
+            {
+              "cache_read": 0.4,
+              "input": 4,
+              "output": 18,
+              "tier": {
+                "size": 200000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "gemini-pro",
+        "id": "google/gemini-3.1-pro-preview-customtools",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-19",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-19",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek/deepseek-v4-flash": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.0028,
+          "input": 0.14,
+          "output": 0.28
+        },
+        "family": "deepseek-flash",
+        "id": "deepseek/deepseek-v4-flash",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-05",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Flash",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5.5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "context_over_200k": {
+            "cache_read": 1,
+            "input": 10,
+            "output": 45
+          },
+          "input": 5,
+          "output": 30,
+          "tiers": [
+            {
+              "cache_read": 1,
+              "input": 10,
+              "output": 45,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 1.25,
+                "input": 12.5,
+                "output": 75
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "family": "gpt",
+        "id": "openai/gpt-5.5",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-04-23",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-23",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "mistral/mistral-large-latest": {
+        "attachment": true,
+        "cost": {
+          "input": 0.5,
+          "output": 1.5
+        },
+        "family": "mistral-large",
+        "id": "mistral/mistral-large-latest",
+        "knowledge": "2024-11",
+        "last_updated": "2025-12-02",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Large (latest)",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-11-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-sonnet-4-5-20250929": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "anthropic/claude-sonnet-4-5-20250929",
+        "knowledge": "2025-07-31",
+        "last_updated": "2025-09-29",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-29",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-3.1-flash-lite": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "input_audio": 0.5,
+          "output": 1.5
+        },
+        "family": "gemini-flash-lite",
+        "id": "google/gemini-3.1-flash-lite",
+        "knowledge": "2025-01",
+        "last_updated": "2026-05-07",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Flash Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-07",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-flash-lite-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "google/gemini-flash-lite-latest",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Flash-Lite Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "minimax/minimax-m2": {
+        "attachment": false,
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "family": "minimax",
+        "id": "minimax/minimax-m2",
+        "last_updated": "2025-10-27",
+        "limit": {
+          "context": 196608,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M2",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-10-27",
+        "temperature": true,
+        "tool_call": true
+      },
+      "zai/glm-4.5-air": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.03,
+          "cache_write": 0,
+          "input": 0.2,
+          "output": 1.1
+        },
+        "family": "glm-air",
+        "id": "zai/glm-4.5-air",
+        "knowledge": "2025-04",
+        "last_updated": "2025-07-28",
+        "limit": {
+          "context": 131072,
+          "output": 98304
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-4.5-Air",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-07-28",
+        "temperature": true,
+        "tool_call": true
+      },
+      "cohere/command-r-plus-08-2024": {
+        "attachment": false,
+        "cost": {
+          "input": 2.5,
+          "output": 10
+        },
+        "family": "command-r",
+        "id": "cohere/command-r-plus-08-2024",
+        "knowledge": "2024-06-01",
+        "last_updated": "2024-08-30",
+        "limit": {
+          "context": 128000,
+          "output": 4000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Command R+",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-08-30",
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/devstral-small-2507": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.3
+        },
+        "family": "devstral",
+        "id": "mistral/devstral-small-2507",
+        "knowledge": "2025-05",
+        "last_updated": "2025-07-10",
+        "limit": {
+          "context": 128000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Devstral Small",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-07-10",
+        "status": "deprecated",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-3-flash-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.05,
+          "input": 0.5,
+          "input_audio": 1,
+          "output": 3
+        },
+        "family": "gemini-flash",
+        "id": "google/gemini-3-flash-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2025-12-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3 Flash Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-17",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5.4-nano": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.02,
+          "input": 0.2,
+          "output": 1.25
+        },
+        "family": "gpt-nano",
+        "id": "openai/gpt-5.4-nano",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-17",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4 nano",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-17",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "mistral/devstral-medium-latest": {
+        "attachment": false,
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "family": "devstral",
+        "id": "mistral/devstral-medium-latest",
+        "knowledge": "2025-12",
+        "last_updated": "2025-12-02",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Devstral 2 (latest)",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-12-02",
+        "status": "deprecated",
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/pixtral-large-latest": {
+        "attachment": true,
+        "cost": {
+          "input": 2,
+          "output": 6
+        },
+        "family": "pixtral",
+        "id": "mistral/pixtral-large-latest",
+        "knowledge": "2024-11",
+        "last_updated": "2024-11-04",
+        "limit": {
+          "context": 128000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Pixtral Large (latest)",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-11-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "mistral/mistral-large-2411": {
+        "attachment": false,
+        "cost": {
+          "input": 2,
+          "output": 6
+        },
+        "family": "mistral-large",
+        "id": "mistral/mistral-large-2411",
+        "knowledge": "2024-11",
+        "last_updated": "2024-11-04",
+        "limit": {
+          "context": 131072,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Mistral Large 2.1",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-11-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5.1-chat-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt-codex",
+        "id": "openai/gpt-5.1-chat-latest",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.1 Chat",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/o3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "input": 2,
+          "output": 8
+        },
+        "family": "o",
+        "id": "openai/o3",
+        "knowledge": "2024-05",
+        "last_updated": "2025-04-16",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-04-16",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4-1-20250805": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4-1-20250805",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5.2-chat-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt-codex",
+        "id": "openai/gpt-5.2-chat-latest",
+        "knowledge": "2025-08-31",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.2 Chat",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-11",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/gpt-5.4": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.25,
+          "context_over_200k": {
+            "cache_read": 0.5,
+            "input": 5,
+            "output": 22.5
+          },
+          "input": 2.5,
+          "output": 15,
+          "tiers": [
+            {
+              "cache_read": 0.5,
+              "input": 5,
+              "output": 22.5,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 0.5,
+                "input": 5,
+                "output": 30
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "family": "gpt",
+        "id": "openai/gpt-5.4",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-05",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/o3-mini": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.55,
+          "input": 1.1,
+          "output": 4.4
+        },
+        "family": "o-mini",
+        "id": "openai/o3-mini",
+        "knowledge": "2024-05",
+        "last_updated": "2025-01-29",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o3-mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-12-20",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "minimax/minimax-m2.7-highspeed": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.06,
+          "cache_write": 0.375,
+          "input": 0.6,
+          "output": 2.4
+        },
+        "family": "minimax",
+        "id": "minimax/minimax-m2.7-highspeed",
+        "last_updated": "2026-03-18",
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M2.7-highspeed",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-03-18",
+        "temperature": true,
+        "tool_call": true
+      },
+      "cohere/command-a-03-2025": {
+        "attachment": false,
+        "cost": {
+          "input": 2.5,
+          "output": 10
+        },
+        "family": "command-a",
+        "id": "cohere/command-a-03-2025",
+        "knowledge": "2024-06-01",
+        "last_updated": "2025-03-13",
+        "limit": {
+          "context": 256000,
+          "output": 8000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Command A",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-03-13",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-2.5-pro": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "context_over_200k": {
+            "cache_read": 0.25,
+            "input": 2.5,
+            "output": 15
+          },
+          "input": 1.25,
+          "output": 10,
+          "tiers": [
+            {
+              "cache_read": 0.25,
+              "input": 2.5,
+              "output": 15,
+              "tier": {
+                "size": 200000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "gemini-pro",
+        "id": "google/gemini-2.5-pro",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-05",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-03-20",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5.1": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "openai/gpt-5.1",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai/gpt-5-nano": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.005,
+          "input": 0.05,
+          "output": 0.4
+        },
+        "family": "gpt-nano",
+        "id": "openai/gpt-5-nano",
+        "knowledge": "2024-05-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Nano",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "google/gemini-2.5-flash-lite": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.01,
+          "input": 0.1,
+          "input_audio": 0.3,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "google/gemini-2.5-flash-lite",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash-Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-17",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek/deepseek-v4-pro": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.003625,
+          "input": 0.435,
+          "output": 0.87
+        },
+        "family": "deepseek-thinking",
+        "id": "deepseek/deepseek-v4-pro",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-05",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-5-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 2
+        },
+        "family": "gpt-mini",
+        "id": "openai/gpt-5-mini",
+        "knowledge": "2024-05-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "google/gemma-4-26b-a4b-it": {
+        "attachment": true,
+        "family": "gemma",
+        "id": "google/gemma-4-26b-a4b-it",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 26B A4B IT",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4-7": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 3,
+                "cache_write": 37.5,
+                "input": 30,
+                "output": 150
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4-7",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-04-16",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.7",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-16",
+        "temperature": false,
+        "tool_call": true
+      },
+      "minimax/minimax-m2.5-highspeed": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.06,
+          "cache_write": 0.375,
+          "input": 0.6,
+          "output": 2.4
+        },
+        "family": "minimax",
+        "id": "minimax/minimax-m2.5-highspeed",
+        "last_updated": "2026-02-13",
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M2.5-highspeed",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-02-13",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-flash-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "input": 0.3,
+          "input_audio": 1,
+          "output": 2.5
+        },
+        "family": "gemini-flash",
+        "id": "google/gemini-flash-latest",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Flash Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "cohere/command-r7b-12-2024": {
+        "attachment": false,
+        "cost": {
+          "input": 0.0375,
+          "output": 0.15
+        },
+        "family": "command-r",
+        "id": "cohere/command-r7b-12-2024",
+        "knowledge": "2024-06-01",
+        "last_updated": "2024-02-27",
+        "limit": {
+          "context": 128000,
+          "output": 4000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Command R7B",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2024-02-27",
+        "temperature": true,
+        "tool_call": true
+      },
+      "google/gemini-3.5-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.15,
+          "input": 1.5,
+          "input_audio": 1.5,
+          "output": 9
+        },
+        "family": "gemini-flash",
+        "id": "google/gemini-3.5-flash",
+        "knowledge": "2025-01",
+        "last_updated": "2026-05-19",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.5 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-19",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      }
+    },
+    "name": "Merge Gateway",
+    "npm": "merge-gateway-ai-sdk-provider"
+  },
   "cloudferro-sherlock": {
     "api": "https://api-sherlock.cloudferro.com/openai/v1/",
     "doc": "https://docs.sherlock.cloudferro.com/",
@@ -103368,7 +111757,7 @@
         "family": "llama",
         "id": "llama3.1-8b",
         "knowledge": "2023-12",
-        "last_updated": "2025-01-01",
+        "last_updated": "2026-05-27",
         "limit": {
           "context": 32000,
           "output": 8000
@@ -103385,6 +111774,7 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-01-01",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -103681,10 +112071,10 @@
             "text"
           ]
         },
-        "name": "DeepSeek R1",
+        "name": "DeepSeek-R1",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2024-12-26",
+        "release_date": "2025-01-20",
         "temperature": true,
         "tool_call": false
       },
@@ -103710,10 +112100,10 @@
             "text"
           ]
         },
-        "name": "DeepSeek V3",
+        "name": "DeepSeek-V3",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-01-20",
+        "release_date": "2024-12-26",
         "temperature": true,
         "tool_call": true
       },
@@ -103927,6 +112317,36 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-04-21",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 0.6,
+          "output": 3.6
+        },
+        "family": "nemotron",
+        "id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 512300,
+          "output": 512300
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nemotron 3 Ultra 550B A55B",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-06-04",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104168,7 +112588,8 @@
         },
         "family": "qwen",
         "id": "Qwen/Qwen3-235B-A22B-Instruct-2507-TEE",
-        "last_updated": "2026-04-25",
+        "knowledge": "2025-04",
+        "last_updated": "2025-04",
         "limit": {
           "context": 262144,
           "output": 65536
@@ -104184,7 +112605,7 @@
         "name": "Qwen3 235B A22B Instruct 2507 TEE",
         "open_weights": true,
         "reasoning": false,
-        "release_date": "2025-12-29",
+        "release_date": "2025-04",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104297,7 +112718,7 @@
         "interleaved": {
           "field": "reasoning_content"
         },
-        "last_updated": "2026-04-25",
+        "last_updated": "2026-02-11",
         "limit": {
           "context": 202752,
           "output": 65535
@@ -104313,7 +112734,7 @@
         "name": "GLM 5 TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-02-14",
+        "release_date": "2026-02-11",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104327,7 +112748,8 @@
         },
         "family": "qwen",
         "id": "Qwen/Qwen3-32B-TEE",
-        "last_updated": "2026-04-25",
+        "knowledge": "2025-04",
+        "last_updated": "2025-04",
         "limit": {
           "context": 40960,
           "output": 40960
@@ -104343,7 +112765,7 @@
         "name": "Qwen3 32B TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-04-25",
+        "release_date": "2025-04",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104454,7 +112876,8 @@
         },
         "family": "mimo",
         "id": "XiaomiMiMo/MiMo-V2-Flash-TEE",
-        "last_updated": "2026-04-25",
+        "knowledge": "2024-12-01",
+        "last_updated": "2026-02-04",
         "limit": {
           "context": 262144,
           "output": 65536
@@ -104470,7 +112893,7 @@
         "name": "MiMo V2 Flash TEE",
         "open_weights": true,
         "reasoning": false,
-        "release_date": "2026-04-25",
+        "release_date": "2025-12-16",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104515,13 +112938,13 @@
           "input": 0.95,
           "output": 4
         },
-        "family": "kimi",
+        "family": "kimi-k2.6",
         "id": "moonshotai/Kimi-K2.6-TEE",
         "interleaved": {
           "field": "reasoning_content"
         },
         "knowledge": "2025-12",
-        "last_updated": "2026-04-25",
+        "last_updated": "2026-04-21",
         "limit": {
           "context": 262144,
           "output": 65535
@@ -104539,7 +112962,7 @@
         "name": "Kimi K2.6 TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-04-20",
+        "release_date": "2026-04-21",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104617,7 +113040,7 @@
         "interleaved": {
           "field": "reasoning_content"
         },
-        "last_updated": "2026-04-25",
+        "last_updated": "2026-03-27",
         "limit": {
           "context": 202752,
           "output": 65535
@@ -104633,7 +113056,7 @@
         "name": "GLM 5.1 TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-04-08",
+        "release_date": "2026-03-27",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104650,7 +113073,8 @@
         "interleaved": {
           "field": "reasoning_content"
         },
-        "last_updated": "2026-04-25",
+        "knowledge": "2024-07",
+        "last_updated": "2025-05-29",
         "limit": {
           "context": 163840,
           "output": 65536
@@ -104666,7 +113090,7 @@
         "name": "DeepSeek R1 0528 TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-12-29",
+        "release_date": "2025-01-20",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104708,13 +113132,13 @@
           "input": 0.44,
           "output": 2
         },
-        "family": "kimi",
+        "family": "kimi-k2.5",
         "id": "moonshotai/Kimi-K2.5-TEE",
         "interleaved": {
           "field": "reasoning_content"
         },
         "knowledge": "2024-10",
-        "last_updated": "2026-04-25",
+        "last_updated": "2026-01",
         "limit": {
           "context": 262144,
           "output": 65535
@@ -104732,7 +113156,7 @@
         "name": "Kimi K2.5 TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-01-27",
+        "release_date": "2026-01",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104749,7 +113173,7 @@
         "interleaved": {
           "field": "reasoning_content"
         },
-        "last_updated": "2026-04-25",
+        "last_updated": "2026-02-15",
         "limit": {
           "context": 262144,
           "output": 65536
@@ -104766,7 +113190,7 @@
         "name": "Qwen3.5 397B A17B TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-02-18",
+        "release_date": "2026-02-15",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -104990,7 +113414,7 @@
         },
         "family": "gemma",
         "id": "google/gemma-4-31B-turbo-TEE",
-        "last_updated": "2026-04-25",
+        "last_updated": "2026-04-02",
         "limit": {
           "context": 131072,
           "output": 65536
@@ -105007,7 +113431,7 @@
         "name": "gemma 4 31B turbo TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-04-25",
+        "release_date": "2026-04-02",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -105024,7 +113448,8 @@
         "interleaved": {
           "field": "reasoning_content"
         },
-        "last_updated": "2026-04-25",
+        "knowledge": "2025-04",
+        "last_updated": "2025-12-22",
         "limit": {
           "context": 202752,
           "output": 65535
@@ -105040,7 +113465,7 @@
         "name": "GLM 4.7 TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-12-29",
+        "release_date": "2025-12-22",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -105118,7 +113543,7 @@
         "interleaved": {
           "field": "reasoning_content"
         },
-        "last_updated": "2026-04-25",
+        "last_updated": "2026-02-12",
         "limit": {
           "context": 196608,
           "output": 65536
@@ -105134,7 +113559,7 @@
         "name": "MiniMax M2.5 TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-02-15",
+        "release_date": "2026-02-12",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -105212,7 +113637,7 @@
         },
         "family": "qwen",
         "id": "Qwen/Qwen3.6-27B-TEE",
-        "last_updated": "2026-04-25",
+        "last_updated": "2026-04-22",
         "limit": {
           "context": 262144,
           "output": 65536
@@ -105229,7 +113654,7 @@
         "name": "Qwen3.6 27B TEE",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-04-25",
+        "release_date": "2026-04-22",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -105852,6 +114277,36 @@
         "status": "deprecated",
         "temperature": false,
         "tool_call": false
+      },
+      "anthropic/claude-opus-4.8": {
+        "attachment": true,
+        "cost": {
+          "input": 4.2929,
+          "output": 21.4646
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4.8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1048576,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude-Opus-4.8",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
       },
       "ideogramai/ideogram": {
         "attachment": true,
@@ -109145,6 +117600,365 @@
     "name": "Poe",
     "npm": "@ai-sdk/openai-compatible"
   },
+  "snowflake-cortex": {
+    "api": "https://${SNOWFLAKE_ACCOUNT}.snowflakecomputing.com/api/v2/cortex/v1",
+    "doc": "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api",
+    "env": [
+      "SNOWFLAKE_ACCOUNT",
+      "SNOWFLAKE_CORTEX_PAT"
+    ],
+    "id": "snowflake-cortex",
+    "models": {
+      "claude-haiku-4-5": {
+        "attachment": true,
+        "family": "claude-haiku",
+        "id": "claude-haiku-4-5",
+        "knowledge": "2025-02-28",
+        "last_updated": "2025-10-15",
+        "limit": {
+          "context": 200000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 4.5 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-10-15",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-7": {
+        "attachment": true,
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 3,
+                "cache_write": 37.5,
+                "input": 30,
+                "output": 150
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-7",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-04-16",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.7",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-16",
+        "status": "beta",
+        "temperature": false,
+        "tool_call": true
+      },
+      "claude-sonnet-4-5": {
+        "attachment": true,
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-5",
+        "knowledge": "2025-07-31",
+        "last_updated": "2025-09-29",
+        "limit": {
+          "context": 200000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.5 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-29",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-sonnet-4-6": {
+        "attachment": true,
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-6",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.6",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai-gpt-4.1": {
+        "attachment": true,
+        "family": "gpt",
+        "id": "openai-gpt-4.1",
+        "knowledge": "2024-04",
+        "last_updated": "2025-04-14",
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4.1",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-14",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai-gpt-5": {
+        "attachment": true,
+        "family": "gpt",
+        "id": "openai-gpt-5",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "status": "beta",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai-gpt-5-mini": {
+        "attachment": true,
+        "family": "gpt-mini",
+        "id": "openai-gpt-5-mini",
+        "knowledge": "2024-05-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 272000,
+          "input": 272000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "status": "beta",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai-gpt-5-nano": {
+        "attachment": true,
+        "family": "gpt-nano",
+        "id": "openai-gpt-5-nano",
+        "knowledge": "2024-05-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Nano",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "status": "beta",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai-gpt-5.1": {
+        "attachment": true,
+        "family": "gpt",
+        "id": "openai-gpt-5.1",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai-gpt-5.2": {
+        "attachment": true,
+        "family": "gpt",
+        "id": "openai-gpt-5.2",
+        "knowledge": "2025-08-31",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.2",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-11",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai-gpt-5.4": {
+        "attachment": true,
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 0.5,
+                "input": 5,
+                "output": 30
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "family": "gpt",
+        "id": "openai-gpt-5.4",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-05",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "status": "beta",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      }
+    },
+    "name": "Snowflake Cortex",
+    "npm": "@ai-sdk/openai-compatible"
+  },
   "wafer.ai": {
     "api": "https://pass.wafer.ai/v1",
     "doc": "https://docs.wafer.ai/wafer-pass",
@@ -109156,15 +117970,15 @@
       "GLM-5.1": {
         "attachment": false,
         "cost": {
-          "cache_read": 0,
+          "cache_read": 0.1,
           "cache_write": 0,
-          "input": 0,
-          "output": 0
+          "input": 1,
+          "output": 3.2
         },
         "family": "glm",
         "id": "GLM-5.1",
         "knowledge": "2025-04",
-        "last_updated": "2026-04-07",
+        "last_updated": "2026-06-01",
         "limit": {
           "context": 202752,
           "output": 131072
@@ -109188,48 +118002,15 @@
       "Kimi-K2.6": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.11,
+          "cache_read": 0.07,
           "cache_write": 0,
-          "input": 1.1,
-          "output": 4.8
+          "input": 0.68,
+          "output": 3.15
         },
         "family": "kimi",
         "id": "Kimi-K2.6",
         "knowledge": "2025-01",
-        "last_updated": "2026-05-13",
-        "limit": {
-          "context": 262144,
-          "output": 65536
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Kimi K2.6",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2026-05-13",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
-      "Qwen3.5-397B-A17B": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0,
-          "cache_write": 0,
-          "input": 0,
-          "output": 0
-        },
-        "family": "qwen",
-        "id": "Qwen3.5-397B-A17B",
-        "knowledge": "2025-04",
-        "last_updated": "2026-02-16",
+        "last_updated": "2026-06-01",
         "limit": {
           "context": 262144,
           "output": 65536
@@ -109244,7 +118025,41 @@
             "text"
           ]
         },
-        "name": "Qwen3.5 397B A17B",
+        "name": "Kimi-K2.6",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-05-13",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "Qwen3.5-397B-A17B": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.04,
+          "cache_write": 0,
+          "input": 0.43,
+          "output": 2.6
+        },
+        "family": "qwen",
+        "id": "Qwen3.5-397B-A17B",
+        "knowledge": "2025-04",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 262144,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.5-397B-A17B",
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-02-16",
@@ -109257,16 +118072,17 @@
         "cost": {
           "cache_read": 0.02,
           "cache_write": 0,
-          "input": 0.19,
-          "output": 1.25
+          "input": 0.15,
+          "output": 1
         },
         "family": "qwen",
         "id": "Qwen3.6-35B-A3B",
         "knowledge": "2025-04",
-        "last_updated": "2026-05-11",
+        "last_updated": "2026-05-30",
         "limit": {
-          "context": 32768,
-          "output": 16384
+          "context": 256000,
+          "input": 229376,
+          "output": 65536
         },
         "modalities": {
           "input": [
@@ -109278,10 +118094,111 @@
             "text"
           ]
         },
-        "name": "Qwen3.6 35B A3B",
+        "name": "Qwen3.6-35B-A3B",
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-05-11",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek-v4-flash": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.01,
+          "cache_write": 0,
+          "input": 0.14,
+          "output": 0.28
+        },
+        "family": "deepseek-flash",
+        "id": "deepseek-v4-flash",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-05",
+        "last_updated": "2026-05-30",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Flash",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek-v4-pro": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.02,
+          "cache_write": 0,
+          "input": 1.74,
+          "output": 3.48
+        },
+        "family": "deepseek-thinking",
+        "id": "deepseek-v4-pro",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-05",
+        "last_updated": "2026-05-30",
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V4 Pro",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "qwen3.7-max": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 0,
+          "input": 5,
+          "output": 15
+        },
+        "family": "qwen3.7-max",
+        "id": "qwen3.7-max",
+        "last_updated": "2026-05-30",
+        "limit": {
+          "context": 256000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7-Max",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-21",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -109557,6 +118474,11 @@
         "name": "GLM-4.5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-07-28",
         "temperature": true,
         "tool_call": true
@@ -109588,6 +118510,11 @@
         "name": "GLM-4.5-Air",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-07-28",
         "temperature": true,
         "tool_call": true
@@ -109619,6 +118546,11 @@
         "name": "GLM-4.5-Flash",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-07-28",
         "temperature": true,
         "tool_call": true
@@ -109650,6 +118582,11 @@
         "name": "GLM-4.5V",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-08-11",
         "temperature": true,
         "tool_call": true
@@ -109681,6 +118618,11 @@
         "name": "GLM-4.6",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-09-30",
         "temperature": true,
         "tool_call": true
@@ -109712,6 +118654,11 @@
         "name": "GLM-4.6V",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-12-08",
         "temperature": true,
         "tool_call": true
@@ -109746,6 +118693,11 @@
         "name": "GLM-4.7",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-12-22",
         "temperature": true,
         "tool_call": true
@@ -109777,6 +118729,11 @@
         "name": "GLM-4.7-Flash",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-01-19",
         "temperature": true,
         "tool_call": true
@@ -109808,6 +118765,11 @@
         "name": "GLM-4.7-FlashX",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-01-19",
         "temperature": true,
         "tool_call": true
@@ -109841,6 +118803,11 @@
         "name": "GLM-5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-02-11",
         "temperature": true,
         "tool_call": true
@@ -109874,6 +118841,11 @@
         "name": "GLM-5-Turbo",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-03-16",
         "structured_output": true,
         "temperature": true,
@@ -109908,6 +118880,11 @@
         "name": "GLM-5.1",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-03-27",
         "structured_output": true,
         "temperature": true,
@@ -109945,6 +118922,11 @@
         "name": "GLM-5V-Turbo",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-04-01",
         "temperature": true,
         "tool_call": true
@@ -109988,6 +118970,11 @@
         "name": "GLM-4.5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-07-28",
         "temperature": true,
         "tool_call": true
@@ -110019,6 +119006,11 @@
         "name": "GLM-4.5-Air",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-07-28",
         "temperature": true,
         "tool_call": true
@@ -110050,6 +119042,11 @@
         "name": "GLM-4.5-Flash",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-07-28",
         "temperature": true,
         "tool_call": true
@@ -110081,6 +119078,11 @@
         "name": "GLM-4.5V",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-08-11",
         "temperature": true,
         "tool_call": true
@@ -110112,6 +119114,11 @@
         "name": "GLM-4.6",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-09-30",
         "temperature": true,
         "tool_call": true
@@ -110143,6 +119150,11 @@
         "name": "GLM-4.6V",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-12-08",
         "temperature": true,
         "tool_call": true
@@ -110177,6 +119189,11 @@
         "name": "GLM-4.7",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2025-12-22",
         "temperature": true,
         "tool_call": true
@@ -110208,6 +119225,11 @@
         "name": "GLM-4.7-Flash",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-01-19",
         "temperature": true,
         "tool_call": true
@@ -110239,6 +119261,11 @@
         "name": "GLM-4.7-FlashX",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-01-19",
         "temperature": true,
         "tool_call": true
@@ -110272,6 +119299,11 @@
         "name": "GLM-5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-02-11",
         "temperature": true,
         "tool_call": true
@@ -110305,6 +119337,11 @@
         "name": "GLM-5.1",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-03-27",
         "structured_output": true,
         "temperature": true,
@@ -110342,6 +119379,11 @@
         "name": "GLM-5V-Turbo",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "release_date": "2026-04-01",
         "temperature": true,
         "tool_call": true
@@ -111109,6 +120151,7 @@
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-voicechat",
         "last_updated": "2026-03-16",
         "limit": {
@@ -111128,6 +120171,34 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2026-03-16",
+        "temperature": true,
+        "tool_call": true
+      },
+      "stepfun-ai/step-3.7-flash": {
+        "attachment": true,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "id": "stepfun-ai/step-3.7-flash",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 256000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Step 3.7 Flash",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-05-28",
         "temperature": true,
         "tool_call": true
       },
@@ -111537,12 +120608,43 @@
         "temperature": true,
         "tool_call": true
       },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.15,
+          "input": 0.5,
+          "output": 2.5
+        },
+        "family": "nemotron",
+        "id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nemotron 3 Ultra 550B A55B",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-06-04",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
       "nvidia/llama-3_1-nemotron-safety-guard-8b-v3": {
         "attachment": false,
         "cost": {
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "nvidia/llama-3_1-nemotron-safety-guard-8b-v3",
         "last_updated": "2025-10-28",
         "limit": {
@@ -111948,6 +121050,7 @@
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
         "last_updated": "2026-03-31",
         "limit": {
@@ -111976,6 +121079,7 @@
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-3-content-safety",
         "last_updated": "2026-04-16",
         "limit": {
@@ -112323,6 +121427,7 @@
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
         "last_updated": "2026-02-10",
         "limit": {
@@ -112807,6 +121912,7 @@
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-content-safety-reasoning-4b",
         "last_updated": "2026-01-22",
         "limit": {
@@ -113244,6 +122350,7 @@
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "mistralai/mistral-nemotron",
         "last_updated": "2025-06-12",
         "limit": {
@@ -113299,6 +122406,7 @@
           "input": 0,
           "output": 0
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-mini-4b-instruct",
         "last_updated": "2024-08-26",
         "limit": {
@@ -116167,7 +125275,7 @@
     "npm": "@ai-sdk/openai-compatible"
   },
   "routing-run": {
-    "api": "https://api.routing.run/v1",
+    "api": "https://ai.routing.sh/v1",
     "doc": "https://docs.routing.run/api-reference/models",
     "env": [
       "ROUTING_RUN_API_KEY"
@@ -116403,7 +125511,7 @@
           ]
         },
         "name": "GLM 5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -116437,7 +125545,7 @@
           ]
         },
         "name": "GLM 5.1 6bit",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -122408,9 +131516,10 @@
           "input": 0.497,
           "output": 4.881
         },
-        "family": "deepseek",
+        "family": "deepseek-thinking",
         "id": "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
-        "last_updated": "2025-01-22",
+        "knowledge": "2024-07",
+        "last_updated": "2025-05-29",
         "limit": {
           "context": 80000,
           "output": 80000
@@ -122426,36 +131535,7 @@
         "name": "Deepseek R1 Distill Qwen 32B",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-01-22",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
-      "@cf/google/gemma-3-12b-it": {
-        "attachment": false,
-        "cost": {
-          "input": 0.345,
-          "output": 0.556
-        },
-        "family": "gemma",
-        "id": "@cf/google/gemma-3-12b-it",
-        "last_updated": "2025-03-18",
-        "limit": {
-          "context": 80000,
-          "output": 80000
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Gemma 3 12B It",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2025-03-18",
+        "release_date": "2025-01-20",
         "structured_output": false,
         "temperature": true,
         "tool_call": false
@@ -122468,7 +131548,7 @@
         },
         "family": "gemma",
         "id": "@cf/google/gemma-4-26b-a4b-it",
-        "last_updated": "2025-12-15",
+        "last_updated": "2026-04-02",
         "limit": {
           "context": 256000,
           "output": 16384
@@ -122485,7 +131565,7 @@
         "name": "Gemma 4 26B A4B IT",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-12-15",
+        "release_date": "2026-04-02",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -122518,122 +131598,6 @@
         "structured_output": false,
         "temperature": true,
         "tool_call": true
-      },
-      "@cf/meta/llama-2-7b-chat-fp16": {
-        "attachment": false,
-        "cost": {
-          "input": 0.556,
-          "output": 6.667
-        },
-        "family": "llama",
-        "id": "@cf/meta/llama-2-7b-chat-fp16",
-        "last_updated": "2023-11-07",
-        "limit": {
-          "context": 4096,
-          "output": 4096
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 2 7B Chat fp16",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2023-11-07",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
-      "@cf/meta/llama-3-8b-instruct": {
-        "attachment": false,
-        "cost": {
-          "input": 0.282,
-          "output": 0.827
-        },
-        "family": "llama",
-        "id": "@cf/meta/llama-3-8b-instruct",
-        "last_updated": "2024-04-18",
-        "limit": {
-          "context": 7968,
-          "output": 7968
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3 8B Instruct",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2024-04-18",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
-      "@cf/meta/llama-3-8b-instruct-awq": {
-        "attachment": false,
-        "cost": {
-          "input": 0.123,
-          "output": 0.266
-        },
-        "family": "llama",
-        "id": "@cf/meta/llama-3-8b-instruct-awq",
-        "last_updated": "2024-05-09",
-        "limit": {
-          "context": 8192,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3 8B Instruct Awq",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2024-05-09",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
-      "@cf/meta/llama-3.1-8b-instruct-awq": {
-        "attachment": false,
-        "cost": {
-          "input": 0.123,
-          "output": 0.266
-        },
-        "family": "llama",
-        "id": "@cf/meta/llama-3.1-8b-instruct-awq",
-        "last_updated": "2024-07-25",
-        "limit": {
-          "context": 8192,
-          "output": 8192
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Llama 3.1 8B Instruct Awq",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2024-07-25",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
       },
       "@cf/meta/llama-3.1-8b-instruct-fp8": {
         "attachment": false,
@@ -122760,6 +131724,7 @@
         },
         "family": "llama",
         "id": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+        "knowledge": "2023-12",
         "last_updated": "2024-12-06",
         "limit": {
           "context": 24000,
@@ -122789,7 +131754,8 @@
         },
         "family": "llama",
         "id": "@cf/meta/llama-4-scout-17b-16e-instruct",
-        "last_updated": "2025-04-16",
+        "knowledge": "2024-08",
+        "last_updated": "2025-04-05",
         "limit": {
           "context": 131000,
           "output": 16384
@@ -122806,7 +131772,7 @@
         "name": "Llama 4 Scout 17B 16E Instruct",
         "open_weights": true,
         "reasoning": false,
-        "release_date": "2025-04-16",
+        "release_date": "2025-04-05",
         "structured_output": false,
         "temperature": true,
         "tool_call": true
@@ -122840,35 +131806,6 @@
         "temperature": true,
         "tool_call": false
       },
-      "@cf/mistral/mistral-7b-instruct-v0.1": {
-        "attachment": false,
-        "cost": {
-          "input": 0.11,
-          "output": 0.19
-        },
-        "family": "mistral",
-        "id": "@cf/mistral/mistral-7b-instruct-v0.1",
-        "last_updated": "2023-11-07",
-        "limit": {
-          "context": 2824,
-          "output": 2824
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Mistral 7B Instruct V0.1",
-        "open_weights": true,
-        "reasoning": false,
-        "release_date": "2023-11-07",
-        "structured_output": false,
-        "temperature": true,
-        "tool_call": false
-      },
       "@cf/mistralai/mistral-small-3.1-24b-instruct": {
         "attachment": false,
         "cost": {
@@ -122898,41 +131835,6 @@
         "temperature": true,
         "tool_call": true
       },
-      "@cf/moonshotai/kimi-k2.5": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0.1,
-          "input": 0.6,
-          "output": 3
-        },
-        "family": "kimi",
-        "id": "@cf/moonshotai/kimi-k2.5",
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "knowledge": "2025-01",
-        "last_updated": "2026-01-27",
-        "limit": {
-          "context": 256000,
-          "output": 256000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Kimi K2.5",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2026-01-27",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
       "@cf/moonshotai/kimi-k2.6": {
         "attachment": true,
         "cost": {
@@ -122940,13 +131842,13 @@
           "input": 0.95,
           "output": 4
         },
-        "family": "kimi",
+        "family": "kimi-k2.6",
         "id": "@cf/moonshotai/kimi-k2.6",
         "interleaved": {
           "field": "reasoning_content"
         },
         "knowledge": "2025-01",
-        "last_updated": "2026-04-20",
+        "last_updated": "2026-04-21",
         "limit": {
           "context": 262144,
           "output": 256000
@@ -122963,7 +131865,7 @@
         "name": "Kimi K2.6",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2026-04-20",
+        "release_date": "2026-04-21",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -123210,6 +132112,17 @@
         "name": "Sarvam-105B",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              null,
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-02-18",
         "temperature": true,
         "tool_call": true
@@ -123237,6 +132150,17 @@
         "name": "Sarvam-30B",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              null,
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-02-18",
         "temperature": true,
         "tool_call": true
@@ -125071,6 +133995,7 @@
           "input": 0.6,
           "output": 1.8
         },
+        "family": "nemotron",
         "id": "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
         "knowledge": "2024-12",
         "last_updated": "2026-02-04",
@@ -125103,6 +134028,7 @@
           "input": 0.06,
           "output": 0.24
         },
+        "family": "nemotron",
         "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
         "knowledge": "2025-05",
         "last_updated": "2026-02-04",
@@ -125135,6 +134061,7 @@
           "input": 0.06,
           "output": 0.24
         },
+        "family": "nemotron",
         "id": "nvidia/Nemotron-3-Nano-Omni",
         "knowledge": "2025-01",
         "last_updated": "2026-05-07",
@@ -125165,6 +134092,7 @@
           "input": 0.3,
           "output": 0.9
         },
+        "family": "nemotron",
         "id": "nvidia/nemotron-3-super-120b-a12b",
         "knowledge": "2026-02",
         "last_updated": "2026-03-12",
@@ -126128,10 +135056,10 @@
       "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.3,
-          "cache_write": 3.75,
-          "input": 3,
-          "output": 15
+          "cache_read": 0.33,
+          "cache_write": 4.125,
+          "input": 3.3,
+          "output": 16.5
         },
         "family": "claude-sonnet",
         "id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -126284,10 +135212,10 @@
       "eu.anthropic.claude-sonnet-4-6": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.3,
-          "cache_write": 3.75,
-          "input": 3,
-          "output": 15
+          "cache_read": 0.33,
+          "cache_write": 4.125,
+          "input": 3.3,
+          "output": 16.5
         },
         "family": "claude-sonnet",
         "id": "eu.anthropic.claude-sonnet-4-6",
@@ -126510,6 +135438,38 @@
         "temperature": true,
         "tool_call": true
       },
+      "global.anthropic.claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "global.anthropic.claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8 (Global)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
       "google.gemma-3-12b-it": {
         "attachment": false,
         "cost": {
@@ -126692,6 +135652,38 @@
         "temperature": true,
         "tool_call": true
       },
+      "jp.anthropic.claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "jp.anthropic.claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8 (JP)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
       "zai.glm-4.7-flash": {
         "attachment": false,
         "cost": {
@@ -126722,6 +135714,38 @@
         "temperature": true,
         "tool_call": true
       },
+      "au.anthropic.claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "au.anthropic.claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8 (AU)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
       "qwen.qwen3-235b-a22b-2507-v1:0": {
         "attachment": false,
         "cost": {
@@ -126748,6 +135772,40 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2025-09-18",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai.gpt-oss-20b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.07,
+          "output": 0.3
+        },
+        "family": "gpt-oss",
+        "id": "openai.gpt-oss-20b",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "gpt-oss-20b",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": false,
+        "release_date": "2025-08-05",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -126881,6 +135939,44 @@
         "release_date": "2025-09-29",
         "structured_output": true,
         "temperature": true,
+        "tool_call": true
+      },
+      "openai.gpt-5.4": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.275,
+          "input": 2.75,
+          "output": 16.5
+        },
+        "family": "gpt",
+        "id": "openai.gpt-5.4",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "temperature": false,
         "tool_call": true
       },
       "us.anthropic.claude-sonnet-4-6": {
@@ -127225,6 +136321,44 @@
         "temperature": true,
         "tool_call": true
       },
+      "openai.gpt-5.5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.55,
+          "input": 5.5,
+          "output": 33
+        },
+        "family": "gpt",
+        "id": "openai.gpt-5.5",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.5",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "release_date": "2026-04-23",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
       "mistral.magistral-small-2509": {
         "attachment": false,
         "cost": {
@@ -127372,7 +136506,7 @@
           ]
         },
         "name": "DeepSeek-R1 (US)",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2025-01-20",
         "temperature": true,
@@ -127436,6 +136570,38 @@
         "release_date": "2025-07-27",
         "structured_output": true,
         "temperature": true,
+        "tool_call": true
+      },
+      "us.anthropic.claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "us.anthropic.claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8 (US)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
         "tool_call": true
       },
       "us.anthropic.claude-opus-4-1-20250805-v1:0": {
@@ -127634,10 +136800,10 @@
       "eu.anthropic.claude-opus-4-6-v1": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.5,
-          "cache_write": 6.25,
-          "input": 5,
-          "output": 25
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "input": 5.5,
+          "output": 27.5
         },
         "family": "claude-opus",
         "id": "eu.anthropic.claude-opus-4-6-v1",
@@ -127695,6 +136861,40 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-10-15",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai.gpt-oss-120b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "gpt-oss",
+        "id": "openai.gpt-oss-120b",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "gpt-oss-120b",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": false,
+        "release_date": "2025-08-05",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -128206,6 +137406,38 @@
         "temperature": true,
         "tool_call": true
       },
+      "eu.anthropic.claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "input": 5.5,
+          "output": 27.5
+        },
+        "family": "claude-opus",
+        "id": "eu.anthropic.claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8 (EU)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
       "zai.glm-4.7": {
         "attachment": false,
         "cost": {
@@ -128419,10 +137651,10 @@
       "eu.anthropic.claude-opus-4-7": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.5,
-          "cache_write": 6.25,
-          "input": 5,
-          "output": 25
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "input": 5.5,
+          "output": 27.5
         },
         "family": "claude-opus",
         "id": "eu.anthropic.claude-opus-4-7",
@@ -128816,9 +138048,9 @@
       "deepseek-v3.2": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.06,
-          "input": 0.28,
-          "output": 0.38
+          "cache_read": 0.04,
+          "input": 0.18,
+          "output": 0.35
         },
         "family": "deepseek",
         "id": "deepseek-v3.2",
@@ -128845,7 +138077,7 @@
       "deepseek-v4-flash": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.02,
+          "cache_read": 0.003,
           "input": 0.12,
           "output": 0.21
         },
@@ -128883,8 +138115,8 @@
         "attachment": false,
         "cost": {
           "cache_read": 0.003,
-          "input": 0.4,
-          "output": 0.85
+          "input": 0.35,
+          "output": 0.8
         },
         "family": "deepseek-thinking",
         "id": "deepseek-v4-pro",
@@ -128916,18 +138148,19 @@
         "temperature": true,
         "tool_call": true
       },
-      "deepseek-v4-pro-precision": {
+      "deepseek-v4-pro-lightning": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.1,
-          "input": 1.25,
-          "output": 2.5
+          "cache_read": 0.02,
+          "input": 0.8,
+          "output": 1.6
         },
         "family": "deepseek-thinking",
-        "id": "deepseek-v4-pro-precision",
+        "id": "deepseek-v4-pro-lightning",
         "interleaved": {
           "field": "reasoning_content"
         },
+        "knowledge": "2025-05",
         "last_updated": "2026-04-24",
         "limit": {
           "context": 1000000,
@@ -128941,8 +138174,11 @@
             "text"
           ]
         },
-        "name": "DeepSeek V4 Pro (Precision)",
+        "name": "DeepSeek V4 Pro",
         "open_weights": true,
+        "provider": {
+          "npm": "@ai-sdk/openai-compatible"
+        },
         "reasoning": true,
         "release_date": "2026-04-24",
         "structured_output": true,
@@ -129033,7 +138269,7 @@
         "knowledge": "2025-04",
         "last_updated": "2026-01-19",
         "limit": {
-          "context": 200000,
+          "context": 202752,
           "output": 131072
         },
         "modalities": {
@@ -129093,10 +138329,10 @@
       "glm-5.1": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.09,
+          "cache_read": 0.08,
           "cache_write": 0,
           "input": 0.45,
-          "output": 2.1
+          "output": 2.15
         },
         "family": "glm",
         "id": "glm-5.1",
@@ -129117,7 +138353,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "provider": {
           "npm": "@ai-sdk/openai-compatible"
         },
@@ -129127,47 +138363,14 @@
         "temperature": true,
         "tool_call": true
       },
-      "glm-5.1-precision": {
-        "attachment": false,
-        "cost": {
-          "cache_read": 0.15,
-          "input": 0.75,
-          "output": 2.9
-        },
-        "family": "glm",
-        "id": "glm-5.1-precision",
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "last_updated": "2026-03-27",
-        "limit": {
-          "context": 202752,
-          "output": 202752
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GLM 5.1 (Precision)",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2026-03-27",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
-      "greg": {
+      "greg-1": {
         "attachment": false,
         "cost": {
           "cache_read": 0.02,
           "input": 0.1,
-          "output": 0.2
+          "output": 0.3
         },
-        "id": "greg",
+        "id": "greg-1",
         "last_updated": "2026-01-27",
         "limit": {
           "context": 229376,
@@ -129181,7 +138384,91 @@
             "text"
           ]
         },
-        "name": "Experiment!: Greg",
+        "name": "Greg 1 Normal",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-01-27",
+        "temperature": true,
+        "tool_call": false
+      },
+      "greg-1-mini": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.01,
+          "input": 0.07,
+          "output": 0.15
+        },
+        "id": "greg-1-mini",
+        "last_updated": "2026-01-27",
+        "limit": {
+          "context": 229376,
+          "output": 229376
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Greg 1 Mini",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-01-27",
+        "temperature": true,
+        "tool_call": false
+      },
+      "greg-1-super": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 1,
+          "output": 5
+        },
+        "id": "greg-1-super",
+        "last_updated": "2026-01-27",
+        "limit": {
+          "context": 229376,
+          "output": 229376
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Greg 1 Super",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-01-27",
+        "temperature": true,
+        "tool_call": false
+      },
+      "greg-rp": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.02,
+          "input": 0.1,
+          "output": 0.3
+        },
+        "id": "greg-rp",
+        "last_updated": "2026-01-27",
+        "limit": {
+          "context": 229376,
+          "output": 229376
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Greg (Roleplay)",
         "open_weights": false,
         "reasoning": false,
         "release_date": "2026-01-27",
@@ -129265,7 +138552,7 @@
       "kimi-k2.6": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.1,
+          "cache_read": 0.05,
           "input": 0.5,
           "output": 1.99
         },
@@ -129301,52 +138588,17 @@
         "temperature": true,
         "tool_call": true
       },
-      "kimi-k2.6-precision": {
-        "attachment": true,
-        "cost": {
-          "cache_read": 0.11,
-          "input": 0.55,
-          "output": 2.7
-        },
-        "family": "kimi-k2.6",
-        "id": "kimi-k2.6-precision",
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "last_updated": "2026-04-21",
-        "limit": {
-          "context": 262144,
-          "output": 262144
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Kimi K2.6 (Precision)",
-        "open_weights": true,
-        "reasoning": true,
-        "release_date": "2026-04-21",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
       "mimo-v2.5-pro": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.1,
+          "cache_read": 0.003,
           "context_over_200k": {
             "cache_read": 0.4,
             "input": 2,
             "output": 6
           },
-          "input": 0.5,
-          "output": 1.5,
+          "input": 0.4,
+          "output": 0.8,
           "tiers": [
             {
               "cache_read": 0.4,
@@ -129383,38 +138635,6 @@
         "provider": {
           "npm": "@ai-sdk/openai-compatible"
         },
-        "reasoning": true,
-        "release_date": "2026-04-22",
-        "temperature": true,
-        "tool_call": true
-      },
-      "mimo-v2.5-pro-precision": {
-        "attachment": false,
-        "cost": {
-          "cache_read": 0.16,
-          "input": 0.8,
-          "output": 2.5
-        },
-        "family": "mimo",
-        "id": "mimo-v2.5-pro-precision",
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "last_updated": "2026-04-22",
-        "limit": {
-          "context": 1000000,
-          "output": 131072
-        },
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "MiMo-V2.5-Pro (Precision)",
-        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-04-22",
         "temperature": true,
@@ -129636,7 +138856,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -129658,28 +138878,31 @@
       "claude-haiku-4.5": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
         },
         "family": "claude-haiku",
         "id": "claude-haiku-4.5",
         "knowledge": "2025-02-28",
         "last_updated": "2025-10-15",
         "limit": {
-          "context": 144000,
-          "input": 128000,
-          "output": 32000
+          "context": 200000,
+          "input": 136000,
+          "output": 64000
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Claude Haiku 4.5",
+        "name": "Claude Haiku 4.5 (latest)",
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-10-15",
@@ -129689,28 +138912,31 @@
       "claude-opus-4.5": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
         },
         "family": "claude-opus",
         "id": "claude-opus-4.5",
         "knowledge": "2025-03-31",
-        "last_updated": "2025-08-01",
+        "last_updated": "2025-11-24",
         "limit": {
-          "context": 160000,
-          "input": 128000,
+          "context": 200000,
+          "input": 168000,
           "output": 32000
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Claude Opus 4.5",
+        "name": "Claude Opus 4.5 (latest)",
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-11-24",
@@ -129720,22 +138946,45 @@
       "claude-opus-4.6": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 3,
+                "cache_write": 37.5,
+                "input": 30,
+                "output": 150
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
         },
         "family": "claude-opus",
         "id": "claude-opus-4.6",
         "knowledge": "2025-05-31",
-        "last_updated": "2026-02-05",
+        "last_updated": "2026-03-13",
         "limit": {
-          "context": 144000,
-          "input": 128000,
-          "output": 64000
+          "context": 200000,
+          "input": 168000,
+          "output": 32000
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -129751,22 +139000,45 @@
       "claude-opus-4.7": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 3,
+                "cache_write": 37.5,
+                "input": 30,
+                "output": 150
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
         },
         "family": "claude-opus",
         "id": "claude-opus-4.7",
         "knowledge": "2026-01-31",
         "last_updated": "2026-04-16",
         "limit": {
-          "context": 144000,
-          "input": 128000,
-          "output": 64000
+          "context": 200000,
+          "input": 168000,
+          "output": 32000
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -129779,42 +139051,66 @@
         "temperature": false,
         "tool_call": true
       },
-      "claude-opus-41": {
+      "claude-opus-4.8": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 1,
+                "cache_write": 12.5,
+                "input": 10,
+                "output": 50
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
         },
         "family": "claude-opus",
-        "id": "claude-opus-41",
-        "knowledge": "2025-03-31",
-        "last_updated": "2025-08-05",
+        "id": "claude-opus-4.8",
+        "last_updated": "2026-05-28",
         "limit": {
-          "context": 80000,
-          "output": 16000
+          "context": 200000,
+          "input": 168000,
+          "output": 64000
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Claude Opus 4.1",
+        "name": "Claude Opus 4.8",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-05",
-        "status": "deprecated",
-        "temperature": true,
-        "tool_call": false
+        "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
       },
       "claude-sonnet-4": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
         },
         "family": "claude-sonnet",
         "id": "claude-sonnet-4",
@@ -129828,45 +139124,48 @@
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Claude Sonnet 4",
+        "name": "Claude Sonnet 4 (latest)",
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-05-22",
-        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
       "claude-sonnet-4.5": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
         },
         "family": "claude-sonnet",
         "id": "claude-sonnet-4.5",
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-07-31",
         "last_updated": "2025-09-29",
         "limit": {
-          "context": 144000,
-          "input": 128000,
+          "context": 200000,
+          "input": 168000,
           "output": 32000
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Claude Sonnet 4.5",
+        "name": "Claude Sonnet 4.5 (latest)",
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-09-29",
@@ -129876,22 +139175,25 @@
       "claude-sonnet-4.6": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
         },
         "family": "claude-sonnet",
         "id": "claude-sonnet-4.6",
         "knowledge": "2025-08-31",
-        "last_updated": "2026-02-17",
+        "last_updated": "2026-03-13",
         "limit": {
           "context": 200000,
-          "input": 128000,
+          "input": 168000,
           "output": 32000
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -129907,8 +139209,25 @@
       "gemini-2.5-pro": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.125,
+          "context_over_200k": {
+            "cache_read": 0.25,
+            "input": 2.5,
+            "output": 15
+          },
+          "input": 1.25,
+          "output": 10,
+          "tiers": [
+            {
+              "cache_read": 0.25,
+              "input": 2.5,
+              "output": 15,
+              "tier": {
+                "size": 200000,
+                "type": "context"
+              }
+            }
+          ]
         },
         "family": "gemini-pro",
         "id": "gemini-2.5-pro",
@@ -129924,7 +139243,8 @@
             "text",
             "image",
             "audio",
-            "video"
+            "video",
+            "pdf"
           ],
           "output": [
             "text"
@@ -129932,16 +139252,19 @@
         },
         "name": "Gemini 2.5 Pro",
         "open_weights": false,
-        "reasoning": false,
+        "reasoning": true,
         "release_date": "2025-03-20",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "gemini-3-flash-preview": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.05,
+          "input": 0.5,
+          "input_audio": 1,
+          "output": 3
         },
         "family": "gemini-flash",
         "id": "gemini-3-flash-preview",
@@ -129956,14 +139279,15 @@
           "input": [
             "text",
             "image",
+            "video",
             "audio",
-            "video"
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Gemini 3 Flash",
+        "name": "Gemini 3 Flash Preview",
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-12-17",
@@ -129971,60 +139295,45 @@
         "temperature": true,
         "tool_call": true
       },
-      "gemini-3-pro-preview": {
-        "attachment": true,
-        "cost": {
-          "input": 0,
-          "output": 0
-        },
-        "family": "gemini-pro",
-        "id": "gemini-3-pro-preview",
-        "knowledge": "2025-01",
-        "last_updated": "2025-11-18",
-        "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 64000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "audio",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "Gemini 3 Pro Preview",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-11-18",
-        "status": "deprecated",
-        "structured_output": true,
-        "temperature": true,
-        "tool_call": true
-      },
       "gemini-3.1-pro-preview": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12,
+          "tiers": [
+            {
+              "cache_read": 0.4,
+              "input": 4,
+              "output": 18,
+              "tier": {
+                "size": 200000,
+                "type": "context"
+              }
+            }
+          ]
         },
         "family": "gemini-pro",
         "id": "gemini-3.1-pro-preview",
         "knowledge": "2025-01",
         "last_updated": "2026-02-19",
         "limit": {
-          "context": 128000,
-          "input": 128000,
+          "context": 200000,
+          "input": 136000,
           "output": 64000
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "video",
+            "audio",
+            "pdf"
           ],
           "output": [
             "text"
@@ -130041,15 +139350,17 @@
       "gemini-3.5-flash": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.15,
+          "input": 1.5,
+          "input_audio": 1.5,
+          "output": 9
         },
         "family": "gemini-flash",
         "id": "gemini-3.5-flash",
         "knowledge": "2025-01",
         "last_updated": "2026-05-19",
         "limit": {
-          "context": 128000,
+          "context": 200000,
           "input": 128000,
           "output": 64000
         },
@@ -130057,8 +139368,9 @@
           "input": [
             "text",
             "image",
+            "video",
             "audio",
-            "video"
+            "pdf"
           ],
           "output": [
             "text"
@@ -130075,8 +139387,9 @@
       "gpt-4.1": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.5,
+          "input": 2,
+          "output": 8
         },
         "family": "gpt",
         "id": "gpt-4.1",
@@ -130084,13 +139397,14 @@
         "last_updated": "2025-04-14",
         "limit": {
           "context": 128000,
-          "input": 64000,
+          "input": 128000,
           "output": 16384
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -130100,81 +139414,21 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-04-14",
-        "temperature": true,
-        "tool_call": true
-      },
-      "gpt-4o": {
-        "attachment": true,
-        "cost": {
-          "input": 0,
-          "output": 0
-        },
-        "family": "gpt",
-        "id": "gpt-4o",
-        "knowledge": "2023-09",
-        "last_updated": "2024-05-13",
-        "limit": {
-          "context": 128000,
-          "input": 64000,
-          "output": 4096
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT-4o",
-        "open_weights": false,
-        "reasoning": false,
-        "release_date": "2024-05-13",
-        "temperature": true,
-        "tool_call": true
-      },
-      "gpt-5": {
-        "attachment": true,
-        "cost": {
-          "input": 0,
-          "output": 0
-        },
-        "family": "gpt",
-        "id": "gpt-5",
-        "knowledge": "2024-10",
-        "last_updated": "2025-08-07",
-        "limit": {
-          "context": 128000,
-          "output": 128000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT-5",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-08-07",
-        "status": "deprecated",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "gpt-5-mini": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 2
         },
         "family": "gpt-mini",
         "id": "gpt-5-mini",
-        "knowledge": "2024-06",
-        "last_updated": "2025-08-13",
+        "knowledge": "2024-05-30",
+        "last_updated": "2025-08-07",
         "limit": {
           "context": 264000,
           "input": 128000,
@@ -130189,155 +139443,29 @@
             "text"
           ]
         },
-        "name": "GPT-5-mini",
+        "name": "GPT-5 Mini",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-13",
-        "temperature": true,
-        "tool_call": true
-      },
-      "gpt-5.1": {
-        "attachment": true,
-        "cost": {
-          "input": 0,
-          "output": 0
-        },
-        "family": "gpt",
-        "id": "gpt-5.1",
-        "knowledge": "2024-09-30",
-        "last_updated": "2025-11-13",
-        "limit": {
-          "context": 264000,
-          "input": 128000,
-          "output": 64000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT-5.1",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-11-13",
-        "status": "deprecated",
-        "temperature": false,
-        "tool_call": true
-      },
-      "gpt-5.1-codex": {
-        "attachment": false,
-        "cost": {
-          "input": 0,
-          "output": 0
-        },
-        "family": "gpt-codex",
-        "id": "gpt-5.1-codex",
-        "knowledge": "2024-09-30",
-        "last_updated": "2025-11-13",
-        "limit": {
-          "context": 400000,
-          "input": 128000,
-          "output": 128000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT-5.1-Codex",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-11-13",
-        "status": "deprecated",
-        "temperature": false,
-        "tool_call": true
-      },
-      "gpt-5.1-codex-max": {
-        "attachment": true,
-        "cost": {
-          "input": 0,
-          "output": 0
-        },
-        "family": "gpt-codex",
-        "id": "gpt-5.1-codex-max",
-        "knowledge": "2024-09-30",
-        "last_updated": "2025-12-04",
-        "limit": {
-          "context": 400000,
-          "input": 128000,
-          "output": 128000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT-5.1-Codex-max",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-12-04",
-        "status": "deprecated",
-        "temperature": false,
-        "tool_call": true
-      },
-      "gpt-5.1-codex-mini": {
-        "attachment": false,
-        "cost": {
-          "input": 0,
-          "output": 0
-        },
-        "family": "gpt-codex",
-        "id": "gpt-5.1-codex-mini",
-        "knowledge": "2024-09-30",
-        "last_updated": "2025-11-13",
-        "limit": {
-          "context": 400000,
-          "input": 128000,
-          "output": 128000
-        },
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "name": "GPT-5.1-Codex-mini",
-        "open_weights": false,
-        "reasoning": true,
-        "release_date": "2025-11-13",
-        "status": "deprecated",
+        "release_date": "2025-08-07",
+        "structured_output": true,
         "temperature": false,
         "tool_call": true
       },
       "gpt-5.2": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
         },
         "family": "gpt",
         "id": "gpt-5.2",
         "knowledge": "2025-08-31",
         "last_updated": "2025-12-11",
         "limit": {
-          "context": 264000,
-          "input": 128000,
-          "output": 64000
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
         },
         "modalities": {
           "input": [
@@ -130352,14 +139480,16 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-12-11",
+        "structured_output": true,
         "temperature": false,
         "tool_call": true
       },
       "gpt-5.2-codex": {
-        "attachment": false,
+        "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
         },
         "family": "gpt-codex",
         "id": "gpt-5.2-codex",
@@ -130373,29 +139503,32 @@
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "GPT-5.2-Codex",
+        "name": "GPT-5.2 Codex",
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-12-11",
+        "structured_output": true,
         "temperature": false,
         "tool_call": true
       },
       "gpt-5.3-codex": {
-        "attachment": false,
+        "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
         },
         "family": "gpt-codex",
         "id": "gpt-5.3-codex",
         "knowledge": "2025-08-31",
-        "last_updated": "2026-02-24",
+        "last_updated": "2026-02-05",
         "limit": {
           "context": 400000,
           "input": 272000,
@@ -130404,24 +139537,43 @@
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "GPT-5.3-Codex",
+        "name": "GPT-5.3 Codex",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2026-02-24",
+        "release_date": "2026-02-05",
+        "structured_output": true,
         "temperature": false,
         "tool_call": true
       },
       "gpt-5.4": {
-        "attachment": false,
+        "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.25,
+          "context_over_200k": {
+            "cache_read": 0.5,
+            "input": 5,
+            "output": 22.5
+          },
+          "input": 2.5,
+          "output": 15,
+          "tiers": [
+            {
+              "cache_read": 0.5,
+              "input": 5,
+              "output": 22.5,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
         },
         "family": "gpt",
         "id": "gpt-5.4",
@@ -130435,7 +139587,8 @@
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -130445,14 +139598,16 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-05",
+        "structured_output": true,
         "temperature": false,
         "tool_call": true
       },
       "gpt-5.4-mini": {
         "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.075,
+          "input": 0.75,
+          "output": 4.5
         },
         "family": "gpt-mini",
         "id": "gpt-5.4-mini",
@@ -130472,7 +139627,7 @@
             "text"
           ]
         },
-        "name": "GPT-5.4 Mini",
+        "name": "GPT-5.4 mini",
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-17",
@@ -130480,16 +139635,17 @@
         "temperature": false,
         "tool_call": true
       },
-      "gpt-5.5": {
-        "attachment": false,
+      "gpt-5.4-nano": {
+        "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.02,
+          "input": 0.2,
+          "output": 1.25
         },
-        "family": "gpt",
-        "id": "gpt-5.5",
+        "family": "gpt-nano",
+        "id": "gpt-5.4-nano",
         "knowledge": "2025-08-31",
-        "last_updated": "2026-04-22",
+        "last_updated": "2026-03-17",
         "limit": {
           "context": 400000,
           "input": 272000,
@@ -130504,41 +139660,95 @@
             "text"
           ]
         },
-        "name": "GPT-5.5",
+        "name": "GPT-5.4 nano",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2026-04-22",
+        "release_date": "2026-03-17",
+        "structured_output": true,
         "temperature": false,
         "tool_call": true
       },
-      "grok-code-fast-1": {
-        "attachment": false,
+      "gpt-5.5": {
+        "attachment": true,
         "cost": {
-          "input": 0,
-          "output": 0
+          "cache_read": 0.5,
+          "context_over_200k": {
+            "cache_read": 1,
+            "input": 10,
+            "output": 45
+          },
+          "input": 5,
+          "output": 30,
+          "tiers": [
+            {
+              "cache_read": 1,
+              "input": 10,
+              "output": 45,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
         },
-        "family": "grok",
-        "id": "grok-code-fast-1",
-        "knowledge": "2025-08",
-        "last_updated": "2025-08-27",
+        "family": "gpt",
+        "id": "gpt-5.5",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-04-23",
         "limit": {
-          "context": 128000,
-          "input": 128000,
-          "output": 64000
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "name": "Grok Code Fast 1",
+        "name": "GPT-5.5",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-27",
-        "temperature": true,
+        "release_date": "2026-04-23",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "raptor-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 2
+        },
+        "family": "gpt-mini",
+        "id": "raptor-mini",
+        "knowledge": "2024-05-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Raptor mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": false,
         "tool_call": true
       }
     },
@@ -130726,6 +139936,43 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-18",
+        "temperature": true,
+        "tool_call": true
+      },
+      "MiniMax-M3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0,
+          "cache_write": 0,
+          "input": 0,
+          "output": 0
+        },
+        "family": "minimax",
+        "id": "MiniMax-M3",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 512000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax-M3",
+        "open_weights": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "release_date": "2026-06-01",
         "temperature": true,
         "tool_call": true
       }
@@ -131230,6 +140477,36 @@
         "reasoning": true,
         "release_date": "2025-10-11",
         "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.145,
+          "input": 1.74,
+          "output": 3.48
+        },
+        "family": "deepseek-thinking",
+        "id": "deepseek-ai/DeepSeek-V4-Pro",
+        "last_updated": "2026-04-24",
+        "limit": {
+          "context": 1049000,
+          "output": 393000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "deepseek-ai/DeepSeek-V4-Pro",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-24",
+        "structured_output": false,
         "temperature": true,
         "tool_call": true
       },
@@ -136272,6 +145549,51 @@
         "temperature": true,
         "tool_call": true
       },
+      "qwen3.7-plus": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.05,
+          "cache_write": 0.625,
+          "input": 0.5,
+          "output": 3,
+          "tiers": [
+            {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "input": 2,
+              "output": 6,
+              "tier": {
+                "size": 128000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "qwen",
+        "id": "qwen3.7-plus",
+        "knowledge": "2025-04",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 1000000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3.7 Plus",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-02",
+        "temperature": true,
+        "tool_call": true
+      },
       "qwen3.5-plus": {
         "attachment": false,
         "cost": {
@@ -136942,6 +146264,64 @@
         "structured_output": true,
         "temperature": true,
         "tool_call": true
+      },
+      "gemini-2.5-pro-tts": {
+        "attachment": false,
+        "cost": {
+          "input": 1,
+          "output": 20
+        },
+        "family": "gemini-pro",
+        "id": "gemini-2.5-pro-tts",
+        "knowledge": "2025-01",
+        "last_updated": "2025-12-10",
+        "limit": {
+          "context": 32768,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "audio"
+          ]
+        },
+        "name": "Gemini 2.5 Pro TTS",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-09-30",
+        "temperature": false,
+        "tool_call": false
+      },
+      "gemini-2.5-flash-tts": {
+        "attachment": false,
+        "cost": {
+          "input": 0.5,
+          "output": 10
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-tts",
+        "knowledge": "2025-01",
+        "last_updated": "2025-12-10",
+        "limit": {
+          "context": 32768,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "audio"
+          ]
+        },
+        "name": "Gemini 2.5 Flash TTS",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-09-30",
+        "temperature": false,
+        "tool_call": false
       },
       "claude-opus-4-8@default": {
         "attachment": true,
@@ -141464,8 +150844,9 @@
       "deepseek/deepseek-v3.1": {
         "attachment": false,
         "cost": {
-          "input": 0.3,
-          "output": 1
+          "cache_read": 0.28,
+          "input": 0.56,
+          "output": 1.68
         },
         "family": "deepseek",
         "id": "deepseek/deepseek-v3.1",
@@ -141473,7 +150854,7 @@
         "last_updated": "2025-08-21",
         "limit": {
           "context": 163840,
-          "output": 128000
+          "output": 8192
         },
         "modalities": {
           "input": [
@@ -141515,16 +150896,16 @@
         "name": "Qwen3-30B-A3B",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-04",
+        "release_date": "2025-04-01",
         "temperature": true,
         "tool_call": true
       },
       "zai/glm-4.7": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.08,
-          "input": 0.43,
-          "output": 1.75
+          "cache_read": 2.25,
+          "input": 2.25,
+          "output": 2.75
         },
         "family": "glm",
         "id": "zai/glm-4.7",
@@ -141532,8 +150913,8 @@
         "knowledge": "2024-10",
         "last_updated": "2025-12-22",
         "limit": {
-          "context": 202752,
-          "output": 120000
+          "context": 131000,
+          "output": 40000
         },
         "modalities": {
           "input": [
@@ -141596,9 +150977,7 @@
         },
         "modalities": {
           "input": [
-            "text",
-            "image",
-            "pdf"
+            "text"
           ],
           "output": [
             "text"
@@ -141671,10 +151050,6 @@
       },
       "voyage/voyage-law-2": {
         "attachment": false,
-        "cost": {
-          "input": 0.12,
-          "output": 0
-        },
         "family": "voyage",
         "id": "voyage/voyage-law-2",
         "last_updated": "2024-03",
@@ -141693,8 +151068,8 @@
         "name": "voyage-law-2",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-03",
-        "temperature": false,
+        "release_date": "2024-03-01",
+        "temperature": true,
         "tool_call": false
       },
       "recraft/recraft-v2": {
@@ -141724,8 +151099,9 @@
       "moonshotai/kimi-k2-turbo": {
         "attachment": false,
         "cost": {
-          "input": 2.4,
-          "output": 10
+          "cache_read": 0.15,
+          "input": 1.15,
+          "output": 8
         },
         "family": "kimi",
         "id": "moonshotai/kimi-k2-turbo",
@@ -141752,10 +151128,6 @@
       },
       "google/text-multilingual-embedding-002": {
         "attachment": false,
-        "cost": {
-          "input": 0.03,
-          "output": 0
-        },
         "family": "text-embedding",
         "id": "google/text-multilingual-embedding-002",
         "last_updated": "2024-03",
@@ -141774,8 +151146,8 @@
         "name": "Text Multilingual Embedding 002",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-03",
-        "temperature": false,
+        "release_date": "2024-03-01",
+        "temperature": true,
         "tool_call": false
       },
       "openai/gpt-5.2-codex": {
@@ -141788,7 +151160,7 @@
         "family": "gpt-codex",
         "id": "openai/gpt-5.2-codex",
         "knowledge": "2024-10",
-        "last_updated": "2025-12",
+        "last_updated": "2025-12-11",
         "limit": {
           "context": 400000,
           "input": 272000,
@@ -141807,13 +151179,15 @@
         "name": "GPT-5.2-Codex",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-12",
+        "release_date": "2025-12-18",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "alibaba/qwen3-coder-plus": {
         "attachment": false,
         "cost": {
+          "cache_read": 0.2,
           "input": 1,
           "output": 5
         },
@@ -141823,7 +151197,7 @@
         "last_updated": "2025-07-23",
         "limit": {
           "context": 1000000,
-          "output": 1000000
+          "output": 65536
         },
         "modalities": {
           "input": [
@@ -141875,7 +151249,7 @@
         "attachment": true,
         "cost": {
           "cache_read": 0.5,
-          "cache_write": 18.75,
+          "cache_write": 6.25,
           "input": 5,
           "output": 25
         },
@@ -141901,16 +151275,12 @@
         "name": "Claude Opus 4.5",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-11-24",
+        "release_date": "2024-11-24",
         "temperature": true,
         "tool_call": true
       },
       "openai/text-embedding-ada-002": {
         "attachment": false,
-        "cost": {
-          "input": 0.1,
-          "output": 0
-        },
         "family": "text-embedding",
         "id": "openai/text-embedding-ada-002",
         "last_updated": "2022-12-15",
@@ -141931,7 +151301,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2022-12-15",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "google/gemini-3.1-pro-preview": {
@@ -141943,7 +151313,8 @@
         },
         "family": "gemini",
         "id": "google/gemini-3.1-pro-preview",
-        "last_updated": "2026-02-24",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-19",
         "limit": {
           "context": 1000000,
           "output": 64000
@@ -141961,7 +151332,8 @@
         "name": "Gemini 3.1 Pro Preview",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2026-02-19",
+        "release_date": "2025-11-18",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -141977,12 +151349,14 @@
         "knowledge": "2024-10",
         "last_updated": "2025-07-09",
         "limit": {
-          "context": 2000000,
-          "output": 30000
+          "context": 1000000,
+          "output": 1000000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -141997,10 +151371,6 @@
       },
       "voyage/voyage-code-2": {
         "attachment": false,
-        "cost": {
-          "input": 0.12,
-          "output": 0
-        },
         "family": "voyage",
         "id": "voyage/voyage-code-2",
         "last_updated": "2024-01",
@@ -142019,8 +151389,8 @@
         "name": "voyage-code-2",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-01",
-        "temperature": false,
+        "release_date": "2024-01-01",
+        "temperature": true,
         "tool_call": false
       },
       "moonshotai/kimi-k2.6": {
@@ -142032,7 +151402,8 @@
         },
         "family": "kimi-k2.6",
         "id": "moonshotai/kimi-k2.6",
-        "last_updated": "2026-04-24",
+        "knowledge": "2025-01",
+        "last_updated": "2026-04-21",
         "limit": {
           "context": 262000,
           "output": 262000
@@ -142051,6 +151422,7 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-04-20",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -142062,7 +151434,7 @@
         "last_updated": "2025-08-30",
         "limit": {
           "context": 128000,
-          "output": 8192
+          "output": 100000
         },
         "modalities": {
           "input": [
@@ -142088,7 +151460,7 @@
         },
         "family": "glm",
         "id": "zai/glm-5v-turbo",
-        "last_updated": "2026-04-03",
+        "last_updated": "2026-04-01",
         "limit": {
           "context": 200000,
           "output": 128000
@@ -142152,7 +151524,7 @@
         "family": "nemotron",
         "id": "nvidia/nemotron-nano-12b-v2-vl",
         "knowledge": "2024-10",
-        "last_updated": "2024-12",
+        "last_updated": "2025-10-28",
         "limit": {
           "context": 131072,
           "output": 131072
@@ -142169,7 +151541,7 @@
         "name": "Nvidia Nemotron Nano 12B V2 VL",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2024-12",
+        "release_date": "2024-12-01",
         "temperature": true,
         "tool_call": true
       },
@@ -142243,7 +151615,7 @@
         "last_updated": "2025-12-17",
         "limit": {
           "context": 1000000,
-          "output": 64000
+          "output": 65000
         },
         "modalities": {
           "input": [
@@ -142332,7 +151704,7 @@
         "family": "gpt",
         "id": "openai/gpt-5-pro",
         "knowledge": "2024-10",
-        "last_updated": "2025-08-07",
+        "last_updated": "2025-10-06",
         "limit": {
           "context": 400000,
           "input": 128000,
@@ -142353,20 +151725,21 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-08-07",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "openai/gpt-5.1-codex-mini": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.03,
+          "cache_read": 0.025,
           "input": 0.25,
           "output": 2
         },
         "family": "gpt",
         "id": "openai/gpt-5.1-codex-mini",
         "knowledge": "2024-10",
-        "last_updated": "2025-05-16",
+        "last_updated": "2025-11-13",
         "limit": {
           "context": 400000,
           "input": 272000,
@@ -142385,20 +151758,54 @@
         "name": "GPT-5.1 Codex mini",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-05-16",
+        "release_date": "2025-11-12",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "anthropic/claude-opus-4.8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "anthropic/claude-opus-4.8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
         "temperature": true,
         "tool_call": true
       },
       "xiaomi/mimo-v2.5": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.08,
-          "input": 0.39999999999999997,
-          "output": 2
+          "cache_read": 0.0028,
+          "input": 0.14,
+          "output": 0.28
         },
         "family": "mimo-v2.5",
         "id": "xiaomi/mimo-v2.5",
-        "last_updated": "2026-05-01",
+        "knowledge": "2024-12",
+        "last_updated": "2026-04-22",
         "limit": {
           "context": 1050000,
           "output": 131100
@@ -142407,8 +151814,7 @@
           "input": [
             "text",
             "image",
-            "audio",
-            "video"
+            "pdf"
           ],
           "output": [
             "text"
@@ -142501,14 +151907,14 @@
       "openai/gpt-5.2": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.18,
+          "cache_read": 0.175,
           "input": 1.75,
           "output": 14
         },
         "family": "gpt",
         "id": "openai/gpt-5.2",
         "knowledge": "2024-10",
-        "last_updated": "2025-08-07",
+        "last_updated": "2025-12-11",
         "limit": {
           "context": 400000,
           "input": 272000,
@@ -142527,7 +151933,8 @@
         "name": "GPT-5.2",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-07",
+        "release_date": "2025-12-11",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -142540,7 +151947,7 @@
         },
         "family": "glm",
         "id": "zai/glm-5-turbo",
-        "last_updated": "2026-03-17",
+        "last_updated": "2026-03-16",
         "limit": {
           "context": 202800,
           "output": 131100
@@ -142557,26 +151964,30 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-15",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "xiaomi/mimo-v2.5-pro": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.19999999999999998,
-          "input": 1,
-          "output": 3
+          "cache_read": 0.0036,
+          "input": 0.435,
+          "output": 0.87
         },
         "family": "mimo-v2.5-pro",
         "id": "xiaomi/mimo-v2.5-pro",
-        "last_updated": "2026-05-01",
+        "knowledge": "2024-12",
+        "last_updated": "2026-04-22",
         "limit": {
           "context": 1050000,
           "output": 131000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -142648,6 +152059,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-12-11",
+        "status": "deprecated",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -142655,9 +152067,8 @@
       "deepseek/deepseek-v3.2-thinking": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.03,
-          "input": 0.28,
-          "output": 0.42
+          "input": 0.62,
+          "output": 1.85
         },
         "family": "deepseek-thinking",
         "id": "deepseek/deepseek-v3.2-thinking",
@@ -142666,11 +152077,13 @@
         "last_updated": "2025-12-01",
         "limit": {
           "context": 128000,
-          "output": 64000
+          "output": 8000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -142687,15 +152100,15 @@
         "attachment": false,
         "cost": {
           "input": 0.15,
-          "output": 1.5
+          "output": 1.2
         },
         "family": "qwen",
         "id": "alibaba/qwen3-next-80b-a3b-thinking",
         "knowledge": "2025-09",
-        "last_updated": "2025-09-12",
+        "last_updated": "2025-09",
         "limit": {
           "context": 131072,
-          "output": 65536
+          "output": 32768
         },
         "modalities": {
           "input": [
@@ -142714,10 +152127,6 @@
       },
       "voyage/voyage-finance-2": {
         "attachment": false,
-        "cost": {
-          "input": 0.12,
-          "output": 0
-        },
         "family": "voyage",
         "id": "voyage/voyage-finance-2",
         "last_updated": "2024-03",
@@ -142736,8 +152145,8 @@
         "name": "voyage-finance-2",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-03",
-        "temperature": false,
+        "release_date": "2024-03-01",
+        "temperature": true,
         "tool_call": false
       },
       "openai/gpt-5.4-pro": {
@@ -142748,7 +152157,8 @@
         },
         "family": "gpt",
         "id": "openai/gpt-5.4-pro",
-        "last_updated": "2026-03-06",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-05",
         "limit": {
           "context": 1050000,
           "input": 922000,
@@ -142768,15 +152178,12 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-05",
+        "structured_output": false,
         "temperature": true,
         "tool_call": true
       },
       "voyage/voyage-3-large": {
         "attachment": false,
-        "cost": {
-          "input": 0.18,
-          "output": 0
-        },
         "family": "voyage",
         "id": "voyage/voyage-3-large",
         "last_updated": "2024-09",
@@ -142795,8 +152202,8 @@
         "name": "voyage-3-large",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-09",
-        "temperature": false,
+        "release_date": "2024-09-01",
+        "temperature": true,
         "tool_call": false
       },
       "voyage/voyage-4": {
@@ -142850,12 +152257,14 @@
       "google/gemini-3.1-flash-image-preview": {
         "attachment": true,
         "cost": {
+          "cache_read": 0.05,
           "input": 0.5,
           "output": 3
         },
         "family": "gemini",
         "id": "google/gemini-3.1-flash-image-preview",
-        "last_updated": "2026-03-06",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-26",
         "limit": {
           "context": 131072,
           "output": 32768
@@ -142907,7 +152316,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2024-06-26",
-        "temperature": false,
+        "temperature": true,
         "tool_call": true
       },
       "mistral/mistral-small": {
@@ -142936,6 +152345,15 @@
         "name": "Mistral Small (latest)",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "high"
+            ]
+          }
+        ],
         "release_date": "2026-03-16",
         "temperature": true,
         "tool_call": true
@@ -142977,6 +152395,7 @@
         },
         "family": "gpt",
         "id": "openai/gpt-5.4-mini",
+        "knowledge": "2025-08-31",
         "last_updated": "2026-03-17",
         "limit": {
           "context": 400000,
@@ -142997,6 +152416,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-17",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -143059,6 +152479,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-12-11",
+        "status": "deprecated",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
@@ -143066,15 +152487,15 @@
       "alibaba/qwen-3-235b": {
         "attachment": false,
         "cost": {
-          "input": 0.13,
-          "output": 0.6
+          "input": 0.22,
+          "output": 0.88
         },
         "family": "qwen",
         "id": "alibaba/qwen-3-235b",
         "knowledge": "2025-04",
         "last_updated": "2025-04",
         "limit": {
-          "context": 40960,
+          "context": 262144,
           "output": 16384
         },
         "modalities": {
@@ -143088,7 +152509,7 @@
         "name": "Qwen3 235B A22B Instruct 2507",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-04",
+        "release_date": "2025-04-01",
         "temperature": true,
         "tool_call": true
       },
@@ -143160,10 +152581,6 @@
       },
       "voyage/voyage-3.5-lite": {
         "attachment": false,
-        "cost": {
-          "input": 0.02,
-          "output": 0
-        },
         "family": "voyage",
         "id": "voyage/voyage-3.5-lite",
         "last_updated": "2025-05-20",
@@ -143183,22 +152600,22 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-05-20",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "meta/llama-3.1-8b": {
         "attachment": false,
         "cost": {
-          "input": 0.03,
-          "output": 0.05
+          "input": 0.22,
+          "output": 0.22
         },
         "family": "llama",
         "id": "meta/llama-3.1-8b",
         "knowledge": "2023-12",
         "last_updated": "2024-07-23",
         "limit": {
-          "context": 131072,
-          "output": 16384
+          "context": 128000,
+          "output": 8192
         },
         "modalities": {
           "input": [
@@ -143225,7 +152642,7 @@
         },
         "family": "minimax",
         "id": "minimax/minimax-m2.5",
-        "last_updated": "2026-02-19",
+        "last_updated": "2026-02-12",
         "limit": {
           "context": 204800,
           "output": 131000
@@ -143248,14 +152665,14 @@
       "openai/gpt-5.1-codex-max": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.13,
+          "cache_read": 0.125,
           "input": 1.25,
           "output": 10
         },
         "family": "gpt",
         "id": "openai/gpt-5.1-codex-max",
         "knowledge": "2024-10",
-        "last_updated": "2025-08-07",
+        "last_updated": "2025-11-13",
         "limit": {
           "context": 400000,
           "input": 272000,
@@ -143274,16 +152691,46 @@
         "name": "GPT 5.1 Codex Max",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-07",
+        "release_date": "2025-11-19",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.12,
+          "input": 0.6,
+          "output": 2.4
+        },
+        "family": "nemotron",
+        "id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 1000000,
+          "output": 65000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Nemotron 3 Ultra",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-04",
         "temperature": true,
         "tool_call": true
       },
       "xai/grok-4.20-non-reasoning-beta": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.19999999999999998,
-          "input": 2,
-          "output": 6
+          "cache_read": 0.4,
+          "input": 1.25,
+          "output": 2.5
         },
         "family": "grok",
         "id": "xai/grok-4.20-non-reasoning-beta",
@@ -143335,6 +152782,10 @@
       },
       "mistral/devstral-2": {
         "attachment": false,
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
         "family": "devstral",
         "id": "mistral/devstral-2",
         "knowledge": "2024-10",
@@ -143386,11 +152837,11 @@
         "attachment": true,
         "cost": {
           "input": 0.14,
-          "output": 0.39999999999999997
+          "output": 0.4
         },
         "family": "gemma",
         "id": "google/gemma-4-31b-it",
-        "last_updated": "2026-04-03",
+        "last_updated": "2026-04-02",
         "limit": {
           "context": 262144,
           "output": 131072
@@ -143409,14 +152860,16 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-04-02",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "alibaba/qwen3-coder": {
         "attachment": false,
         "cost": {
-          "input": 0.38,
-          "output": 1.53
+          "cache_read": 0.3,
+          "input": 1.5,
+          "output": 7.5
         },
         "family": "qwen",
         "id": "alibaba/qwen3-coder",
@@ -143424,7 +152877,7 @@
         "last_updated": "2025-04",
         "limit": {
           "context": 262144,
-          "output": 66536
+          "output": 65536
         },
         "modalities": {
           "input": [
@@ -143437,16 +152890,12 @@
         "name": "Qwen3 Coder 480B A35B Instruct",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-04",
+        "release_date": "2025-04-01",
         "temperature": true,
         "tool_call": true
       },
       "alibaba/qwen3-embedding-0.6b": {
         "attachment": false,
-        "cost": {
-          "input": 0.01,
-          "output": 0
-        },
         "family": "qwen",
         "id": "alibaba/qwen3-embedding-0.6b",
         "last_updated": "2025-11-14",
@@ -143466,7 +152915,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-11-14",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "mistral/mistral-large-3": {
@@ -143659,13 +153108,14 @@
       "xiaomi/mimo-v2-pro": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.19999999999999998,
+          "cache_read": 0.2,
           "input": 1,
           "output": 3
         },
         "family": "mimo",
         "id": "xiaomi/mimo-v2-pro",
-        "last_updated": "2026-03-20",
+        "knowledge": "2024-12",
+        "last_updated": "2026-03-18",
         "limit": {
           "context": 1000000,
           "output": 128000
@@ -143694,10 +153144,10 @@
         },
         "family": "glm",
         "id": "zai/glm-5",
-        "last_updated": "2026-02-19",
+        "last_updated": "2026-02-11",
         "limit": {
           "context": 202800,
-          "output": 131072
+          "output": 131100
         },
         "modalities": {
           "input": [
@@ -143717,9 +153167,9 @@
       "xai/grok-4.20-reasoning": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.19999999999999998,
-          "input": 2,
-          "output": 6
+          "cache_read": 0.2,
+          "input": 1.25,
+          "output": 2.5
         },
         "family": "grok",
         "id": "xai/grok-4.20-reasoning",
@@ -143779,10 +153229,6 @@
       },
       "alibaba/qwen3-embedding-4b": {
         "attachment": false,
-        "cost": {
-          "input": 0.02,
-          "output": 0
-        },
         "family": "qwen",
         "id": "alibaba/qwen3-embedding-4b",
         "last_updated": "2025-06-05",
@@ -143802,14 +153248,15 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-06-05",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "deepseek/deepseek-v3": {
         "attachment": false,
         "cost": {
-          "input": 0.77,
-          "output": 0.77
+          "cache_read": 0.135,
+          "input": 0.27,
+          "output": 1.12
         },
         "family": "deepseek",
         "id": "deepseek/deepseek-v3",
@@ -143817,7 +153264,7 @@
         "last_updated": "2024-12-26",
         "limit": {
           "context": 163840,
-          "output": 16384
+          "output": 163840
         },
         "modalities": {
           "input": [
@@ -143845,7 +153292,7 @@
         "id": "zai/glm-4.7-flashx",
         "interleaved": true,
         "knowledge": "2025-01",
-        "last_updated": "2025-01",
+        "last_updated": "2026-01-19",
         "limit": {
           "context": 200000,
           "output": 128000
@@ -143861,7 +153308,7 @@
         "name": "GLM 4.7 FlashX",
         "open_weights": true,
         "reasoning": true,
-        "release_date": "2025-01",
+        "release_date": "2025-01-01",
         "temperature": true,
         "tool_call": true
       },
@@ -143873,7 +153320,7 @@
         },
         "family": "mercury",
         "id": "inception/mercury-coder-small",
-        "last_updated": "2026-05-01",
+        "last_updated": "2025-02-26",
         "limit": {
           "context": 32000,
           "output": 16384
@@ -143896,8 +153343,8 @@
       "alibaba/qwen3-vl-235b-a22b-instruct": {
         "attachment": true,
         "cost": {
-          "input": 0.39999999999999997,
-          "output": 1.5999999999999999
+          "input": 0.4,
+          "output": 1.6
         },
         "family": "qwen",
         "id": "alibaba/qwen3-vl-235b-a22b-instruct",
@@ -143909,7 +153356,8 @@
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -143931,10 +153379,10 @@
         },
         "family": "glm",
         "id": "zai/glm-5.1",
-        "last_updated": "2026-04-16",
+        "last_updated": "2026-03-27",
         "limit": {
-          "context": 202752,
-          "output": 202752
+          "context": 202800,
+          "output": 64000
         },
         "modalities": {
           "input": [
@@ -143950,12 +153398,14 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-04-07",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "deepseek/deepseek-v3.1-terminus": {
         "attachment": false,
         "cost": {
+          "cache_read": 0.135,
           "input": 0.27,
           "output": 1
         },
@@ -143984,12 +153434,9 @@
       },
       "google/gemini-embedding-001": {
         "attachment": false,
-        "cost": {
-          "input": 0.15,
-          "output": 0
-        },
         "family": "gemini-embedding",
         "id": "google/gemini-embedding-001",
+        "knowledge": "2025-05",
         "last_updated": "2025-05-20",
         "limit": {
           "context": 8192,
@@ -144007,15 +153454,15 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-05-20",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "xai/grok-4.20-non-reasoning": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.19999999999999998,
-          "input": 2,
-          "output": 6
+          "cache_read": 0.2,
+          "input": 1.25,
+          "output": 2.5
         },
         "family": "grok",
         "id": "xai/grok-4.20-non-reasoning",
@@ -144043,10 +153490,6 @@
       },
       "amazon/titan-embed-text-v2": {
         "attachment": false,
-        "cost": {
-          "input": 0.02,
-          "output": 0
-        },
         "family": "titan-embed",
         "id": "amazon/titan-embed-text-v2",
         "last_updated": "2024-04",
@@ -144065,14 +153508,14 @@
         "name": "Titan Text Embeddings V2",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-04",
-        "temperature": false,
+        "release_date": "2024-04-01",
+        "temperature": true,
         "tool_call": false
       },
       "openai/gpt-5.1-instant": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.13,
+          "cache_read": 0.125,
           "input": 1.25,
           "output": 10
         },
@@ -144092,23 +153535,18 @@
             "pdf"
           ],
           "output": [
-            "text",
-            "image"
+            "text"
           ]
         },
         "name": "GPT-5.1 Instant",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-07",
+        "release_date": "2025-11-12",
         "temperature": true,
         "tool_call": true
       },
       "perplexity/sonar-reasoning-pro": {
         "attachment": false,
-        "cost": {
-          "input": 2,
-          "output": 8
-        },
         "family": "sonar-reasoning",
         "id": "perplexity/sonar-reasoning-pro",
         "knowledge": "2025-09",
@@ -144135,16 +153573,16 @@
       "meta/llama-3.1-70b": {
         "attachment": false,
         "cost": {
-          "input": 0.4,
-          "output": 0.4
+          "input": 0.72,
+          "output": 0.72
         },
         "family": "llama",
         "id": "meta/llama-3.1-70b",
         "knowledge": "2023-12",
         "last_updated": "2024-07-23",
         "limit": {
-          "context": 131072,
-          "output": 16384
+          "context": 128000,
+          "output": 8192
         },
         "modalities": {
           "input": [
@@ -144206,7 +153644,8 @@
         },
         "family": "qwen",
         "id": "alibaba/qwen3.5-plus",
-        "last_updated": "2026-02-19",
+        "knowledge": "2025-04",
+        "last_updated": "2026-02-16",
         "limit": {
           "context": 1000000,
           "output": 64000
@@ -144231,8 +153670,9 @@
       "zai/glm-4.6": {
         "attachment": false,
         "cost": {
-          "input": 0.45,
-          "output": 1.8
+          "cache_read": 0.11,
+          "input": 0.6,
+          "output": 2.2
         },
         "family": "glm",
         "id": "zai/glm-4.6",
@@ -144323,8 +153763,8 @@
       "nvidia/nemotron-nano-9b-v2": {
         "attachment": false,
         "cost": {
-          "input": 0.04,
-          "output": 0.16
+          "input": 0.06,
+          "output": 0.23
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-nano-9b-v2",
@@ -144352,14 +153792,14 @@
       "openai/gpt-5.1-codex": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.13,
+          "cache_read": 0.125,
           "input": 1.25,
           "output": 10
         },
         "family": "gpt",
         "id": "openai/gpt-5.1-codex",
         "knowledge": "2024-10",
-        "last_updated": "2025-08-07",
+        "last_updated": "2025-11-13",
         "limit": {
           "context": 400000,
           "input": 272000,
@@ -144378,7 +153818,8 @@
         "name": "GPT-5.1-Codex",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-07",
+        "release_date": "2025-11-12",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -144417,8 +153858,6 @@
           "input": [
             "text",
             "image",
-            "video",
-            "audio",
             "pdf"
           ],
           "output": [
@@ -144429,6 +153868,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-11-18",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -144441,7 +153881,8 @@
         },
         "family": "gpt",
         "id": "openai/gpt-5.3-codex",
-        "last_updated": "2026-02-24",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-02-05",
         "limit": {
           "context": 400000,
           "input": 272000,
@@ -144461,6 +153902,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-02-24",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -144553,16 +153995,19 @@
         "name": "Claude Sonnet 3.7",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-02-19",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
       "perplexity/sonar": {
         "attachment": true,
-        "cost": {
-          "input": 1,
-          "output": 1
-        },
         "family": "sonar",
         "id": "perplexity/sonar",
         "knowledge": "2025-02",
@@ -144614,13 +154059,13 @@
       "xai/grok-4.3": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.19999999999999998,
+          "cache_read": 0.2,
           "input": 1.25,
           "output": 2.5
         },
         "family": "grok",
         "id": "xai/grok-4.3",
-        "last_updated": "2026-05-01",
+        "last_updated": "2026-04-17",
         "limit": {
           "context": 1000000,
           "output": 1000000
@@ -144672,15 +154117,47 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-03-13",
+        "status": "deprecated",
+        "temperature": true,
+        "tool_call": true
+      },
+      "minimax/minimax-m3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.06,
+          "input": 0.3,
+          "output": 1.2
+        },
+        "family": "minimax-m3",
+        "id": "minimax/minimax-m3",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 1000000,
+          "output": 1000000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax M3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-31",
         "temperature": true,
         "tool_call": true
       },
       "moonshotai/kimi-k2-thinking": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.14,
-          "input": 0.47,
-          "output": 2
+          "cache_read": 0.15,
+          "input": 0.6,
+          "output": 2.5
         },
         "family": "kimi-thinking",
         "id": "moonshotai/kimi-k2-thinking",
@@ -144688,8 +154165,8 @@
         "knowledge": "2024-08",
         "last_updated": "2025-11-06",
         "limit": {
-          "context": 216144,
-          "output": 216144
+          "context": 262114,
+          "output": 262114
         },
         "modalities": {
           "input": [
@@ -144732,7 +154209,7 @@
         "name": "Seed 1.6",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-09",
+        "release_date": "2025-09-01",
         "temperature": true,
         "tool_call": true
       },
@@ -144764,7 +154241,7 @@
         "attachment": false,
         "cost": {
           "cache_read": 0.03,
-          "cache_write": 0.38,
+          "cache_write": 0.375,
           "input": 0.3,
           "output": 1.2
         },
@@ -144772,7 +154249,7 @@
         "id": "minimax/minimax-m2.1",
         "interleaved": true,
         "knowledge": "2024-10",
-        "last_updated": "2025-10-27",
+        "last_updated": "2025-12-23",
         "limit": {
           "context": 204800,
           "output": 131072
@@ -144824,14 +154301,14 @@
       "google/gemini-3.1-flash-lite-preview": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.025,
-          "cache_write": 1,
+          "cache_read": 0.03,
           "input": 0.25,
           "output": 1.5
         },
         "family": "gemini",
         "id": "google/gemini-3.1-flash-lite-preview",
-        "last_updated": "2026-03-06",
+        "knowledge": "2025-01",
+        "last_updated": "2026-03-03",
         "limit": {
           "context": 1000000,
           "output": 65000
@@ -144850,22 +154327,23 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-03",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "alibaba/qwen3-coder-30b-a3b": {
         "attachment": false,
         "cost": {
-          "input": 0.07,
-          "output": 0.27
+          "input": 0.15,
+          "output": 0.6
         },
         "family": "qwen",
         "id": "alibaba/qwen3-coder-30b-a3b",
         "knowledge": "2025-04",
         "last_updated": "2025-04",
         "limit": {
-          "context": 160000,
-          "output": 32768
+          "context": 262144,
+          "output": 8192
         },
         "modalities": {
           "input": [
@@ -144878,7 +154356,7 @@
         "name": "Qwen 3 Coder 30B A3B Instruct",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-04",
+        "release_date": "2025-04-01",
         "temperature": true,
         "tool_call": true
       },
@@ -144912,6 +154390,7 @@
       "zai/glm-4.5": {
         "attachment": false,
         "cost": {
+          "cache_read": 0.11,
           "input": 0.6,
           "output": 2.2
         },
@@ -144921,8 +154400,8 @@
         "knowledge": "2025-07",
         "last_updated": "2025-07-28",
         "limit": {
-          "context": 131072,
-          "output": 131072
+          "context": 128000,
+          "output": 96000
         },
         "modalities": {
           "input": [
@@ -144969,6 +154448,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-10-22",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -144998,7 +154478,7 @@
         "name": "GPT 4o Mini Search Preview",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-01",
+        "release_date": "2025-03-12",
         "structured_output": false,
         "temperature": true,
         "tool_call": false
@@ -145006,7 +154486,7 @@
       "openai/gpt-5-chat": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.13,
+          "cache_read": 0.125,
           "input": 1.25,
           "output": 10
         },
@@ -145067,6 +154547,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-10-22",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -145137,8 +154618,8 @@
       "alibaba/qwen3-vl-thinking": {
         "attachment": true,
         "cost": {
-          "input": 0.7,
-          "output": 8.4
+          "input": 0.4,
+          "output": 4
         },
         "family": "qwen",
         "id": "alibaba/qwen3-vl-thinking",
@@ -145146,12 +154627,13 @@
         "last_updated": "2025-09-24",
         "limit": {
           "context": 131072,
-          "output": 129024
+          "output": 32768
         },
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -145195,6 +154677,16 @@
         "name": "Gemini 2.5 Flash",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "max": 24576,
+            "min": 0,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-03-20",
         "structured_output": true,
         "temperature": true,
@@ -145226,10 +154718,6 @@
       },
       "mistral/mistral-embed": {
         "attachment": false,
-        "cost": {
-          "input": 0.1,
-          "output": 0
-        },
         "family": "mistral-embed",
         "id": "mistral/mistral-embed",
         "last_updated": "2023-12-11",
@@ -145249,16 +154737,16 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2023-12-11",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "alibaba/qwen3.7-max": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.5,
-          "cache_write": 3.125,
-          "input": 2.5,
-          "output": 7.5
+          "cache_read": 0.25,
+          "cache_write": 1.5625,
+          "input": 1.25,
+          "output": 3.75
         },
         "family": "qwen",
         "id": "alibaba/qwen3.7-max",
@@ -145270,7 +154758,6 @@
         "modalities": {
           "input": [
             "text",
-            "image",
             "pdf"
           ],
           "output": [
@@ -145287,16 +154774,16 @@
       "alibaba/qwen3-235b-a22b-thinking": {
         "attachment": true,
         "cost": {
-          "input": 0.3,
-          "output": 2.9
+          "input": 0.4,
+          "output": 4
         },
         "family": "qwen",
         "id": "alibaba/qwen3-235b-a22b-thinking",
         "knowledge": "2025-04",
         "last_updated": "2025-04",
         "limit": {
-          "context": 262114,
-          "output": 262114
+          "context": 131072,
+          "output": 32768
         },
         "modalities": {
           "input": [
@@ -145311,16 +154798,16 @@
         "name": "Qwen3 235B A22B Thinking 2507",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-04",
+        "release_date": "2025-09-24",
         "temperature": true,
         "tool_call": true
       },
       "xai/grok-4.20-reasoning-beta": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.19999999999999998,
-          "input": 2,
-          "output": 6
+          "cache_read": 0.2,
+          "input": 1.25,
+          "output": 2.5
         },
         "family": "grok",
         "id": "xai/grok-4.20-reasoning-beta",
@@ -145343,6 +154830,36 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-11",
+        "temperature": true,
+        "tool_call": true
+      },
+      "stepfun/step-3.7-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.04,
+          "input": 0.2,
+          "output": 1.15
+        },
+        "family": "step",
+        "id": "stepfun/step-3.7-flash",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 256000,
+          "output": 256000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Step 3.7 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
         "temperature": true,
         "tool_call": true
       },
@@ -145376,7 +154893,7 @@
         "id": "anthropic/claude-sonnet-4.6",
         "interleaved": true,
         "knowledge": "2025-08-31",
-        "last_updated": "2026-02-17",
+        "last_updated": "2026-03-13",
         "limit": {
           "context": 1000000,
           "output": 128000
@@ -145428,10 +154945,6 @@
       },
       "perplexity/sonar-pro": {
         "attachment": true,
-        "cost": {
-          "input": 3,
-          "output": 15
-        },
         "family": "sonar-pro",
         "id": "perplexity/sonar-pro",
         "knowledge": "2025-09",
@@ -145481,15 +154994,49 @@
         "temperature": true,
         "tool_call": false
       },
+      "alibaba/qwen3.7-plus": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.08,
+          "cache_write": 0.5,
+          "input": 0.4,
+          "output": 1.6
+        },
+        "family": "qwen3.7-plus",
+        "id": "alibaba/qwen3.7-plus",
+        "knowledge": "2025-04",
+        "last_updated": "2026-06-02",
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen 3.7 Plus",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-01",
+        "temperature": true,
+        "tool_call": true
+      },
       "deepseek/deepseek-v4-flash": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.028,
+          "cache_read": 0.0028,
           "input": 0.14,
           "output": 0.28
         },
         "family": "deepseek",
         "id": "deepseek/deepseek-v4-flash",
+        "knowledge": "2025-05",
         "last_updated": "2026-04-24",
         "limit": {
           "context": 1000000,
@@ -145497,7 +155044,9 @@
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -145507,15 +155056,12 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-04-23",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "openai/text-embedding-3-small": {
         "attachment": false,
-        "cost": {
-          "input": 0.02,
-          "output": 0
-        },
         "family": "text-embedding",
         "id": "openai/text-embedding-3-small",
         "last_updated": "2024-01-25",
@@ -145536,7 +155082,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-01-25",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "openai/gpt-5.5": {
@@ -145548,7 +155094,8 @@
         },
         "family": "gpt",
         "id": "openai/gpt-5.5",
-        "last_updated": "2026-04-24",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-04-23",
         "limit": {
           "context": 1000000,
           "input": 872000,
@@ -145568,6 +155115,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-04-24",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -145659,7 +155207,7 @@
         "name": "Seed 1.8",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-10",
+        "release_date": "2025-09-01",
         "temperature": true,
         "tool_call": true
       },
@@ -145752,6 +155300,37 @@
         "temperature": true,
         "tool_call": true
       },
+      "google/gemini-3.1-flash-image": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.05,
+          "input": 0.5,
+          "output": 3
+        },
+        "family": "gemini",
+        "id": "google/gemini-3.1-flash-image",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "name": "Gemini 3.1 Flash Image (Nano Banana 2)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "temperature": true,
+        "tool_call": false
+      },
       "anthropic/claude-opus-4.1": {
         "attachment": true,
         "cost": {
@@ -145763,7 +155342,7 @@
         "family": "claude-opus",
         "id": "anthropic/claude-opus-4.1",
         "knowledge": "2025-03-31",
-        "last_updated": "2025-05-22",
+        "last_updated": "2025-08-05",
         "limit": {
           "context": 200000,
           "output": 32000
@@ -145778,16 +155357,23 @@
             "text"
           ]
         },
-        "name": "Claude Opus 4",
+        "name": "Claude Opus 4.1",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-05-22",
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
+        "release_date": "2025-08-05",
         "temperature": true,
         "tool_call": true
       },
       "alibaba/qwen3-max": {
         "attachment": false,
         "cost": {
+          "cache_read": 0.24,
           "input": 1.2,
           "output": 6
         },
@@ -145876,7 +155462,8 @@
         },
         "family": "gemini",
         "id": "google/gemini-3.1-flash-lite",
-        "last_updated": "2026-05-08",
+        "knowledge": "2025-01",
+        "last_updated": "2026-05-07",
         "limit": {
           "context": 1000000,
           "output": 65000
@@ -145895,6 +155482,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-05-07",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -145902,9 +155490,9 @@
         "attachment": false,
         "cost": {
           "cache_read": 0.03,
-          "cache_write": 0.38,
-          "input": 0.27,
-          "output": 1.15
+          "cache_write": 0.375,
+          "input": 0.3,
+          "output": 1.2
         },
         "family": "minimax",
         "id": "minimax/minimax-m2",
@@ -145912,8 +155500,8 @@
         "knowledge": "2024-10",
         "last_updated": "2025-10-27",
         "limit": {
-          "context": 262114,
-          "output": 262114
+          "context": 205000,
+          "output": 205000
         },
         "modalities": {
           "input": [
@@ -145965,9 +155553,9 @@
       "xai/grok-4.20-multi-agent-beta": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.19999999999999998,
-          "input": 2,
-          "output": 6
+          "cache_read": 0.2,
+          "input": 1.25,
+          "output": 2.5
         },
         "family": "grok",
         "id": "xai/grok-4.20-multi-agent-beta",
@@ -145978,7 +155566,9 @@
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -146018,6 +155608,7 @@
       "zai/glm-4.5v": {
         "attachment": true,
         "cost": {
+          "cache_read": 0.11,
           "input": 0.6,
           "output": 1.8
         },
@@ -146027,7 +155618,7 @@
         "last_updated": "2025-08-11",
         "limit": {
           "context": 66000,
-          "output": 66000
+          "output": 16000
         },
         "modalities": {
           "input": [
@@ -146048,8 +155639,8 @@
       "openai/gpt-oss-20b": {
         "attachment": false,
         "cost": {
-          "input": 0.07,
-          "output": 0.3
+          "input": 0.05,
+          "output": 0.2
         },
         "family": "gpt-oss",
         "id": "openai/gpt-oss-20b",
@@ -146057,8 +155648,8 @@
         "last_updated": "2025-08-05",
         "limit": {
           "context": 131072,
-          "input": 98304,
-          "output": 32768
+          "input": 122880,
+          "output": 8192
         },
         "modalities": {
           "input": [
@@ -146085,7 +155676,7 @@
         "family": "glm",
         "id": "zai/glm-4.6v",
         "knowledge": "2024-10",
-        "last_updated": "2025-09-30",
+        "last_updated": "2025-12-08",
         "limit": {
           "context": 128000,
           "output": 24000
@@ -146110,8 +155701,8 @@
       "openai/gpt-oss-safeguard-20b": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.04,
-          "input": 0.08,
+          "cache_read": 0.037,
+          "input": 0.075,
           "output": 0.3
         },
         "family": "gpt-oss",
@@ -146141,6 +155732,7 @@
       "zai/glm-4.5-air": {
         "attachment": false,
         "cost": {
+          "cache_read": 0.03,
           "input": 0.2,
           "output": 1.1
         },
@@ -146229,14 +155821,15 @@
       "alibaba/qwen3.6-plus": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.09999999999999999,
+          "cache_read": 0.1,
           "cache_write": 0.625,
           "input": 0.5,
           "output": 3
         },
         "family": "qwen",
         "id": "alibaba/qwen3.6-plus",
-        "last_updated": "2026-04-03",
+        "knowledge": "2025-04",
+        "last_updated": "2026-04-02",
         "limit": {
           "context": 1000000,
           "output": 64000
@@ -146266,7 +155859,7 @@
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-3-super-120b-a12b",
-        "last_updated": "2026-03-30",
+        "last_updated": "2026-03-11",
         "limit": {
           "context": 256000,
           "output": 32000
@@ -146294,7 +155887,8 @@
         },
         "family": "gpt",
         "id": "openai/gpt-5.5-pro",
-        "last_updated": "2026-04-24",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-04-23",
         "limit": {
           "context": 1000000,
           "input": 872000,
@@ -146314,29 +155908,30 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-04-24",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "moonshotai/kimi-k2.5": {
         "attachment": true,
         "cost": {
+          "cache_read": 0.1,
           "input": 0.6,
-          "output": 1.2
+          "output": 3
         },
         "family": "kimi",
         "id": "moonshotai/kimi-k2.5",
         "interleaved": true,
         "knowledge": "2025-01",
-        "last_updated": "2026-01-26",
+        "last_updated": "2026-01",
         "limit": {
-          "context": 262144,
-          "output": 262144
+          "context": 262114,
+          "output": 262114
         },
         "modalities": {
           "input": [
             "text",
-            "image",
-            "video"
+            "image"
           ],
           "output": [
             "text"
@@ -146346,6 +155941,7 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-01-26",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -146381,16 +155977,16 @@
       "alibaba/qwen-3-32b": {
         "attachment": false,
         "cost": {
-          "input": 0.1,
-          "output": 0.3
+          "input": 0.16,
+          "output": 0.64
         },
         "family": "qwen",
         "id": "alibaba/qwen-3-32b",
         "knowledge": "2025-04",
         "last_updated": "2025-04",
         "limit": {
-          "context": 40960,
-          "output": 16384
+          "context": 128000,
+          "output": 8192
         },
         "modalities": {
           "input": [
@@ -146403,7 +155999,7 @@
         "name": "Qwen 3.32B",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-04",
+        "release_date": "2025-04-01",
         "temperature": true,
         "tool_call": true
       },
@@ -146411,11 +156007,12 @@
         "attachment": true,
         "cost": {
           "cache_read": 0.02,
-          "input": 0.19999999999999998,
+          "input": 0.2,
           "output": 1.25
         },
         "family": "gpt",
         "id": "openai/gpt-5.4-nano",
+        "knowledge": "2025-08-31",
         "last_updated": "2026-03-17",
         "limit": {
           "context": 400000,
@@ -146436,15 +156033,12 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-17",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "alibaba/qwen3-embedding-8b": {
         "attachment": false,
-        "cost": {
-          "input": 0.05,
-          "output": 0
-        },
         "family": "qwen",
         "id": "alibaba/qwen3-embedding-8b",
         "last_updated": "2025-06-05",
@@ -146464,13 +156058,13 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-06-05",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "openai/gpt-5.2-chat": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.18,
+          "cache_read": 0.175,
           "input": 1.75,
           "output": 14
         },
@@ -146496,7 +156090,7 @@
         "name": "GPT-5.2 Chat",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-07",
+        "release_date": "2025-12-11",
         "temperature": true,
         "tool_call": true
       },
@@ -146529,6 +156123,12 @@
         "name": "Claude Sonnet 4.5",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-09-29",
         "temperature": true,
         "tool_call": true
@@ -146601,11 +156201,12 @@
         "attachment": false,
         "cost": {
           "input": 0.07,
-          "output": 0.39999999999999997
+          "output": 0.4
         },
         "family": "glm",
         "id": "zai/glm-4.7-flash",
-        "last_updated": "2026-03-13",
+        "knowledge": "2025-04",
+        "last_updated": "2026-01-19",
         "limit": {
           "context": 200000,
           "output": 131000
@@ -146654,6 +156255,12 @@
         "name": "Claude Opus 4",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-05-22",
         "temperature": true,
         "tool_call": true
@@ -146691,8 +156298,9 @@
       "google/gemini-3-pro-image": {
         "attachment": false,
         "cost": {
+          "cache_read": 0.2,
           "input": 2,
-          "output": 120
+          "output": 12
         },
         "family": "gemini-pro",
         "id": "google/gemini-3-pro-image",
@@ -146714,7 +156322,7 @@
         "name": "Nano Banana Pro (Gemini 3 Pro Image)",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-09",
+        "release_date": "2025-09-01",
         "temperature": true,
         "tool_call": false
       },
@@ -146766,7 +156374,6 @@
         "modalities": {
           "input": [
             "text",
-            "image",
             "pdf"
           ],
           "output": [
@@ -146871,15 +156478,15 @@
       "alibaba/qwen3-next-80b-a3b-instruct": {
         "attachment": false,
         "cost": {
-          "input": 0.09,
-          "output": 1.1
+          "input": 0.15,
+          "output": 1.2
         },
         "family": "qwen",
         "id": "alibaba/qwen3-next-80b-a3b-instruct",
         "knowledge": "2025-04",
-        "last_updated": "2025-09-12",
+        "last_updated": "2025-09",
         "limit": {
-          "context": 262144,
+          "context": 131072,
           "output": 32768
         },
         "modalities": {
@@ -146907,6 +156514,7 @@
         },
         "family": "claude-opus",
         "id": "anthropic/claude-opus-4.7",
+        "knowledge": "2026-01-31",
         "last_updated": "2026-04-16",
         "limit": {
           "context": 1000000,
@@ -146926,7 +156534,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-04-16",
-        "temperature": false,
+        "temperature": true,
         "tool_call": true
       },
       "openai/gpt-3.5-turbo": {
@@ -146938,7 +156546,7 @@
         "family": "gpt",
         "id": "openai/gpt-3.5-turbo",
         "knowledge": "2021-09",
-        "last_updated": "2023-03-01",
+        "last_updated": "2023-11-06",
         "limit": {
           "context": 16385,
           "input": 12289,
@@ -146955,7 +156563,8 @@
         "name": "GPT-3.5 Turbo",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2023-03-01",
+        "release_date": "2023-05-28",
+        "structured_output": false,
         "temperature": true,
         "tool_call": false
       },
@@ -147013,16 +156622,12 @@
         "name": "Trinity Large Preview",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-01",
+        "release_date": "2025-01-01",
         "temperature": true,
         "tool_call": true
       },
       "voyage/voyage-3.5": {
         "attachment": false,
-        "cost": {
-          "input": 0.06,
-          "output": 0
-        },
         "family": "voyage",
         "id": "voyage/voyage-3.5",
         "last_updated": "2025-05-20",
@@ -147042,7 +156647,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-05-20",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "openai/o3": {
@@ -147110,7 +156715,7 @@
       "alibaba/qwen-3-14b": {
         "attachment": false,
         "cost": {
-          "input": 0.06,
+          "input": 0.12,
           "output": 0.24
         },
         "family": "qwen",
@@ -147132,12 +156737,16 @@
         "name": "Qwen3-14B",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-04",
+        "release_date": "2025-04-01",
         "temperature": true,
         "tool_call": true
       },
       "mistral/devstral-small-2": {
         "attachment": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.3
+        },
         "family": "devstral",
         "id": "mistral/devstral-small-2",
         "knowledge": "2024-10",
@@ -147164,21 +156773,23 @@
       "deepseek/deepseek-v3.2": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.22,
-          "input": 0.27,
-          "output": 0.4
+          "cache_read": 0.028,
+          "input": 0.28,
+          "output": 0.42
         },
         "family": "deepseek",
         "id": "deepseek/deepseek-v3.2",
         "knowledge": "2024-07",
         "last_updated": "2025-12-01",
         "limit": {
-          "context": 163842,
+          "context": 128000,
           "output": 8000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -147194,16 +156805,17 @@
       "google/gemini-2.5-flash-image": {
         "attachment": false,
         "cost": {
+          "cache_read": 0.03,
           "input": 0.3,
           "output": 2.5
         },
         "family": "gemini-flash",
         "id": "google/gemini-2.5-flash-image",
         "knowledge": "2025-01",
-        "last_updated": "2025-03-20",
+        "last_updated": "2025-08-26",
         "limit": {
           "context": 32768,
-          "output": 32768
+          "output": 65536
         },
         "modalities": {
           "input": [
@@ -147279,6 +156891,12 @@
         "name": "Claude Sonnet 4",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-05-22",
         "temperature": true,
         "tool_call": true
@@ -147295,7 +156913,7 @@
         "id": "anthropic/claude-opus-4.6",
         "interleaved": true,
         "knowledge": "2025-05-31",
-        "last_updated": "2026-02",
+        "last_updated": "2026-03-13",
         "limit": {
           "context": 1000000,
           "output": 128000
@@ -147313,7 +156931,7 @@
         "name": "Claude Opus 4.6",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2026-02",
+        "release_date": "2026-02-05",
         "temperature": true,
         "tool_call": true
       },
@@ -147344,13 +156962,14 @@
       "xiaomi/mimo-v2-flash": {
         "attachment": false,
         "cost": {
+          "cache_read": 0.01,
           "input": 0.1,
-          "output": 0.29
+          "output": 0.3
         },
         "family": "mimo",
         "id": "xiaomi/mimo-v2-flash",
         "knowledge": "2024-10",
-        "last_updated": "2025-12-17",
+        "last_updated": "2026-02-04",
         "limit": {
           "context": 262144,
           "output": 32000
@@ -147401,8 +157020,9 @@
       "openai/gpt-oss-120b": {
         "attachment": false,
         "cost": {
-          "input": 0.1,
-          "output": 0.5
+          "cache_read": 0.25,
+          "input": 0.35,
+          "output": 0.75
         },
         "family": "gpt-oss",
         "id": "openai/gpt-oss-120b",
@@ -147410,7 +157030,8 @@
         "last_updated": "2025-08-05",
         "limit": {
           "context": 131072,
-          "output": 131072
+          "input": 72,
+          "output": 131000
         },
         "modalities": {
           "input": [
@@ -147427,11 +157048,41 @@
         "temperature": true,
         "tool_call": true
       },
+      "stepfun/step-3.5-flash": {
+        "attachment": false,
+        "cost": {
+          "cache_write": 0.02,
+          "input": 0.09,
+          "output": 0.3
+        },
+        "family": "step",
+        "id": "stepfun/step-3.5-flash",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-13",
+        "limit": {
+          "context": 262114,
+          "output": 262114
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "StepFun 3.5 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-01-29",
+        "temperature": true,
+        "tool_call": true
+      },
       "alibaba/qwen3-vl-instruct": {
         "attachment": true,
         "cost": {
-          "input": 0.7,
-          "output": 2.8
+          "input": 0.4,
+          "output": 1.6
         },
         "family": "qwen",
         "id": "alibaba/qwen3-vl-instruct",
@@ -147444,7 +157095,8 @@
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -147527,7 +157179,8 @@
         },
         "family": "gpt",
         "id": "openai/gpt-5.4",
-        "last_updated": "2026-03-06",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-05",
         "limit": {
           "context": 1050000,
           "input": 922000,
@@ -147547,6 +157200,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-03-05",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -147580,6 +157234,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-02-29",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
@@ -147617,13 +157272,13 @@
       "xai/grok-build-0.1": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.19999999999999998,
+          "cache_read": 0.2,
           "input": 1,
           "output": 2
         },
         "family": "grok-build",
         "id": "xai/grok-build-0.1",
-        "last_updated": "2026-05-21",
+        "last_updated": "2026-04-16",
         "limit": {
           "context": 256000,
           "output": 256000
@@ -147641,6 +157296,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-05-20",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -147653,7 +157309,7 @@
         "family": "gpt",
         "id": "openai/gpt-5.2-pro",
         "knowledge": "2024-10",
-        "last_updated": "2025-08-07",
+        "last_updated": "2025-12-11",
         "limit": {
           "context": 400000,
           "input": 272000,
@@ -147672,7 +157328,8 @@
         "name": "GPT 5.2 ",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-07",
+        "release_date": "2025-12-11",
+        "structured_output": false,
         "temperature": true,
         "tool_call": true
       },
@@ -147726,6 +157383,11 @@
       },
       "kwaipilot/kat-coder-pro-v1": {
         "attachment": false,
+        "cost": {
+          "cache_read": 0.06,
+          "input": 0.03,
+          "output": 1.2
+        },
         "family": "kat-coder",
         "id": "kwaipilot/kat-coder-pro-v1",
         "knowledge": "2024-10",
@@ -147766,8 +157428,7 @@
         },
         "modalities": {
           "input": [
-            "text",
-            "image"
+            "text"
           ],
           "output": [
             "text"
@@ -147782,10 +157443,6 @@
       },
       "cohere/embed-v4.0": {
         "attachment": false,
-        "cost": {
-          "input": 0.12,
-          "output": 0
-        },
         "family": "cohere-embed",
         "id": "cohere/embed-v4.0",
         "last_updated": "2025-04-15",
@@ -147805,7 +157462,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-04-15",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "inception/mercury-2": {
@@ -147883,6 +157540,13 @@
         "name": "Gemini 2.5 Pro",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "max": 32768,
+            "min": 128,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-03-20",
         "structured_output": true,
         "temperature": true,
@@ -147996,8 +157660,6 @@
           "input": [
             "text",
             "image",
-            "audio",
-            "video",
             "pdf"
           ],
           "output": [
@@ -148008,6 +157670,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-06-17",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -148015,7 +157678,7 @@
         "attachment": false,
         "cost": {
           "cache_read": 0.03,
-          "cache_write": 0.38,
+          "cache_write": 0.375,
           "input": 0.3,
           "output": 2.4
         },
@@ -148079,7 +157742,7 @@
       "arcee-ai/trinity-mini": {
         "attachment": false,
         "cost": {
-          "input": 0.05,
+          "input": 0.045,
           "output": 0.15
         },
         "family": "trinity",
@@ -148101,16 +157764,12 @@
         "name": "Trinity Mini",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2025-12",
+        "release_date": "2025-12-01",
         "temperature": true,
         "tool_call": false
       },
       "mistral/codestral-embed": {
         "attachment": false,
-        "cost": {
-          "input": 0.15,
-          "output": 0
-        },
         "family": "codestral-embed",
         "id": "mistral/codestral-embed",
         "last_updated": "2025-05-28",
@@ -148130,19 +157789,19 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2025-05-28",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "nvidia/nemotron-3-nano-30b-a3b": {
         "attachment": false,
         "cost": {
-          "input": 0.06,
+          "input": 0.05,
           "output": 0.24
         },
         "family": "nemotron",
         "id": "nvidia/nemotron-3-nano-30b-a3b",
         "knowledge": "2024-10",
-        "last_updated": "2024-12",
+        "last_updated": "2025-12-15",
         "limit": {
           "context": 262144,
           "output": 262144
@@ -148158,7 +157817,7 @@
         "name": "Nemotron 3 Nano 30B A3B",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2024-12",
+        "release_date": "2024-12-01",
         "temperature": true,
         "tool_call": false
       },
@@ -148200,7 +157859,7 @@
         "family": "o-pro",
         "id": "openai/o3-pro",
         "knowledge": "2024-10",
-        "last_updated": "2025-04-16",
+        "last_updated": "2025-06-10",
         "limit": {
           "context": 200000,
           "input": 100000,
@@ -148220,18 +157879,20 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2025-04-16",
-        "temperature": false,
+        "structured_output": true,
+        "temperature": true,
         "tool_call": true
       },
       "deepseek/deepseek-v4-pro": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.145,
-          "input": 1.74,
-          "output": 3.48
+          "cache_read": 0.0036,
+          "input": 0.435,
+          "output": 0.87
         },
         "family": "deepseek",
         "id": "deepseek/deepseek-v4-pro",
+        "knowledge": "2025-05",
         "last_updated": "2026-04-24",
         "limit": {
           "context": 1000000,
@@ -148239,7 +157900,8 @@
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "pdf"
           ],
           "output": [
             "text"
@@ -148249,6 +157911,7 @@
         "open_weights": true,
         "reasoning": true,
         "release_date": "2026-04-23",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -148317,12 +157980,13 @@
       "google/gemma-4-26b-a4b-it": {
         "attachment": true,
         "cost": {
-          "input": 0.13,
-          "output": 0.39999999999999997
+          "cache_read": 0.015,
+          "input": 0.15,
+          "output": 0.6
         },
         "family": "gemma",
         "id": "google/gemma-4-26b-a4b-it",
-        "last_updated": "2026-04-03",
+        "last_updated": "2026-04-02",
         "limit": {
           "context": 262144,
           "output": 131072
@@ -148341,22 +158005,23 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-04-02",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "mistral/mistral-nemo": {
         "attachment": false,
         "cost": {
-          "input": 0.04,
-          "output": 0.17
+          "input": 0.02,
+          "output": 0.04
         },
         "family": "mistral-nemo",
         "id": "mistral/mistral-nemo",
         "knowledge": "2024-04",
         "last_updated": "2024-07-01",
         "limit": {
-          "context": 60288,
-          "output": 16000
+          "context": 131072,
+          "output": 131072
         },
         "modalities": {
           "input": [
@@ -148377,11 +158042,11 @@
         "attachment": true,
         "cost": {
           "input": 0.6,
-          "output": 3.5999999999999996
+          "output": 3.6
         },
         "family": "qwen3.6",
         "id": "alibaba/qwen3.6-27b",
-        "last_updated": "2026-05-01",
+        "last_updated": "2026-04-22",
         "limit": {
           "context": 256000,
           "output": 256000
@@ -148400,6 +158065,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-04-22",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -148435,10 +158101,6 @@
       },
       "voyage/voyage-code-3": {
         "attachment": false,
-        "cost": {
-          "input": 0.18,
-          "output": 0
-        },
         "family": "voyage",
         "id": "voyage/voyage-code-3",
         "last_updated": "2024-09",
@@ -148457,8 +158119,8 @@
         "name": "voyage-code-3",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-09",
-        "temperature": false,
+        "release_date": "2024-09-01",
+        "temperature": true,
         "tool_call": false
       },
       "mistral/pixtral-12b": {
@@ -148501,10 +158163,10 @@
         },
         "family": "minimax",
         "id": "minimax/minimax-m2.5-highspeed",
-        "last_updated": "2026-03-13",
+        "last_updated": "2026-02-13",
         "limit": {
-          "context": 0,
-          "output": 0
+          "context": 204800,
+          "output": 131000
         },
         "modalities": {
           "input": [
@@ -148523,10 +158185,6 @@
       },
       "google/text-embedding-005": {
         "attachment": false,
-        "cost": {
-          "input": 0.03,
-          "output": 0
-        },
         "family": "text-embedding",
         "id": "google/text-embedding-005",
         "last_updated": "2024-08",
@@ -148545,8 +158203,8 @@
         "name": "Text Embedding 005",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2024-08",
-        "temperature": false,
+        "release_date": "2024-08-01",
+        "temperature": true,
         "tool_call": false
       },
       "xai/grok-4.1-fast-non-reasoning": {
@@ -148561,12 +158219,14 @@
         "knowledge": "2024-10",
         "last_updated": "2025-07-09",
         "limit": {
-          "context": 2000000,
-          "output": 30000
+          "context": 1000000,
+          "output": 1000000
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -148582,6 +158242,7 @@
       "amazon/nova-2-lite": {
         "attachment": true,
         "cost": {
+          "cache_read": 0.075,
           "input": 0.3,
           "output": 2.5
         },
@@ -148612,9 +158273,9 @@
       "xai/grok-4.20-multi-agent": {
         "attachment": false,
         "cost": {
-          "cache_read": 0.19999999999999998,
-          "input": 2,
-          "output": 6
+          "cache_read": 0.2,
+          "input": 1.25,
+          "output": 2.5
         },
         "family": "grok",
         "id": "xai/grok-4.20-multi-agent",
@@ -148625,7 +158286,9 @@
         },
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -148641,7 +158304,7 @@
       "openai/gpt-5.1-thinking": {
         "attachment": true,
         "cost": {
-          "cache_read": 0.13,
+          "cache_read": 0.125,
           "input": 1.25,
           "output": 10
         },
@@ -148668,8 +158331,8 @@
         "name": "GPT 5.1 Thinking",
         "open_weights": false,
         "reasoning": true,
-        "release_date": "2025-08-07",
-        "temperature": false,
+        "release_date": "2025-11-12",
+        "temperature": true,
         "tool_call": true
       },
       "meta/llama-3.2-90b": {
@@ -148736,10 +158399,6 @@
       },
       "openai/text-embedding-3-large": {
         "attachment": false,
-        "cost": {
-          "input": 0.13,
-          "output": 0
-        },
         "family": "text-embedding",
         "id": "openai/text-embedding-3-large",
         "last_updated": "2024-01-25",
@@ -148760,7 +158419,7 @@
         "open_weights": false,
         "reasoning": false,
         "release_date": "2024-01-25",
-        "temperature": false,
+        "temperature": true,
         "tool_call": false
       },
       "openai/gpt-3.5-turbo-instruct": {
@@ -148789,7 +158448,7 @@
         "name": "GPT-3.5 Turbo Instruct",
         "open_weights": false,
         "reasoning": false,
-        "release_date": "2023-03-01",
+        "release_date": "2023-09-28",
         "temperature": true,
         "tool_call": false
       },
@@ -148802,7 +158461,8 @@
         },
         "family": "gemini",
         "id": "google/gemini-3.5-flash",
-        "last_updated": "2026-05-21",
+        "knowledge": "2025-01",
+        "last_updated": "2026-05-19",
         "limit": {
           "context": 1000000,
           "output": 64000
@@ -148821,6 +158481,7 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-05-19",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       }
@@ -149038,7 +158699,7 @@
           ]
         },
         "name": "GLM-5.1",
-        "open_weights": false,
+        "open_weights": true,
         "reasoning": true,
         "release_date": "2026-03-27",
         "structured_output": true,
@@ -150439,12 +160100,13 @@
       "google-gemma-4-31b-it": {
         "attachment": true,
         "cost": {
-          "input": 0.155,
-          "output": 0.44
+          "cache_read": 0.09,
+          "input": 0.12,
+          "output": 0.36
         },
         "family": "gemma",
         "id": "google-gemma-4-31b-it",
-        "last_updated": "2026-05-25",
+        "last_updated": "2026-06-08",
         "limit": {
           "context": 256000,
           "output": 8192
@@ -150714,6 +160376,37 @@
         "reasoning": true,
         "release_date": "2026-04-01",
         "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "minimax-m3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.06,
+          "input": 0.3,
+          "output": 1.2
+        },
+        "family": "minimax-m3",
+        "id": "minimax-m3",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 500000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "MiniMax M3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-01",
         "temperature": true,
         "tool_call": true
       },
@@ -151086,6 +160779,37 @@
         "temperature": true,
         "tool_call": true
       },
+      "nvidia-nemotron-3-ultra-550b-a55b": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1875,
+          "input": 0.625,
+          "output": 3.125
+        },
+        "family": "nemotron",
+        "id": "nvidia-nemotron-3-ultra-550b-a55b",
+        "last_updated": "2026-06-08",
+        "limit": {
+          "context": 256000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "NVIDIA Nemotron 3 Ultra",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-06-04",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
       "llama-3.3-70b": {
         "attachment": false,
         "cost": {
@@ -151329,6 +161053,57 @@
         "open_weights": true,
         "reasoning": false,
         "release_date": "2024-10-03",
+        "temperature": true,
+        "tool_call": true
+      },
+      "qwen-3-7-plus": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.05,
+          "cache_write": 0.625,
+          "context_over_200k": {
+            "cache_read": 0.15,
+            "cache_write": 1.875,
+            "input": 1.5,
+            "output": 6
+          },
+          "input": 0.5,
+          "output": 2,
+          "tiers": [
+            {
+              "cache_read": 0.15,
+              "cache_write": 1.875,
+              "input": 1.5,
+              "output": 6,
+              "tier": {
+                "size": 256000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "family": "qwen",
+        "id": "qwen-3-7-plus",
+        "last_updated": "2026-06-04",
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen 3.7 Plus",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-06-02",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
@@ -151727,6 +161502,38 @@
         "temperature": true,
         "tool_call": true
       },
+      "claude-opus-4-8": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.6,
+          "cache_write": 7.5,
+          "input": 6,
+          "output": 30
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-8",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
       "grok-4-20-multi-agent": {
         "attachment": true,
         "cost": {
@@ -151803,6 +161610,38 @@
         "open_weights": false,
         "reasoning": true,
         "release_date": "2026-02-12",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-8-fast": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.2,
+          "cache_write": 15,
+          "input": 12,
+          "output": 60
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-8-fast",
+        "last_updated": "2026-05-28",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.8 Fast",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-28",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },

--- a/priv/llm_db/upstream/models-dev-ea9de843.manifest.json
+++ b/priv/llm_db/upstream/models-dev-ea9de843.manifest.json
@@ -1,8 +1,8 @@
 {
   "last_modified": null,
   "source_url": "https://models.dev/api.json",
-  "sha256": "fd1c747f705fd11a9d4a6370d9221a7ade73702591d25ea90f01358478ea3a08",
-  "downloaded_at": "2026-05-28T17:31:46.722586Z",
-  "etag": "W/\"14895b96f01559c5a8d87541f5fdde38\"",
-  "size_bytes": 3693638
+  "sha256": "6cb84de28fffbaccd09bffa4abd6df933292c1d9972ca60c6099a08e8f11b9d7",
+  "size_bytes": 3930166,
+  "downloaded_at": "2026-06-08T15:18:57.293448Z",
+  "etag": "W/\"b6a111ce5b753daa84f50896dd3dc7f6\""
 }


### PR DESCRIPTION
Provider: amazon_bedrock | Result: mismatches found

Sources checked on 2026-06-08:
- AWS Models at a glance: https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
- AWS Supported foundation models moved notice: https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
- models.dev public API source: https://models.dev/api.json
- models.dev repository/API docs: https://github.com/sst/models.dev
- AWS model cards used for local overrides and alias checks:
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-ai21-labs-jamba-1-5-large.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-ai21-labs-jamba-1-5-mini.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-premier.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-3-5-haiku.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-3-haiku.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-1.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-cohere-command-r.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-cohere-command-r-plus.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-2-1b-instruct.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-2-3b-instruct.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-2-11b-instruct.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-2-90b-instruct.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-3-70b-instruct.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-8b-instruct.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-70b-instruct.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-mistral-ai-mistral-7b-instruct.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-mistral-ai-mistral-large.html
  - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-mistral-ai-mixtral-8x7b-instruct.html

Summary:
- Checked: 115 final Bedrock model records plus provider metadata.
- Mismatched/fixed: missing AWS-documented Bedrock model records, undocumented inference-profile aliases, Llama 3.3 70B output limit/lifecycle, and Llama 3.2 3B provider model ID/limits/lifecycle.
- Verified: AWS-published model IDs, lifecycle, EOL, limits, modalities, and documented geo/global inference IDs for the local override set.
- Unverified: exact current pricing for docs-restored legacy models was not added because the public model cards defer pricing to the general Bedrock pricing page, and an unauthenticated public ListFoundationModels response was not available.

Capture layers:
- remote-cache: refreshed `priv/llm_db/upstream/models-dev-ea9de843.*` with `mix llm_db.pull --source models_dev`. This source is aggregate/shared by design; this verification run reviewed Bedrock only.
- local-override: added or updated sparse TOML under `priv/llm_db/local/amazon_bedrock` for AWS docs-only facts: lifecycle/EOL dates, limits, modalities, provider model IDs, and documented inference profile aliases.
- generated-artifact: rebuilt `priv/llm_db/snapshot.json` with `mix llm_db.build --install`; provider registry files regenerated byte-identical.
- unverified: left resolver behavior in `LLMDB.Spec` unchanged. It still strips known Bedrock geography prefixes at runtime and can resolve unsupported profile prefixes even when metadata aliases are stricter.

Tests:
- `mix llm_db.build --check --install`: passed
- `mix format --check-formatted`: passed
- `mix test test/llm_db/sources_test.exs test/llm_db/spec_test.exs test/llm_db_test.exs`: 185 tests, 0 failures
- `mix test`: 41 doctests, 700 tests, 0 failures
- pre-push `mix quality`: passed, including tests, credo, and dialyzer
