### PR TITLE
feat: add Claude Fable 5 metadata

### DIFF
--- a/lib/llm_db/enrich/azure_wire_protocol.ex
+++ b/lib/llm_db/enrich/azure_wire_protocol.ex
@@ -54,6 +54,9 @@ defmodule LLMDB.Enrich.AzureWireProtocol do
         write_cache(cache_path, manifest_path, bin)
         {:ok, cache_path}
 
+      {:error, {:http_status, 429}} ->
+        keep_existing_cache(cache_path, {:http_status, 429})
+
       {:error, reason} ->
         {:error, reason}
     end
@@ -222,6 +225,20 @@ defmodule LLMDB.Enrich.AzureWireProtocol do
   defp get_cache_dir do
     Application.get_env(:llm_db, :azure_foundry_cache_dir, @default_cache_dir)
   end
+
+  defp keep_existing_cache(cache_path, reason) do
+    if File.exists?(cache_path) do
+      Logger.warning(
+        "Azure Foundry pull failed with #{format_http_status(reason)}; keeping existing cache at #{cache_path}"
+      )
+
+      :noop
+    else
+      {:error, reason}
+    end
+  end
+
+  defp format_http_status({:http_status, status}), do: "HTTP #{status}"
 
   defp write_cache(cache_path, manifest_path, content) do
     File.mkdir_p!(Path.dirname(cache_path))

--- a/lib/llm_db/sources/anthropic.ex
+++ b/lib/llm_db/sources/anthropic.ex
@@ -126,6 +126,14 @@ defmodule LLMDB.Sources.Anthropic do
           id: "claude-sonnet-4-20250514",
           provider: :anthropic,
           name: "Claude Sonnet 4",
+          limits: %{
+            context: 200000,
+            output: 64000
+          },
+          modalities: %{
+            input: [:text, :image, :pdf],
+            output: [:text]
+          },
           extra: %{
             type: "model",
             created_at: "2025-02-19T00:00:00Z"
@@ -164,9 +172,15 @@ defmodule LLMDB.Sources.Anthropic do
         base
       end
 
+    base =
+      base
+      |> map_limits(model)
+      |> map_modalities(model["capabilities"])
+      |> map_capabilities(model["capabilities"])
+
     extra =
       model
-      |> Map.drop(["id", "display_name"])
+      |> Map.drop(["id", "display_name", "max_input_tokens", "max_tokens"])
       |> Enum.reduce(%{}, fn {k, v}, acc -> Map.put(acc, String.to_atom(k), v) end)
 
     if map_size(extra) > 0 do
@@ -175,6 +189,68 @@ defmodule LLMDB.Sources.Anthropic do
       base
     end
   end
+
+  defp map_limits(model, source_model) do
+    limits =
+      %{}
+      |> put_if_valid_limit(:context, source_model["max_input_tokens"])
+      |> put_if_valid_limit(:output, source_model["max_tokens"])
+
+    if map_size(limits) > 0 do
+      Map.put(model, :limits, limits)
+    else
+      model
+    end
+  end
+
+  defp map_modalities(model, capabilities) when is_map(capabilities) do
+    input =
+      [:text]
+      |> maybe_append(:image, supported?(capabilities, "image_input"))
+      |> maybe_append(:pdf, supported?(capabilities, "pdf_input"))
+
+    Map.put(model, :modalities, %{input: input, output: [:text]})
+  end
+
+  defp map_modalities(model, _capabilities), do: model
+
+  defp map_capabilities(model, capabilities) when is_map(capabilities) do
+    canonical =
+      %{}
+      |> put_if_true(:reasoning, %{enabled: true}, supported?(capabilities, "thinking"))
+      |> put_if_true(
+        :json,
+        %{native: false, schema: true, strict: false},
+        supported?(capabilities, "structured_outputs")
+      )
+
+    if map_size(canonical) > 0 do
+      Map.put(model, :capabilities, canonical)
+    else
+      model
+    end
+  end
+
+  defp map_capabilities(model, _capabilities), do: model
+
+  defp supported?(capabilities, key) do
+    case get_in(capabilities, [key, "supported"]) do
+      true -> true
+      _other -> false
+    end
+  end
+
+  defp maybe_append(list, value, true), do: list ++ [value]
+  defp maybe_append(list, _value, _supported?), do: list
+
+  defp put_if_true(map, key, value, true), do: Map.put(map, key, value)
+  defp put_if_true(map, _key, _value, _flag), do: map
+
+  defp put_if_valid_limit(map, key, value) when is_integer(value) and value > 0 do
+    Map.put(map, key, value)
+  end
+
+  defp put_if_valid_limit(map, _key, _value), do: map
 
   defp fetch_all_pages(url, req_opts, limit, acc) do
     params = [limit: limit]

--- a/priv/llm_db/local/anthropic/claude-fable-5.toml
+++ b/priv/llm_db/local/anthropic/claude-fable-5.toml
@@ -1,0 +1,26 @@
+id = "claude-fable-5"
+release_date = "2026-06-09"
+knowledge = "2026-01"
+doc_url = "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[capabilities.tools]
+enabled = true
+
+[capabilities.streaming]
+text = true
+tool_calls = true
+
+[lifecycle]
+status = "active"
+
+[extra]
+availability = "general"
+training_data_cutoff = "2026-01"
+fallback_model = "claude-opus-4-8"
+fallback_domains = ["cybersecurity", "biology", "chemistry", "distillation"]

--- a/priv/llm_db/remote/anthropic-81d2be36.json
+++ b/priv/llm_db/remote/anthropic-81d2be36.json
@@ -36,7 +36,79 @@
           "medium": {
             "supported": true
           },
+          "supported": true,
+          "xhigh": {
+            "supported": true
+          }
+        },
+        "image_input": {
           "supported": true
+        },
+        "pdf_input": {
+          "supported": true
+        },
+        "structured_outputs": {
+          "supported": true
+        },
+        "thinking": {
+          "supported": true,
+          "types": {
+            "adaptive": {
+              "supported": true
+            },
+            "enabled": {
+              "supported": false
+            }
+          }
+        }
+      },
+      "created_at": "2026-06-07T00:00:00Z",
+      "display_name": "Claude Fable 5",
+      "id": "claude-fable-5",
+      "max_input_tokens": 1000000,
+      "max_tokens": 128000,
+      "type": "model"
+    },
+    {
+      "capabilities": {
+        "batch": {
+          "supported": true
+        },
+        "citations": {
+          "supported": true
+        },
+        "code_execution": {
+          "supported": true
+        },
+        "context_management": {
+          "clear_thinking_20251015": {
+            "supported": true
+          },
+          "clear_tool_uses_20250919": {
+            "supported": true
+          },
+          "compact_20260112": {
+            "supported": true
+          },
+          "supported": true
+        },
+        "effort": {
+          "high": {
+            "supported": true
+          },
+          "low": {
+            "supported": true
+          },
+          "max": {
+            "supported": true
+          },
+          "medium": {
+            "supported": true
+          },
+          "supported": true,
+          "xhigh": {
+            "supported": true
+          }
         },
         "image_input": {
           "supported": true
@@ -102,7 +174,10 @@
           "medium": {
             "supported": true
           },
-          "supported": true
+          "supported": true,
+          "xhigh": {
+            "supported": true
+          }
         },
         "image_input": {
           "supported": true
@@ -168,7 +243,10 @@
           "medium": {
             "supported": true
           },
-          "supported": true
+          "supported": true,
+          "xhigh": {
+            "supported": false
+          }
         },
         "image_input": {
           "supported": true
@@ -234,7 +312,10 @@
           "medium": {
             "supported": true
           },
-          "supported": true
+          "supported": true,
+          "xhigh": {
+            "supported": false
+          }
         },
         "image_input": {
           "supported": true
@@ -300,7 +381,10 @@
           "medium": {
             "supported": true
           },
-          "supported": true
+          "supported": true,
+          "xhigh": {
+            "supported": false
+          }
         },
         "image_input": {
           "supported": true
@@ -366,7 +450,10 @@
           "medium": {
             "supported": false
           },
-          "supported": false
+          "supported": false,
+          "xhigh": {
+            "supported": false
+          }
         },
         "image_input": {
           "supported": true
@@ -432,7 +519,10 @@
           "medium": {
             "supported": false
           },
-          "supported": false
+          "supported": false,
+          "xhigh": {
+            "supported": false
+          }
         },
         "image_input": {
           "supported": true
@@ -498,7 +588,10 @@
           "medium": {
             "supported": false
           },
-          "supported": false
+          "supported": false,
+          "xhigh": {
+            "supported": false
+          }
         },
         "image_input": {
           "supported": true
@@ -564,7 +657,10 @@
           "medium": {
             "supported": false
           },
-          "supported": false
+          "supported": false,
+          "xhigh": {
+            "supported": false
+          }
         },
         "image_input": {
           "supported": true
@@ -630,7 +726,10 @@
           "medium": {
             "supported": false
           },
-          "supported": false
+          "supported": false,
+          "xhigh": {
+            "supported": false
+          }
         },
         "image_input": {
           "supported": true

--- a/priv/llm_db/remote/anthropic-81d2be36.manifest.json
+++ b/priv/llm_db/remote/anthropic-81d2be36.manifest.json
@@ -1,6 +1,6 @@
 {
   "source_url": "https://api.anthropic.com/v1/models",
-  "sha256": "ffd7ac6571188fec29e79d4902e6ab7395f065bd6e0d2b62058a554dff9f5ed1",
-  "size_bytes": 15024,
-  "downloaded_at": "2026-05-28T17:31:41.229947Z"
+  "sha256": "192fdfb15743ab9c2635711da67460f2856037607606895f04496da075b6dcea",
+  "downloaded_at": "2026-06-09T17:17:56.403268Z",
+  "size_bytes": 17226
 }

--- a/test/llm_db/enrich/azure_wire_protocol_test.exs
+++ b/test/llm_db/enrich/azure_wire_protocol_test.exs
@@ -28,6 +28,23 @@ defmodule LLMDB.Enrich.AzureWireProtocolTest do
     {:ok, cache_dir: cache_dir}
   end
 
+  describe "pull/1" do
+    test "returns :noop on HTTP 429 when cache exists", %{cache_dir: cache_dir} do
+      write_cache(cache_dir, [])
+
+      plug = make_plug(fn conn -> Plug.Conn.send_resp(conn, 429, "Too Many Requests") end)
+
+      assert :noop = AzureWireProtocol.pull(%{req_opts: [plug: plug]})
+    end
+
+    test "returns error on HTTP 429 when cache is missing" do
+      plug = make_plug(fn conn -> Plug.Conn.send_resp(conn, 429, "Too Many Requests") end)
+
+      assert {:error, {:http_status, 429}} =
+               AzureWireProtocol.pull(%{req_opts: [plug: plug]})
+    end
+  end
+
   test "matches instruct-suffixed cache entries for azure providers", %{cache_dir: cache_dir} do
     write_cache(cache_dir, [
       foundry_model("Phi-4-mini-instruct", ["chat-completion"]),
@@ -46,6 +63,12 @@ defmodule LLMDB.Enrich.AzureWireProtocolTest do
     assert get_in(cognitive_model, [:extra, :wire_protocol]) == :openai_completion
     assert preserved.extra.wire_protocol == :openai_responses
     refute Map.has_key?(non_azure, :extra)
+  end
+
+  defp make_plug(fun) do
+    fn conn ->
+      fun.(conn)
+    end
   end
 
   defp write_cache(cache_dir, models) do

--- a/test/llm_db/sources/anthropic_test.exs
+++ b/test/llm_db/sources/anthropic_test.exs
@@ -1,0 +1,55 @@
+defmodule LLMDB.Sources.AnthropicTest do
+  use ExUnit.Case, async: true
+
+  alias LLMDB.Sources.Anthropic
+
+  describe "transform/1" do
+    test "maps model limits, modalities, and canonical capabilities" do
+      input = %{
+        "data" => [
+          %{
+            "id" => "claude-fable-5",
+            "type" => "model",
+            "display_name" => "Claude Fable 5",
+            "created_at" => "2026-06-07T00:00:00Z",
+            "max_input_tokens" => 1_000_000,
+            "max_tokens" => 128_000,
+            "capabilities" => %{
+              "image_input" => %{"supported" => true},
+              "pdf_input" => %{"supported" => true},
+              "structured_outputs" => %{"supported" => true},
+              "thinking" => %{
+                "supported" => true,
+                "types" => %{
+                  "adaptive" => %{"supported" => true},
+                  "enabled" => %{"supported" => false}
+                }
+              }
+            }
+          }
+        ]
+      }
+
+      assert %{
+               "anthropic" => %{
+                 id: :anthropic,
+                 name: "Anthropic",
+                 models: [model]
+               }
+             } = Anthropic.transform(input)
+
+      assert model.id == "claude-fable-5"
+      assert model.provider == :anthropic
+      assert model.name == "Claude Fable 5"
+      assert model.limits == %{context: 1_000_000, output: 128_000}
+      assert model.modalities == %{input: [:text, :image, :pdf], output: [:text]}
+      assert model.capabilities.reasoning.enabled == true
+      assert model.capabilities.json == %{native: false, schema: true, strict: false}
+      assert model.extra.type == "model"
+      assert model.extra.created_at == "2026-06-07T00:00:00Z"
+      assert model.extra.capabilities["thinking"]["types"]["adaptive"]["supported"] == true
+      refute Map.has_key?(model.extra, :max_input_tokens)
+      refute Map.has_key?(model.extra, :max_tokens)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Claude Fable 5 Anthropic metadata and rebuild the catalog snapshot
- normalize Anthropic model limits, modalities, and canonical capabilities from the Models API payload
- keep the Azure Foundry enrichment cache on HTTP 429 so transient rate limits do not fail metadata publishing

## Verification
- mix llm_db.build --check --install
- mix test
- mix quality