### PR TITLE
feat: evolve model pricing and capability metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`
 - [Runtime Filters](guides/runtime-filters.md) — Load-time and runtime filtering
 - [Sources & Engine](guides/sources-and-engine.md) — ETL pipeline, data sources, precedence
 - [Schema System](guides/schema-system.md) — Zoi validation and data structures
+- [Model Struct Evolution Proposal](guides/model-struct-evolution-proposal.md) — Proposed conditional pricing and richer capability metadata
 - [Release Process](guides/release-process.md) — Snapshot-based releases
 
 ## License

--- a/guides/model-struct-evolution-proposal.md
+++ b/guides/model-struct-evolution-proposal.md
@@ -1,0 +1,617 @@
+# Model Struct Evolution Proposal
+
+This proposal describes how to evolve `%LLMDB.Model{}` and the build/runtime
+pipeline so LLMDB can represent provider-published conditional pricing and richer
+runtime capabilities without breaking existing consumers.
+
+Status: design proposal only. This is not the current runtime contract.
+
+## Why This Is Needed
+
+Recent provider metadata has outgrown the current flat model shape:
+
+- OpenAI publishes different token rates by context tier, service tier, Batch,
+  Flex, Priority, and data residency. GPT-5.5 is the motivating example: the
+  standard short-context rates are not the same as the long-context rates.
+- OpenAI reasoning effort changes token usage and latency, while reasoning tokens
+  are billed as output tokens rather than at a separate per-effort price.
+- Anthropic's Models API publishes rich capability metadata for Claude Fable 5,
+  including effort levels, adaptive thinking, batch support, code execution,
+  citations, and context management.
+- Anthropic pricing has condition-specific modifiers: prompt cache TTL, Batch API
+  discounts, data residency multipliers, and fast mode on supported Opus models.
+  Claude Fable 5 does not have OpenAI-style long-context tier pricing, but it
+  still needs conditional pricing for cache TTL, Batch, and data residency.
+
+The current model schema can store only a subset of this:
+
+- `cost` is a flat legacy map.
+- `pricing.components` can represent many billable components, but not when a
+  component applies, whether it is a multiplier, or which request/provider mode
+  activates it.
+- `capabilities.reasoning` currently captures `enabled` and `token_budget`, but
+  not effort levels, thinking modes, display behavior, or provider-specific
+  context handling features.
+- `limits` has `context` and `output`, but provider APIs often publish
+  `max_input_tokens` separately.
+
+## Source Authority
+
+Use provider-direct sources first and third-party catalogs only as discovery
+leads.
+
+| Provider | Direct source to trust | What it can supply | What still needs docs or curated local metadata |
+| --- | --- | --- | --- |
+| OpenAI | `GET /v1/models` | Model inventory and basic ownership/created data | Pricing, context tiers, reasoning effort values/defaults, service tiers, data residency |
+| Anthropic | `GET /v1/models` | Model inventory, display names, dates, token limits, capability tree | Pricing, lifecycle notes, aliases, cloud-specific caveats, retention/cross-model behavior |
+
+For OpenAI and Anthropic, `models.dev` should not drive the schema shape. It can
+still be useful as a fallback source or comparison point, but provider APIs and
+official provider docs should decide which fields become canonical.
+
+## Evidence Links
+
+Official provider references used for this proposal:
+
+- OpenAI Models API:
+  <https://developers.openai.com/api/reference/resources/models/methods/list>
+- OpenAI pricing:
+  <https://developers.openai.com/api/docs/pricing>
+- OpenAI reasoning models:
+  <https://developers.openai.com/api/docs/guides/reasoning>
+- Anthropic Models API:
+  <https://platform.claude.com/docs/en/api/models/list>
+- Anthropic pricing:
+  <https://platform.claude.com/docs/en/about-claude/pricing>
+- Anthropic prompt caching:
+  <https://platform.claude.com/docs/en/build-with-claude/prompt-caching>
+- Anthropic context windows:
+  <https://platform.claude.com/docs/en/build-with-claude/context-windows>
+- Claude Fable 5 and Mythos 5:
+  <https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5>
+
+## Current Implementation Touchpoints
+
+The implementation work should be planned around these existing boundaries:
+
+- `lib/llm_db/model.ex` owns the `LLMDB.Model` struct and nested Zoi schemas.
+- `lib/llm_db/pricing.ex` converts legacy `cost` maps into
+  `pricing.components` and merges provider defaults at load time.
+- `lib/llm_db/sources/openai.ex` maps OpenAI's direct `/v1/models` inventory.
+- `lib/llm_db/sources/anthropic.ex` maps Anthropic's direct `/v1/models`
+  inventory, limits, modalities, and a small subset of capabilities.
+- `priv/llm_db/local/<provider>/*.toml` should remain the place for official
+  docs-only facts such as pricing and lifecycle.
+- `priv/llm_db/remote/*.json` should remain provider API cache data and should
+  not be hand-edited.
+- `priv/llm_db/providers/*.json` and `priv/llm_db/snapshot.json` should remain
+  generated artifacts.
+
+## Goals
+
+- Preserve existing `%LLMDB.Model{}` field names and consumer access patterns.
+- Represent conditional pricing without forcing every consumer to become a
+  billing engine.
+- Capture provider-published reasoning metadata in a typed, queryable form.
+- Preserve provider raw capability data during schema transitions.
+- Keep old snapshots and custom provider maps loadable.
+- Allow incremental implementation through additive schema changes.
+
+## Non-Goals
+
+- Remove `cost` or change its meaning.
+- Guarantee exact invoice calculation for every provider and contract.
+- Encode private account discounts, negotiated enterprise pricing, or dashboard
+  entitlements.
+- Replace provider SDKs or API references for request validation.
+
+## Proposed `%LLMDB.Model{}` Shape
+
+The top-level struct should remain recognizable. The proposal is to extend
+existing nested maps instead of replacing them.
+
+```elixir
+%LLMDB.Model{
+  id: "claude-fable-5",
+  provider: :anthropic,
+  limits: %{
+    context: 1_000_000,
+    input: 1_000_000,
+    output: 128_000
+  },
+  cost: %{
+    input: 10.0,
+    output: 50.0,
+    cache_read: 1.0,
+    cache_write: 12.5
+  },
+  capabilities: %{
+    reasoning: %{
+      enabled: true,
+      effort: %{
+        supported: true,
+        values: ["low", "medium", "high", "xhigh", "max"],
+        default: nil
+      },
+      thinking: %{
+        types: ["adaptive"],
+        default_type: "adaptive",
+        disable_supported: false,
+        raw_output_supported: false
+      },
+      token_budget: nil
+    },
+    batch: %{supported: true},
+    citations: %{supported: true},
+    code_execution: %{supported: true},
+    context_management: %{
+      supported: true,
+      features: ["clear_thinking", "clear_tool_uses", "compact"]
+    },
+    json: %{schema: true},
+    tools: %{enabled: true}
+  },
+  pricing: %{
+    currency: "USD",
+    merge: "merge_by_id",
+    components: [
+      %{
+        id: "token.input",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 10.0
+      },
+      %{
+        id: "token.input.batch",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 5.0,
+        applies_when: %{api: "batch"}
+      },
+      %{
+        id: "token.cache_write.1h",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 20.0,
+        applies_when: %{cache_ttl: "1h"}
+      },
+      %{
+        id: "pricing.data_residency",
+        kind: "other",
+        unit: "other",
+        multiplier: 1.1,
+        applies_when: %{inference_geo: true}
+      }
+    ]
+  },
+  extra: %{
+    provider_capabilities: %{...}
+  }
+}
+```
+
+### Compatibility Rules
+
+- `cost` remains the default standard token rate surface. Consumers that only
+  read `model.cost.input` or `model.cost.output` keep working.
+- `limits.context` remains the broad maximum window used by existing consumers.
+  `limits.input` is additive and should mirror provider-published input limits
+  when available.
+- `capabilities.reasoning.enabled` remains the coarse boolean. New nested
+  reasoning fields refine it.
+- Existing pricing components without `applies_when`, `multiplier`, or new
+  metadata remain valid.
+- Adding optional nested keys is preferred over adding many new top-level struct
+  fields.
+
+## Pricing Component Extensions
+
+Extend `pricing.components` with optional fields:
+
+```elixir
+%{
+  id: "token.input.long_context",
+  kind: "token",
+  unit: "token",
+  per: 1_000_000,
+  rate: 10.0,
+  multiplier: nil,
+  applies_when: %{input_tokens: %{gt: 272_000}},
+  excludes_when: nil,
+  meter: "input_tokens",
+  mode: "standard",
+  source: "provider_docs",
+  notes: "OpenAI GPT-5.5 long-context input rate"
+}
+```
+
+Recommended semantics:
+
+- `rate` is an absolute price in `pricing.currency`.
+- `multiplier` is a factor applied to one or more matched components.
+- `applies_when` is a provider-neutral condition map.
+- `excludes_when` is optional and should be rare; prefer positive selectors.
+- `source` should identify the evidence layer, not a full citation system. Use
+  values such as `"provider_api"`, `"provider_docs"`, `"local_override"`, or
+  `"provider_default"`.
+- `notes` remains human-readable and non-authoritative.
+
+Recommended condition keys:
+
+| Key | Example | Use |
+| --- | --- | --- |
+| `api` | `%{api: "batch"}` | Batch API or provider-specific async batch mode |
+| `service_tier` | `%{service_tier: "priority"}` | OpenAI Priority or other service tier rates |
+| `processing_mode` | `%{processing_mode: "flex"}` | Flex, background, or similar processing modes |
+| `input_tokens` | `%{input_tokens: %{gt: 272_000}}` | Long-context tiers |
+| `cache_ttl` | `%{cache_ttl: "1h"}` | Prompt cache write duration |
+| `inference_geo` | `%{inference_geo: true}` | Data residency/regional processing uplifts |
+| `request.body` | `%{request: %{body: %{speed: "fast"}}}` | Provider request body switches |
+| `request.headers` | `%{request: %{headers: %{"anthropic-beta" => "fast-mode-2026-02-01"}}}` | Provider beta/header switches |
+
+Keep component IDs unique. The current merge behavior uses `id`, so conditional
+variants should be named explicitly:
+
+- `token.input`
+- `token.input.long_context`
+- `token.input.batch`
+- `token.input.priority`
+- `token.cache_write.5m`
+- `token.cache_write.1h`
+- `pricing.data_residency`
+
+This avoids changing `merge_by_id` in the first implementation phase.
+
+## Reasoning Capability Extensions
+
+Extend the current reasoning schema from:
+
+```elixir
+%{enabled: true, token_budget: 10_000}
+```
+
+to:
+
+```elixir
+%{
+  enabled: true,
+  effort: %{
+    supported: true,
+    values: ["none", "low", "medium", "high", "xhigh"],
+    default: "medium"
+  },
+  thinking: %{
+    types: ["adaptive", "enabled"],
+    default_type: "adaptive",
+    disable_supported: false,
+    raw_output_supported: false,
+    summary_supported: true,
+    encrypted_supported: true
+  },
+  token_budget: %{
+    min: 1_024,
+    max: nil,
+    default: nil
+  }
+}
+```
+
+Notes:
+
+- OpenAI GPT-5.5 effort is a request control. It changes expected output token
+  usage and latency, but it does not publish separate per-effort token rates.
+- Anthropic Claude Fable 5 uses adaptive thinking as the only thinking mode and
+  publishes effort support in the Models API.
+- `token_budget` should stay backward compatible with the current integer form.
+  Loaders should accept both `token_budget: 10_000` and the richer map form.
+
+## Provider Examples
+
+### OpenAI GPT-5.5
+
+OpenAI's direct model endpoint supplies inventory, not pricing. Official OpenAI
+docs supply pricing, context tiers, service tiers, and reasoning behavior.
+
+Proposed capture:
+
+```elixir
+%{
+  cost: %{input: 5.0, output: 30.0, cache_read: 0.5},
+  limits: %{context: 1_050_000, input: 1_050_000, output: 128_000},
+  capabilities: %{
+    reasoning: %{
+      enabled: true,
+      effort: %{
+        supported: true,
+        values: ["none", "low", "medium", "high", "xhigh"],
+        default: "medium"
+      }
+    }
+  },
+  pricing: %{
+    components: [
+      %{id: "token.input", kind: "token", unit: "token", per: 1_000_000, rate: 5.0},
+      %{id: "token.output", kind: "token", unit: "token", per: 1_000_000, rate: 30.0},
+      %{id: "token.cache_read", kind: "token", unit: "token", per: 1_000_000, rate: 0.5},
+      %{
+        id: "token.input.long_context",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 10.0,
+        applies_when: %{input_tokens: %{gt: 272_000}}
+      },
+      %{
+        id: "token.output.long_context",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 45.0,
+        applies_when: %{input_tokens: %{gt: 272_000}}
+      },
+      %{
+        id: "token.input.priority",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 12.5,
+        applies_when: %{service_tier: "priority"}
+      }
+    ]
+  }
+}
+```
+
+The first implementation should not create separate pricing for each reasoning
+effort. It should expose effort values under capabilities and let consumers
+estimate cost from measured or expected output/reasoning token counts.
+
+### Anthropic Claude Fable 5
+
+Anthropic's direct Models API supplies the capability tree and token limits.
+Official Anthropic docs supply pricing.
+
+Proposed capture:
+
+```elixir
+%{
+  cost: %{input: 10.0, output: 50.0, cache_read: 1.0, cache_write: 12.5},
+  limits: %{context: 1_000_000, input: 1_000_000, output: 128_000},
+  capabilities: %{
+    reasoning: %{
+      enabled: true,
+      effort: %{
+        supported: true,
+        values: ["low", "medium", "high", "xhigh", "max"],
+        default: nil
+      },
+      thinking: %{
+        types: ["adaptive"],
+        default_type: "adaptive",
+        disable_supported: false,
+        raw_output_supported: false
+      }
+    },
+    batch: %{supported: true},
+    citations: %{supported: true},
+    code_execution: %{supported: true},
+    context_management: %{supported: true}
+  },
+  pricing: %{
+    components: [
+      %{id: "token.input", kind: "token", unit: "token", per: 1_000_000, rate: 10.0},
+      %{id: "token.output", kind: "token", unit: "token", per: 1_000_000, rate: 50.0},
+      %{id: "token.cache_read", kind: "token", unit: "token", per: 1_000_000, rate: 1.0},
+      %{
+        id: "token.cache_write.5m",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 12.5,
+        applies_when: %{cache_ttl: "5m"}
+      },
+      %{
+        id: "token.cache_write.1h",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 20.0,
+        applies_when: %{cache_ttl: "1h"}
+      },
+      %{
+        id: "token.input.batch",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 5.0,
+        applies_when: %{api: "batch"}
+      },
+      %{
+        id: "token.output.batch",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 25.0,
+        applies_when: %{api: "batch"}
+      },
+      %{
+        id: "pricing.data_residency",
+        kind: "other",
+        unit: "other",
+        multiplier: 1.1,
+        applies_when: %{inference_geo: true}
+      }
+    ]
+  }
+}
+```
+
+Do not add a Fable long-context premium component unless Anthropic publishes one.
+Current docs say the full 1M context window is standard pricing.
+
+## Pipeline Changes
+
+### 1. Source Pull
+
+- Keep existing remote cache behavior.
+- Do not hand-edit remote caches.
+- Treat provider APIs as authoritative for fields they publish.
+- Preserve raw provider capability trees in cache exactly as received.
+
+### 2. Source Transform
+
+Source modules should map provider API fields into the richer canonical shape:
+
+- Anthropic:
+  - `max_input_tokens` -> `limits.input` and `limits.context`
+  - `max_tokens` -> `limits.output`
+  - `capabilities.effort` -> `capabilities.reasoning.effort`
+  - `capabilities.thinking.types` -> `capabilities.reasoning.thinking`
+  - `batch`, `citations`, `code_execution`, `context_management` -> typed
+    `capabilities`
+  - Preserve original `capabilities` under `extra.provider_capabilities` until
+    coverage is complete.
+- OpenAI:
+  - Continue using `/v1/models` for inventory.
+  - Keep pricing/reasoning facts in curated local overlays sourced from official
+    OpenAI docs, because `/v1/models` does not publish those details.
+
+### 3. Normalize
+
+- Normalize nested map keys without atom leaks.
+- Accept both atom and string keys for new nested fields.
+- Normalize modality and capability enum values to strings or atoms according to
+  existing conventions, but avoid inventing atoms from untrusted runtime input.
+
+### 4. Validate
+
+Add optional Zoi schemas for:
+
+- `limits.input`
+- `capabilities.reasoning.effort`
+- `capabilities.reasoning.thinking`
+- richer `capabilities.batch`, `capabilities.citations`,
+  `capabilities.code_execution`, and `capabilities.context_management`
+- `pricing.components[].applies_when`
+- `pricing.components[].excludes_when`
+- `pricing.components[].multiplier`
+- `pricing.components[].source`
+
+Validation should remain permissive for unknown provider-specific condition keys
+inside `applies_when` so new provider pricing modes do not require immediate
+library releases.
+
+### 5. Merge
+
+- Keep current last-source-wins precedence.
+- Keep list merge behavior unless explicitly changed.
+- Preserve `cost` as flat standard pricing.
+- Merge `pricing.components` by `id` as today. Conditional variants should use
+  unique IDs.
+- Deep-merge nested capability maps so local curated docs can add defaults or
+  caveats without replacing provider API capability trees.
+
+### 6. Enrich
+
+- Continue synthesizing `pricing.components` from `cost`.
+- Only generate unconditional standard token components from `cost`.
+- Do not synthesize conditional components unless there is explicit provider
+  evidence.
+- Populate coarse booleans from rich capability maps:
+  - `capabilities.reasoning.enabled = true` when any effort/thinking support is
+    present.
+  - `capabilities.tools.enabled = true` remains independent of code execution or
+    provider-hosted tools.
+- Keep provider-level pricing defaults and merge them after model pricing.
+
+### 7. Snapshot Build
+
+- Generated `priv/llm_db/providers/*.json` and `priv/llm_db/snapshot.json`
+  should include optional fields only when present.
+- Old snapshots without new fields must load unchanged.
+- New snapshots should still include legacy `cost` where the provider publishes
+  simple standard token rates.
+
+### 8. Runtime Load
+
+- `LLMDB.Loader` should deserialize old and new shapes.
+- `LLMDB.Pricing.apply_cost_components/1` should remain idempotent and avoid
+  overwriting explicit conditional components.
+- Consumers should be able to ignore `applies_when` and still read base rates.
+
+### 9. Query Helpers
+
+After the data shape is stable, add optional helpers rather than forcing pricing
+calculation into the struct:
+
+```elixir
+LLMDB.Pricing.components_for(model,
+  api: "batch",
+  input_tokens: 900_000,
+  cache_ttl: "1h",
+  inference_geo: "us"
+)
+```
+
+This keeps `%LLMDB.Model{}` as metadata and lets billing logic evolve
+independently.
+
+## Backward Compatibility Plan
+
+1. Add new schema fields as optional.
+2. Keep `cost` and automatic `cost` -> `pricing.components` conversion.
+3. Keep old `token_budget` integer support while accepting the richer map.
+4. Keep `limits.context` as the primary broad context field.
+5. Keep `capabilities.reasoning.enabled` and existing capability booleans.
+6. Preserve unknown provider fields in `extra`.
+7. Use unique component IDs so existing `merge_by_id` remains valid.
+8. Avoid changing public APIs in the first implementation PR.
+9. Add tests that construct old-format models and new-format models through
+   `LLMDB.Model.new/1`, source transforms, snapshot loading, and runtime custom
+   providers.
+
+## Implementation Sequence
+
+Recommended PR breakdown:
+
+1. **Schema-only compatibility PR**
+   - Add optional Zoi schemas.
+   - Add loader support for old and new `token_budget`.
+   - Add tests showing old model maps still validate.
+2. **Pricing component condition PR**
+   - Add `applies_when`, `excludes_when`, `multiplier`, and `source`.
+   - Update pricing docs.
+   - Add component selection helper behind a new API.
+3. **Anthropic direct-source PR**
+   - Map the direct Models API capability tree.
+   - Preserve `extra.provider_capabilities`.
+   - Add Fable and Opus/Sonnet tests from cached API fixtures.
+4. **OpenAI curated overlay PR**
+   - Encode GPT-5.5 long-context, Batch, Flex, Priority, and data-residency
+     components from official OpenAI docs.
+   - Encode reasoning effort values/defaults from official OpenAI docs.
+5. **Anthropic pricing overlay PR**
+   - Encode cache TTL, Batch, data residency, and fast mode where officially
+     documented.
+   - Explicitly omit long-context premium for Fable unless docs change.
+6. **Consumer API PR**
+   - Add query helpers and examples for choosing active pricing components.
+   - Keep raw metadata access unchanged.
+
+## Acceptance Criteria
+
+- Existing consumers reading `model.cost`, `model.limits.context`,
+  `model.capabilities.reasoning.enabled`, and `model.pricing.components` continue
+  to work.
+- Old snapshots and custom provider maps load without migration steps.
+- Fable exposes effort and adaptive-thinking metadata from Anthropic's direct
+  Models API.
+- GPT-5.5 exposes long-context pricing without pretending reasoning effort has a
+  separate per-effort token rate.
+- Conditional pricing components can represent OpenAI context tiers and Anthropic
+  cache TTL/Batch/data-residency cases.
+- Provider docs and direct APIs remain the evidence source for OpenAI and
+  Anthropic changes.

--- a/guides/model-struct-evolution-proposal.md
+++ b/guides/model-struct-evolution-proposal.md
@@ -75,6 +75,8 @@ Official provider references used for this proposal:
 The implementation work should be planned around these existing boundaries:
 
 - `lib/llm_db/model.ex` owns the `LLMDB.Model` struct and nested Zoi schemas.
+- `lib/llm_db/provider.ex` owns provider-level `pricing_defaults`, which shares
+  the pricing component shape and must be updated with model-level pricing.
 - `lib/llm_db/pricing.ex` converts legacy `cost` maps into
   `pricing.components` and merges provider defaults at load time.
 - `lib/llm_db/sources/openai.ex` maps OpenAI's direct `/v1/models` inventory.
@@ -86,6 +88,17 @@ The implementation work should be planned around these existing boundaries:
   not be hand-edited.
 - `priv/llm_db/providers/*.json` and `priv/llm_db/snapshot.json` should remain
   generated artifacts.
+
+Important current behavior:
+
+- `Zoi.parse/2` currently drops unknown nested keys in schemas such as
+  `limits`, `capabilities.reasoning`, and `pricing.components`.
+- Sparse overlay validation also preserves only schema-known keys.
+- Therefore, the schema must be expanded before any source transform or local
+  TOML starts emitting new canonical fields, or the data can be silently lost.
+- Runtime pricing enrichment runs in `LLMDB.Loader` after packaged/custom models
+  are validated, so new pricing fields must validate before
+  `LLMDB.Pricing.apply_cost_components/1` sees them.
 
 ## Goals
 
@@ -175,14 +188,17 @@ existing nested maps instead of replacing them.
         kind: "token",
         unit: "token",
         per: 1_000_000,
-        rate: 20.0,
-        applies_when: %{cache_ttl: "1h"}
+        meter: "cache_write_tokens",
+        multiplier: 2.0,
+        derives_from: "token.input",
+        applies_when: %{cache_operation: "write", cache_ttl: "1h"}
       },
       %{
         id: "pricing.data_residency",
         kind: "other",
         unit: "other",
         multiplier: 1.1,
+        applies_to: ["token.*"],
         applies_when: %{inference_geo: true}
       }
     ]
@@ -219,10 +235,13 @@ Extend `pricing.components` with optional fields:
   per: 1_000_000,
   rate: 10.0,
   multiplier: nil,
+  derives_from: nil,
+  applies_to: nil,
   applies_when: %{input_tokens: %{gt: 272_000}},
   excludes_when: nil,
   meter: "input_tokens",
   mode: "standard",
+  charge_scope: "full_request",
   source: "provider_docs",
   notes: "OpenAI GPT-5.5 long-context input rate"
 }
@@ -231,13 +250,41 @@ Extend `pricing.components` with optional fields:
 Recommended semantics:
 
 - `rate` is an absolute price in `pricing.currency`.
-- `multiplier` is a factor applied to one or more matched components.
+- `multiplier` is a factor applied to one or more matched components, or a
+  factor used to derive this component from another component.
+- `derives_from` identifies a base component ID used to calculate this
+  component's rate. This is useful for prompt-cache write/read rates that are
+  published as a multiplier of the active input-token rate.
+- `applies_to` identifies component IDs or prefixes that a modifier component
+  affects. Entries match exact component IDs unless they end in `.*`; reserve
+  prefixes such as `"token.*"` for provider-wide multipliers.
 - `applies_when` is a provider-neutral condition map.
 - `excludes_when` is optional and should be rare; prefer positive selectors.
+- `charge_scope` distinguishes full-request tier pricing from marginal overage
+  pricing. Use `"full_request"` for provider rules where crossing a threshold
+  changes the rate for all request/session tokens, not just tokens over the
+  threshold.
 - `source` should identify the evidence layer, not a full citation system. Use
   values such as `"provider_api"`, `"provider_docs"`, `"local_override"`, or
   `"provider_default"`.
 - `notes` remains human-readable and non-authoritative.
+
+Component classes:
+
+- **Base rate components** have `rate` and no `applies_when`, such as
+  `token.input`.
+- **Conditional rate components** have `rate` and `applies_when`, such as
+  `token.input.long_context`.
+- **Derived rate components** have `derives_from` and `multiplier`, such as
+  Anthropic cache writes derived from the active input-token rate.
+- **Modifier components** have `multiplier` and `applies_to`, such as data
+  residency uplifts.
+
+Do not encode a stackable provider multiplier only as a fixed absolute rate
+unless every supported combination is enumerated. For example, Anthropic prompt
+cache TTL multipliers stack with Batch API discounts and data residency, so a
+1-hour cache write should be represented as `2.0 * active token.input`, not only
+as `$20 / MTok` for Claude Fable 5 standard requests.
 
 Recommended condition keys:
 
@@ -247,10 +294,11 @@ Recommended condition keys:
 | `service_tier` | `%{service_tier: "priority"}` | OpenAI Priority or other service tier rates |
 | `processing_mode` | `%{processing_mode: "flex"}` | Flex, background, or similar processing modes |
 | `input_tokens` | `%{input_tokens: %{gt: 272_000}}` | Long-context tiers |
+| `cache_operation` | `%{cache_operation: "write"}` | Cache read/write billing meters |
 | `cache_ttl` | `%{cache_ttl: "1h"}` | Prompt cache write duration |
 | `inference_geo` | `%{inference_geo: true}` | Data residency/regional processing uplifts |
-| `request.body` | `%{request: %{body: %{speed: "fast"}}}` | Provider request body switches |
-| `request.headers` | `%{request: %{headers: %{"anthropic-beta" => "fast-mode-2026-02-01"}}}` | Provider beta/header switches |
+| `request_body` | `%{request_body: %{speed: "fast"}}` | Provider request body switches |
+| `request_headers` | `%{request_headers: %{"anthropic-beta" => "fast-mode-2026-02-01"}}` | Provider beta/header switches |
 
 Keep component IDs unique. The current merge behavior uses `id`, so conditional
 variants should be named explicitly:
@@ -342,7 +390,8 @@ Proposed capture:
         unit: "token",
         per: 1_000_000,
         rate: 10.0,
-        applies_when: %{input_tokens: %{gt: 272_000}}
+        applies_when: %{input_tokens: %{gt: 272_000}},
+        charge_scope: "full_request"
       },
       %{
         id: "token.output.long_context",
@@ -350,7 +399,8 @@ Proposed capture:
         unit: "token",
         per: 1_000_000,
         rate: 45.0,
-        applies_when: %{input_tokens: %{gt: 272_000}}
+        applies_when: %{input_tokens: %{gt: 272_000}},
+        charge_scope: "full_request"
       },
       %{
         id: "token.input.priority",
@@ -406,20 +456,34 @@ Proposed capture:
       %{id: "token.output", kind: "token", unit: "token", per: 1_000_000, rate: 50.0},
       %{id: "token.cache_read", kind: "token", unit: "token", per: 1_000_000, rate: 1.0},
       %{
+        id: "token.cache_read.derived",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        meter: "cache_read_tokens",
+        multiplier: 0.1,
+        derives_from: "token.input",
+        applies_when: %{cache_operation: "read"}
+      },
+      %{
         id: "token.cache_write.5m",
         kind: "token",
         unit: "token",
         per: 1_000_000,
-        rate: 12.5,
-        applies_when: %{cache_ttl: "5m"}
+        meter: "cache_write_tokens",
+        multiplier: 1.25,
+        derives_from: "token.input",
+        applies_when: %{cache_operation: "write", cache_ttl: "5m"}
       },
       %{
         id: "token.cache_write.1h",
         kind: "token",
         unit: "token",
         per: 1_000_000,
-        rate: 20.0,
-        applies_when: %{cache_ttl: "1h"}
+        meter: "cache_write_tokens",
+        multiplier: 2.0,
+        derives_from: "token.input",
+        applies_when: %{cache_operation: "write", cache_ttl: "1h"}
       },
       %{
         id: "token.input.batch",
@@ -442,6 +506,7 @@ Proposed capture:
         kind: "other",
         unit: "other",
         multiplier: 1.1,
+        applies_to: ["token.*"],
         applies_when: %{inference_geo: true}
       }
     ]
@@ -498,6 +563,9 @@ Add optional Zoi schemas for:
 - `pricing.components[].applies_when`
 - `pricing.components[].excludes_when`
 - `pricing.components[].multiplier`
+- `pricing.components[].derives_from`
+- `pricing.components[].applies_to`
+- `pricing.components[].charge_scope`
 - `pricing.components[].source`
 
 Validation should remain permissive for unknown provider-specific condition keys
@@ -526,6 +594,9 @@ library releases.
   - `capabilities.tools.enabled = true` remains independent of code execution or
     provider-hosted tools.
 - Keep provider-level pricing defaults and merge them after model pricing.
+- Do not apply conditional pricing during enrichment. Enrichment should preserve
+  metadata; pricing selection belongs in an explicit helper or downstream
+  billing code.
 
 ### 7. Snapshot Build
 
@@ -534,6 +605,11 @@ library releases.
 - Old snapshots without new fields must load unchanged.
 - New snapshots should still include legacy `cost` where the provider publishes
   simple standard token rates.
+- Before publishing a snapshot that contains new canonical fields, test that the
+  minimum supported package version can either load the snapshot or fails with a
+  clear compatibility error. If older packages silently strip important fields,
+  add a snapshot metadata gate such as `min_reader_version` before publishing the
+  new shape through the public snapshot channel.
 
 ### 8. Runtime Load
 
@@ -541,6 +617,9 @@ library releases.
 - `LLMDB.Pricing.apply_cost_components/1` should remain idempotent and avoid
   overwriting explicit conditional components.
 - Consumers should be able to ignore `applies_when` and still read base rates.
+- Custom provider overlays must accept the new shape only after schema support is
+  in place; otherwise `validate_model_overlay/1` can strip the new fields before
+  merge.
 
 ### 9. Query Helpers
 
@@ -559,6 +638,10 @@ LLMDB.Pricing.components_for(model,
 This keeps `%LLMDB.Model{}` as metadata and lets billing logic evolve
 independently.
 
+The helper should return both selected components and unresolved modifiers when
+conditions are incomplete. Silent best guesses are worse than partial answers for
+billing.
+
 ## Backward Compatibility Plan
 
 1. Add new schema fields as optional.
@@ -572,6 +655,43 @@ independently.
 9. Add tests that construct old-format models and new-format models through
    `LLMDB.Model.new/1`, source transforms, snapshot loading, and runtime custom
    providers.
+10. Add regression tests proving unknown new fields are not stripped after the
+    schema PR lands.
+
+## Risk Register
+
+| Risk | Mitigation |
+| --- | --- |
+| New fields are emitted before schema support and silently stripped | Land schema and validation support before source/local overlay changes |
+| Conditional pricing is treated as marginal when provider docs mean full-request pricing | Capture `charge_scope` and test GPT-5.5 long-context selection |
+| Stackable modifiers are encoded as fixed rates | Use `derives_from`, `multiplier`, and `applies_to` for cache TTL and data residency cases |
+| Old consumers fetch new snapshots and lose important metadata | Add snapshot compatibility tests and a `min_reader_version` gate if needed |
+| Provider capability booleans become ambiguous | Preserve coarse booleans and add richer nested fields rather than replacing existing fields |
+| Provider docs change after metadata is encoded | Keep source URLs in local overlays or docs notes and make provider verification repeatable |
+| Atom leaks from provider-specific condition keys | Keep condition keys as strings unless they are part of a small canonical allowlist |
+
+## Test Matrix
+
+Implementation PRs should add coverage at these layers:
+
+- `LLMDB.Model.new/1` accepts old and new model maps.
+- `LLMDB.Provider.new/1` accepts provider pricing defaults with new component
+  fields.
+- `LLMDB.Validate.validate_model_overlay/1` preserves new sparse overlay fields.
+- `LLMDB.Sources.Anthropic.transform/1` maps direct API capabilities without
+  dropping raw provider capability data.
+- `LLMDB.Pricing.apply_cost_components/1` keeps legacy generated components and
+  preserves explicit conditional/derived components.
+- Snapshot load accepts old snapshots and new snapshots.
+- Runtime custom providers can define new pricing/capability fields.
+- Pricing helper selection handles:
+  - GPT-5.5 short-context standard pricing
+  - GPT-5.5 long-context full-request pricing
+  - GPT-5.5 Priority pricing
+  - Claude Fable 5 standard pricing
+  - Claude Fable 5 Batch pricing
+  - Claude Fable 5 1-hour cache write derived from active input rate
+  - data residency multiplier stacking
 
 ## Implementation Sequence
 

--- a/guides/model-struct-evolution-proposal.md
+++ b/guides/model-struct-evolution-proposal.md
@@ -4,7 +4,11 @@ This proposal describes how to evolve `%LLMDB.Model{}` and the build/runtime
 pipeline so LLMDB can represent provider-published conditional pricing and richer
 runtime capabilities without breaking existing consumers.
 
-Status: design proposal only. This is not the current runtime contract.
+Status: phase 1 implemented. The runtime contract now supports the additive
+schema fields described here for limits, pricing components, reasoning
+capabilities, provider capability groups, Anthropic direct-source mapping, and
+conditional pricing component selection. The OpenAI and Anthropic docs-sourced
+pricing overlays remain follow-up curation work.
 
 ## Why This Is Needed
 

--- a/guides/pricing-and-billing.md
+++ b/guides/pricing-and-billing.md
@@ -10,6 +10,8 @@ LLMDB provides a flexible pricing system that supports:
 - **Tool pricing** - Per-call fees for web search, code interpreter, file search, etc.
 - **Storage pricing** - Per-GB-day fees for file storage
 - **Image/media pricing** - Per-image or per-token fees for multimodal content
+- **Conditional pricing** - Context tiers, service tiers, Batch API discounts,
+  cache TTLs, and other provider-specific billing conditions
 
 The pricing system has two layers:
 
@@ -32,6 +34,14 @@ Each pricing component describes a single billable item with the following field
   meter: "input_tokens",       # Optional: billing meter name
   tool: "web_search",          # Optional: tool name (for kind: "tool")
   size_class: "1024x1024",     # Optional: size variant (for images)
+  multiplier: 1.1,             # Optional: multiplier for derived/modifier pricing
+  derives_from: "token.input", # Optional: base component for derived rates
+  applies_to: ["token.*"],     # Optional: component ids/prefixes affected by modifier
+  applies_when: %{api: "batch"},       # Optional: conditions that activate this component
+  excludes_when: %{region: "legacy"},  # Optional: conditions that suppress it
+  mode: "standard",            # Optional: provider/request mode label
+  charge_scope: "full_request",# Optional: full_request vs marginal semantics
+  source: "provider_docs",     # Optional: provider_api, provider_docs, local_override, ...
   notes: "Cached tokens"       # Optional: human-readable notes
 }
 ```
@@ -217,6 +227,33 @@ tool_components = Enum.filter(model.pricing.components, & &1.kind == "tool")
 # Check if model has web search pricing
 has_web_search = Enum.any?(model.pricing.components, & &1.tool == "web_search")
 ```
+
+### Select Conditional Components
+
+Use `LLMDB.Pricing.components_for/2` when pricing data includes `applies_when`
+or `excludes_when`. The helper selects components whose conditions are fully
+satisfied and returns unresolved components separately when the supplied context
+is incomplete.
+
+```elixir
+selection =
+  LLMDB.Pricing.components_for(model,
+    api: "batch",
+    input_tokens: 900_000,
+    cache_ttl: "1h",
+    inference_geo: "us"
+  )
+
+selection.components
+# => components that apply for this context
+
+selection.unresolved
+# => components that need more request context before they can be applied
+```
+
+The helper does not calculate invoices. It preserves the distinction between
+base rates, conditional rates, derived rates, and stackable modifiers so billing
+logic can make provider-specific choices explicitly.
 
 ### Calculate Costs
 

--- a/guides/pricing-and-billing.md
+++ b/guides/pricing-and-billing.md
@@ -371,4 +371,5 @@ model.pricing.components
 ## Next Steps
 
 - **[Schema System](schema-system.md)**: Full schema definitions including pricing
+- **[Model Struct Evolution Proposal](model-struct-evolution-proposal.md)**: Proposed conditional pricing extensions
 - **[Using the Data](using-the-data.md)**: Runtime API and queries

--- a/guides/schema-system.md
+++ b/guides/schema-system.md
@@ -353,6 +353,11 @@ Pricing per million tokens (USD):
 
 See `LLMDB.Schema.Cost`.
 
+For proposed additive schema changes that would capture conditional pricing,
+reasoning effort values, richer thinking modes, and provider-published capability
+trees while preserving `cost` compatibility, see the
+[Model Struct Evolution Proposal](model-struct-evolution-proposal.md).
+
 ## Validation APIs
 
 ### Batch Validation

--- a/guides/schema-system.md
+++ b/guides/schema-system.md
@@ -227,8 +227,10 @@ See [Consumer Integration Guide](consumer-integration.md) for detailed guidance 
 
 - `:modalities` (map, required) - Input/output modalities (see below)
 - `:capabilities` (map, required) - Feature capabilities (see below)
-- `:limits` (map, optional) - Context and output limits
-- `:cost` (map, optional) - Pricing information
+- `:limits` (map, optional) - Context, input, and output token limits
+- `:cost` (map, optional) - Legacy standard pricing information
+- `:pricing` (map, optional) - Component-based pricing, including conditional
+  provider pricing metadata
 
 ### Construction
 
@@ -248,6 +250,7 @@ model_data = %{
   },
   "limits" => %{
     "context" => 8192,
+    "input" => 8192,
     "output" => 4096
   }
 }
@@ -279,7 +282,17 @@ The capabilities schema uses granular nested objects to accurately represent rea
   "rerank" => false,
   "reasoning" => %{
     "enabled" => true,
-    "token_budget" => 10000
+    "effort" => %{
+      "supported" => true,
+      "values" => ["low", "medium", "high"],
+      "default" => "medium"
+    },
+    "thinking" => %{
+      "supported" => true,
+      "types" => ["adaptive"],
+      "default_type" => "adaptive"
+    },
+    "token_budget" => %{"min" => 0, "max" => 10000, "default" => 5000}
   },
   "tools" => %{
     "enabled" => true,
@@ -295,6 +308,13 @@ The capabilities schema uses granular nested objects to accurately represent rea
   "streaming" => %{
     "text" => true,
     "tool_calls" => true
+  },
+  "batch" => %{"supported" => true},
+  "citations" => %{"supported" => true},
+  "code_execution" => %{"supported" => true},
+  "context_management" => %{
+    "supported" => true,
+    "features" => ["clear_thinking", "compact"]
   }
 }
 ```
@@ -323,6 +343,7 @@ Defaults applied during Enrich stage: booleans default to `false`, optional valu
 ```elixir
 %{
   "context" => 128000,
+  "input" => 128000,
   "output" => 4096
 }
 ```
@@ -353,9 +374,9 @@ Pricing per million tokens (USD):
 
 See `LLMDB.Schema.Cost`.
 
-For proposed additive schema changes that would capture conditional pricing,
-reasoning effort values, richer thinking modes, and provider-published capability
-trees while preserving `cost` compatibility, see the
+For conditional pricing components and request-context selection, see
+[Pricing and Billing](pricing-and-billing.md). For the rationale behind the
+additive model shape, see the
 [Model Struct Evolution Proposal](model-struct-evolution-proposal.md).
 
 ## Validation APIs

--- a/lib/llm_db/engine/normalize.ex
+++ b/lib/llm_db/engine/normalize.ex
@@ -327,8 +327,6 @@ defmodule LLMDB.Normalize do
     Map.get(lifecycle, :status) || Map.get(lifecycle, "status")
   end
 
-  defp lifecycle_status_from_map(_), do: nil
-
   defp normalize_date_field(model, field) do
     if Map.has_key?(model, field) do
       case Map.get(model, field) do

--- a/lib/llm_db/engine/validate.ex
+++ b/lib/llm_db/engine/validate.ex
@@ -366,8 +366,6 @@ defmodule LLMDB.Validate do
       String.contains?(normalized_id, "whisper")
   end
 
-  defp explicit_transcription_model?(_model), do: false
-
   defp speech?(%Model{} = model) do
     exclusive_speech_model?(model) or explicit_speech_model?(model)
   end
@@ -386,8 +384,6 @@ defmodule LLMDB.Validate do
       String.contains?(normalized_id, "-tts")
   end
 
-  defp explicit_speech_model?(_model), do: false
-
   defp realtime?(%Model{provider: provider, id: id, extra: extra}) do
     extra_realtime? =
       case extra do
@@ -401,8 +397,6 @@ defmodule LLMDB.Validate do
     extra_realtime? or
       (provider == :openai and String.contains?(String.downcase(id), "realtime"))
   end
-
-  defp realtime?(_model), do: false
 
   defp exclusive_media_model?(%Model{} = model) do
     embeddings?(model) or image_generation?(model) or realtime?(model) or
@@ -565,7 +559,7 @@ defmodule LLMDB.Validate do
        when is_list(parsed_value) and is_list(raw_value) do
     if length(parsed_value) == length(raw_value) and
          Enum.all?(raw_value, &is_map/1) and
-         Enum.all?(parsed_value, &(is_map(&1) or is_struct(&1))) do
+         Enum.all?(parsed_value, &is_map/1) do
       Enum.zip(parsed_value, raw_value)
       |> Enum.map(fn {parsed_item, raw_item} ->
         sparse_overlay(parsed_item, raw_item, [])

--- a/lib/llm_db/enrich/runtime_contract.ex
+++ b/lib/llm_db/enrich/runtime_contract.ex
@@ -673,11 +673,12 @@ defmodule LLMDB.Enrich.RuntimeContract do
   defp text_input?(%Model{modalities: %{input: input}}) when is_list(input), do: :text in input
   defp text_input?(_model), do: false
 
-  defp text_output?(%Model{modalities: %{output: output}}) when is_list(output),
-    do: :text in output
-
-  defp text_output?(%Model{capabilities: %{chat: true}}), do: true
-  defp text_output?(_model), do: false
+  defp text_output?(%Model{} = model) do
+    case model.modalities do
+      %{output: output} when is_list(output) -> :text in output
+      _other -> chat_capability?(model)
+    end
+  end
 
   defp embedding_model?(%Model{modalities: %{output: output}}) when is_list(output),
     do: :embedding in output or :embeddings in output

--- a/lib/llm_db/history/backfill.ex
+++ b/lib/llm_db/history/backfill.ex
@@ -1280,8 +1280,6 @@ defmodule LLMDB.History.Backfill do
   defp canonical_sort_key(value) when is_atom(value), do: {1, Atom.to_string(value)}
   defp canonical_sort_key(value) when is_integer(value), do: {2, value}
   defp canonical_sort_key(value) when is_float(value), do: {3, value}
-  defp canonical_sort_key(value) when is_boolean(value), do: {4, value}
-  defp canonical_sort_key(nil), do: {5, nil}
   defp canonical_sort_key(value), do: {6, inspect(value)}
 
   defp commit_date_iso8601(sha) do

--- a/lib/llm_db/loader.ex
+++ b/lib/llm_db/loader.ex
@@ -254,8 +254,6 @@ defmodule LLMDB.Loader do
     end)
   end
 
-  defp deserialize_modality_list(other), do: other
-
   defp merge_custom({providers, models}, %{providers: [], models: []}) do
     # No custom overlay
     {providers, models}

--- a/lib/llm_db/model.ex
+++ b/lib/llm_db/model.ex
@@ -55,6 +55,7 @@ defmodule LLMDB.Model do
 
   @limits_schema Zoi.object(%{
                    context: Zoi.integer() |> Zoi.min(1) |> Zoi.nullish(),
+                   input: Zoi.integer() |> Zoi.min(1) |> Zoi.nullish(),
                    output: Zoi.integer() |> Zoi.min(1) |> Zoi.nullish()
                  })
 
@@ -103,6 +104,14 @@ defmodule LLMDB.Model do
                               meter: Zoi.string() |> Zoi.nullish(),
                               tool: Zoi.union([Zoi.atom(), Zoi.string()]) |> Zoi.nullish(),
                               size_class: Zoi.string() |> Zoi.nullish(),
+                              multiplier: Zoi.number() |> Zoi.nullish(),
+                              derives_from: Zoi.string() |> Zoi.nullish(),
+                              applies_to: Zoi.array(Zoi.string()) |> Zoi.nullish(),
+                              applies_when: Zoi.map() |> Zoi.nullish(),
+                              excludes_when: Zoi.map() |> Zoi.nullish(),
+                              mode: Zoi.string() |> Zoi.nullish(),
+                              charge_scope: Zoi.string() |> Zoi.nullish(),
+                              source: Zoi.string() |> Zoi.nullish(),
                               notes: Zoi.string() |> Zoi.nullish()
                             })
 
@@ -112,9 +121,35 @@ defmodule LLMDB.Model do
                     merge: Zoi.enum(["replace", "merge_by_id"]) |> Zoi.default("merge_by_id")
                   })
 
+  @token_budget_schema Zoi.object(%{
+                         min: Zoi.integer() |> Zoi.min(0) |> Zoi.nullish(),
+                         max: Zoi.integer() |> Zoi.min(0) |> Zoi.nullish(),
+                         default: Zoi.integer() |> Zoi.min(0) |> Zoi.nullish()
+                       })
+
+  @reasoning_effort_schema Zoi.object(%{
+                             supported: Zoi.boolean() |> Zoi.default(false),
+                             values: Zoi.array(Zoi.string()) |> Zoi.default([]),
+                             default: Zoi.string() |> Zoi.nullish()
+                           })
+
+  @reasoning_thinking_schema Zoi.object(%{
+                               supported: Zoi.boolean() |> Zoi.default(false),
+                               types: Zoi.array(Zoi.string()) |> Zoi.default([]),
+                               default_type: Zoi.string() |> Zoi.nullish(),
+                               disable_supported: Zoi.boolean() |> Zoi.nullish(),
+                               raw_output_supported: Zoi.boolean() |> Zoi.nullish(),
+                               summary_supported: Zoi.boolean() |> Zoi.nullish(),
+                               encrypted_supported: Zoi.boolean() |> Zoi.nullish()
+                             })
+
   @reasoning_schema Zoi.object(%{
                       enabled: Zoi.boolean() |> Zoi.nullish(),
-                      token_budget: Zoi.integer() |> Zoi.min(0) |> Zoi.nullish()
+                      effort: @reasoning_effort_schema |> Zoi.nullish(),
+                      thinking: @reasoning_thinking_schema |> Zoi.nullish(),
+                      token_budget:
+                        Zoi.union([Zoi.integer() |> Zoi.min(0), @token_budget_schema])
+                        |> Zoi.nullish()
                     })
 
   @tools_schema Zoi.object(%{
@@ -139,6 +174,11 @@ defmodule LLMDB.Model do
                       text: Zoi.boolean() |> Zoi.nullish(),
                       tool_calls: Zoi.boolean() |> Zoi.nullish()
                     })
+
+  @supported_feature_schema Zoi.object(%{
+                              supported: Zoi.boolean() |> Zoi.default(false),
+                              features: Zoi.array(Zoi.string()) |> Zoi.default([])
+                            })
 
   @lifecycle_schema Zoi.object(%{
                       status: Zoi.enum(["active", "deprecated", "retired"]) |> Zoi.nullish(),
@@ -192,7 +232,11 @@ defmodule LLMDB.Model do
                            |> Zoi.default(%{native: false, schema: false, strict: false}),
                          caching: @caching_schema |> Zoi.nullish(),
                          streaming:
-                           @streaming_schema |> Zoi.default(%{text: true, tool_calls: false})
+                           @streaming_schema |> Zoi.default(%{text: true, tool_calls: false}),
+                         batch: @supported_feature_schema |> Zoi.nullish(),
+                         citations: @supported_feature_schema |> Zoi.nullish(),
+                         code_execution: @supported_feature_schema |> Zoi.nullish(),
+                         context_management: @supported_feature_schema |> Zoi.nullish()
                        })
 
   @derive {Jason.Encoder,

--- a/lib/llm_db/pricing.ex
+++ b/lib/llm_db/pricing.ex
@@ -231,15 +231,13 @@ defmodule LLMDB.Pricing do
 
   defp conditions_status(nil, _context, :application), do: :match
   defp conditions_status(nil, _context, :exclusion), do: :no_match
+  defp conditions_status(conditions, _context, :application) when conditions == %{}, do: :match
+  defp conditions_status(conditions, _context, :exclusion) when conditions == %{}, do: :no_match
 
   defp conditions_status(conditions, context, _mode) when is_map(conditions) do
-    if map_size(conditions) == 0 do
-      :match
-    else
-      conditions
-      |> Enum.map(fn {key, expected} -> condition_status(key, expected, context) end)
-      |> merge_condition_statuses()
-    end
+    conditions
+    |> Enum.map(fn {key, expected} -> condition_status(key, expected, context) end)
+    |> merge_condition_statuses()
   end
 
   defp conditions_status(_conditions, _context, _mode), do: :unknown

--- a/lib/llm_db/pricing.ex
+++ b/lib/llm_db/pricing.ex
@@ -203,9 +203,11 @@ defmodule LLMDB.Pricing do
     |> Map.put(:components, merged_components)
   end
 
-  defp components_list(pricing) do
+  defp components_list(pricing) when is_map(pricing) do
     Map.get(pricing, :components) || Map.get(pricing, "components") || []
   end
+
+  defp components_list(_pricing), do: []
 
   defp component_status(component, context) do
     excludes_when = Map.get(component, :excludes_when) || Map.get(component, "excludes_when")
@@ -340,6 +342,7 @@ defmodule LLMDB.Pricing do
 
   defp context_map(context) when is_list(context), do: Map.new(context)
   defp context_map(context) when is_map(context), do: context
+  defp context_map(_context), do: %{}
 
   defp cost_components(cost) when is_map(cost) do
     []

--- a/lib/llm_db/pricing.ex
+++ b/lib/llm_db/pricing.ex
@@ -106,6 +106,38 @@ defmodule LLMDB.Pricing do
     end)
   end
 
+  @doc """
+  Selects pricing components that apply for a request context.
+
+  This helper does not calculate final cost. It separates components with fully
+  satisfied conditions from components that cannot be resolved because the
+  supplied context is incomplete.
+
+  ## Examples
+
+      iex> model = %{pricing: %{components: [
+      ...>   %{id: "token.input", rate: 5.0},
+      ...>   %{id: "token.input.long_context", rate: 10.0, applies_when: %{input_tokens: %{gt: 272_000}}}
+      ...> ]}}
+      iex> LLMDB.Pricing.components_for(model, input_tokens: 900_000).components |> Enum.map(& &1.id)
+      ["token.input", "token.input.long_context"]
+  """
+  @spec components_for(map(), map() | keyword()) :: %{components: [map()], unresolved: [map()]}
+  def components_for(model, context \\ %{}) when is_map(model) do
+    request_context = context_map(context)
+
+    model
+    |> Map.get(:pricing, Map.get(model, "pricing", %{}))
+    |> components_list()
+    |> Enum.reduce(%{components: [], unresolved: []}, fn component, acc ->
+      case component_status(component, request_context) do
+        :applies -> update_in(acc.components, &(&1 ++ [component]))
+        :unresolved -> update_in(acc.unresolved, &(&1 ++ [component]))
+        :excluded -> acc
+      end
+    end)
+  end
+
   defp apply_defaults_to_model(model, defaults) do
     case Map.get(model, :pricing) do
       nil -> Map.put(model, :pricing, defaults)
@@ -174,6 +206,140 @@ defmodule LLMDB.Pricing do
   defp components_list(pricing) do
     Map.get(pricing, :components) || Map.get(pricing, "components") || []
   end
+
+  defp component_status(component, context) do
+    excludes_when = Map.get(component, :excludes_when) || Map.get(component, "excludes_when")
+    applies_when = Map.get(component, :applies_when) || Map.get(component, "applies_when")
+
+    case conditions_status(excludes_when, context, :exclusion) do
+      :match ->
+        :excluded
+
+      :no_match ->
+        case conditions_status(applies_when, context, :application) do
+          :match -> :applies
+          :unknown -> :unresolved
+          :no_match -> :excluded
+        end
+
+      :unknown ->
+        :unresolved
+    end
+  end
+
+  defp conditions_status(nil, _context, :application), do: :match
+  defp conditions_status(nil, _context, :exclusion), do: :no_match
+
+  defp conditions_status(conditions, context, _mode) when is_map(conditions) do
+    if map_size(conditions) == 0 do
+      :match
+    else
+      conditions
+      |> Enum.map(fn {key, expected} -> condition_status(key, expected, context) end)
+      |> merge_condition_statuses()
+    end
+  end
+
+  defp conditions_status(_conditions, _context, _mode), do: :unknown
+
+  defp condition_status(key, expected, context) do
+    case fetch_context(context, key) do
+      {:ok, actual} -> expected_status(expected, actual)
+      :error -> :unknown
+    end
+  end
+
+  defp expected_status(expected, actual) when is_map(expected) and is_map(actual) do
+    if comparison_map?(expected) do
+      comparison_status(expected, actual)
+    else
+      expected
+      |> Enum.map(fn {key, nested_expected} -> condition_status(key, nested_expected, actual) end)
+      |> merge_condition_statuses()
+    end
+  end
+
+  defp expected_status(expected, actual) when is_map(expected) do
+    if comparison_map?(expected) do
+      comparison_status(expected, actual)
+    else
+      :no_match
+    end
+  end
+
+  defp expected_status(true, actual), do: truthy_status(actual)
+  defp expected_status(expected, actual), do: if(expected == actual, do: :match, else: :no_match)
+
+  defp comparison_map?(map) when is_map(map) do
+    map
+    |> Map.keys()
+    |> Enum.any?(&(&1 in [:gt, "gt", :gte, "gte", :lt, "lt", :lte, "lte"]))
+  end
+
+  defp comparison_status(comparisons, actual) when is_number(actual) do
+    comparisons
+    |> Enum.map(fn
+      {key, expected} when key in [:gt, "gt"] and is_number(expected) -> actual > expected
+      {key, expected} when key in [:gte, "gte"] and is_number(expected) -> actual >= expected
+      {key, expected} when key in [:lt, "lt"] and is_number(expected) -> actual < expected
+      {key, expected} when key in [:lte, "lte"] and is_number(expected) -> actual <= expected
+      _other -> :unknown
+    end)
+    |> bools_to_status()
+  end
+
+  defp comparison_status(_comparisons, _actual), do: :unknown
+
+  defp truthy_status(false), do: :no_match
+  defp truthy_status(nil), do: :unknown
+  defp truthy_status(_actual), do: :match
+
+  defp merge_condition_statuses(statuses) do
+    cond do
+      Enum.any?(statuses, &(&1 == :no_match)) -> :no_match
+      Enum.any?(statuses, &(&1 == :unknown)) -> :unknown
+      true -> :match
+    end
+  end
+
+  defp bools_to_status(results) do
+    cond do
+      Enum.any?(results, &(&1 == false)) -> :no_match
+      Enum.any?(results, &(&1 == :unknown)) -> :unknown
+      true -> :match
+    end
+  end
+
+  defp fetch_context(context, key) do
+    cond do
+      Map.has_key?(context, key) ->
+        {:ok, Map.get(context, key)}
+
+      is_atom(key) and Map.has_key?(context, Atom.to_string(key)) ->
+        {:ok, Map.get(context, Atom.to_string(key))}
+
+      is_binary(key) ->
+        atom_key = existing_atom(key)
+
+        if not is_nil(atom_key) and Map.has_key?(context, atom_key) do
+          {:ok, Map.get(context, atom_key)}
+        else
+          :error
+        end
+
+      true ->
+        :error
+    end
+  end
+
+  defp existing_atom(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp context_map(context) when is_list(context), do: Map.new(context)
+  defp context_map(context) when is_map(context), do: context
 
   defp cost_components(cost) when is_map(cost) do
     []

--- a/lib/llm_db/provider.ex
+++ b/lib/llm_db/provider.ex
@@ -73,6 +73,14 @@ defmodule LLMDB.Provider do
                               meter: Zoi.string() |> Zoi.nullish(),
                               tool: Zoi.union([Zoi.atom(), Zoi.string()]) |> Zoi.nullish(),
                               size_class: Zoi.string() |> Zoi.nullish(),
+                              multiplier: Zoi.number() |> Zoi.nullish(),
+                              derives_from: Zoi.string() |> Zoi.nullish(),
+                              applies_to: Zoi.array(Zoi.string()) |> Zoi.nullish(),
+                              applies_when: Zoi.map() |> Zoi.nullish(),
+                              excludes_when: Zoi.map() |> Zoi.nullish(),
+                              mode: Zoi.string() |> Zoi.nullish(),
+                              charge_scope: Zoi.string() |> Zoi.nullish(),
+                              source: Zoi.string() |> Zoi.nullish(),
                               notes: Zoi.string() |> Zoi.nullish()
                             })
 

--- a/lib/llm_db/snapshot.ex
+++ b/lib/llm_db/snapshot.ex
@@ -296,7 +296,7 @@ defmodule LLMDB.Snapshot do
     value
     |> Enum.sort_by(fn {key, _nested} -> key end)
     |> Enum.map(fn {key, nested} -> {key, canonical_json_map(nested)} end)
-    |> Map.new()
+    |> Jason.OrderedObject.new()
   end
 
   defp canonical_json_map(value) when is_list(value), do: Enum.map(value, &canonical_json_map/1)

--- a/lib/llm_db/sources/anthropic.ex
+++ b/lib/llm_db/sources/anthropic.ex
@@ -37,6 +37,8 @@ defmodule LLMDB.Sources.Anthropic do
   @default_url "https://api.anthropic.com/v1/models"
   @default_cache_dir "priv/llm_db/remote"
   @default_version "2023-06-01"
+  @effort_order ~w[low medium high xhigh max]
+  @thinking_type_order ~w[disabled enabled adaptive]
 
   @impl true
   def pull(opts) do
@@ -183,6 +185,7 @@ defmodule LLMDB.Sources.Anthropic do
     limits =
       %{}
       |> put_if_valid_limit(:context, source["max_input_tokens"])
+      |> put_if_valid_limit(:input, source["max_input_tokens"])
       |> put_if_valid_limit(:output, source["max_tokens"])
 
     if map_size(limits) > 0 do
@@ -208,13 +211,29 @@ defmodule LLMDB.Sources.Anthropic do
       %{}
       |> maybe_put_capability(
         :reasoning,
-        %{enabled: true},
-        supported?(capabilities, "thinking")
+        reasoning_capability(capabilities),
+        reasoning_supported?(capabilities)
       )
       |> maybe_put_capability(
         :json,
         %{schema: true},
         supported?(capabilities, "structured_outputs")
+      )
+      |> maybe_put_capability(:batch, %{supported: true}, supported?(capabilities, "batch"))
+      |> maybe_put_capability(
+        :citations,
+        %{supported: true},
+        supported?(capabilities, "citations")
+      )
+      |> maybe_put_capability(
+        :code_execution,
+        %{supported: true},
+        supported?(capabilities, "code_execution")
+      )
+      |> maybe_put_capability(
+        :context_management,
+        context_management_capability(capabilities["context_management"]),
+        supported?(capabilities, "context_management")
       )
 
     if map_size(canonical) > 0 do
@@ -231,6 +250,7 @@ defmodule LLMDB.Sources.Anthropic do
       source
       |> Map.drop(@mapped_fields)
       |> Enum.reduce(%{}, fn {k, v}, acc -> Map.put(acc, String.to_atom(k), v) end)
+      |> put_if_present(:provider_capabilities, source["capabilities"])
 
     if map_size(extra) > 0 do
       Map.put(model, :extra, extra)
@@ -262,6 +282,86 @@ defmodule LLMDB.Sources.Anthropic do
   defp supported?(capabilities, name) do
     match?(%{"supported" => true}, Map.get(capabilities, name))
   end
+
+  defp reasoning_supported?(capabilities) do
+    supported?(capabilities, "effort") or supported?(capabilities, "thinking")
+  end
+
+  defp reasoning_capability(capabilities) do
+    %{
+      enabled: true
+    }
+    |> maybe_put(:effort, effort_capability(capabilities["effort"]))
+    |> maybe_put(:thinking, thinking_capability(capabilities["thinking"]))
+  end
+
+  defp effort_capability(effort) when is_map(effort) do
+    values = supported_child_names(effort, @effort_order)
+
+    if supported?(%{"effort" => effort}, "effort") or values != [] do
+      %{supported: true, values: values}
+    end
+  end
+
+  defp effort_capability(_effort), do: nil
+
+  defp thinking_capability(thinking) when is_map(thinking) do
+    types = supported_child_names(thinking["types"], @thinking_type_order)
+
+    if supported?(%{"thinking" => thinking}, "thinking") or types != [] do
+      %{
+        supported: true,
+        types: types,
+        default_type: default_thinking_type(types),
+        disable_supported: "disabled" in types,
+        raw_output_supported: supported?(thinking, "raw_output"),
+        summary_supported: supported?(thinking, "summary"),
+        encrypted_supported: supported?(thinking, "encrypted")
+      }
+    end
+  end
+
+  defp thinking_capability(_thinking), do: nil
+
+  defp context_management_capability(context_management) when is_map(context_management) do
+    features =
+      context_management
+      |> supported_child_names([])
+      |> Enum.map(&strip_feature_date_suffix/1)
+      |> Enum.uniq()
+
+    %{supported: true, features: features}
+  end
+
+  defp context_management_capability(_context_management), do: %{supported: true}
+
+  defp supported_child_names(children, preferred_order) when is_map(children) do
+    supported =
+      children
+      |> Enum.reject(fn {key, _value} -> key == "supported" end)
+      |> Enum.filter(fn {_key, value} -> match?(%{"supported" => true}, value) end)
+      |> Enum.map(fn {key, _value} -> key end)
+
+    ordered = Enum.filter(preferred_order, &(&1 in supported))
+    extras = supported |> Enum.reject(&(&1 in ordered)) |> Enum.sort()
+
+    ordered ++ extras
+  end
+
+  defp supported_child_names(_children, _preferred_order), do: []
+
+  defp default_thinking_type(types) do
+    cond do
+      "adaptive" in types -> "adaptive"
+      types != [] -> hd(types)
+      true -> nil
+    end
+  end
+
+  defp strip_feature_date_suffix(feature), do: String.replace(feature, ~r/_\d{8}$/, "")
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp fetch_all_pages(url, req_opts, limit, acc) do
     params = [limit: limit]

--- a/lib/llm_db/sources/xai.ex
+++ b/lib/llm_db/sources/xai.ex
@@ -264,6 +264,7 @@ defmodule LLMDB.Sources.XAI do
 
   defp token_price(nil), do: nil
   defp token_price(price) when is_number(price), do: price / 10_000
+  defp token_price(_price), do: nil
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/test/llm_db/engine/validate_test.exs
+++ b/test/llm_db/engine/validate_test.exs
@@ -496,6 +496,48 @@ defmodule LLMDB.Engine.ValidateTest do
     end
   end
 
+  describe "validate_model_overlay/1" do
+    test "preserves sparse extended pricing and capability fields" do
+      input = %{
+        id: "claude-fable-5",
+        provider: :anthropic,
+        limits: %{input: 1_000_000},
+        capabilities: %{
+          reasoning: %{
+            effort: %{supported: true, values: ["low", "medium", "high"]},
+            thinking: %{supported: true, types: ["adaptive"], default_type: "adaptive"}
+          },
+          context_management: %{supported: true, features: ["compact"]}
+        },
+        pricing: %{
+          components: [
+            %{
+              id: "token.cache_write.1h",
+              kind: "token",
+              unit: "token",
+              per: 1_000_000,
+              multiplier: 2.0,
+              derives_from: "token.input",
+              applies_when: %{cache_operation: "write", cache_ttl: "1h"}
+            }
+          ]
+        }
+      }
+
+      assert {:ok, overlay} = Validate.validate_model_overlay(input)
+
+      assert overlay.limits == %{input: 1_000_000}
+      assert overlay.capabilities.reasoning.effort.values == ["low", "medium", "high"]
+      assert overlay.capabilities.reasoning.thinking.default_type == "adaptive"
+      assert overlay.capabilities.context_management.features == ["compact"]
+
+      [component] = overlay.pricing.components
+      assert component.multiplier == 2.0
+      assert component.derives_from == "token.input"
+      assert component.applies_when == %{cache_operation: "write", cache_ttl: "1h"}
+    end
+  end
+
   describe "ensure_viable/2" do
     test "returns :ok with non-empty providers and models" do
       providers = [%{id: :test_provider_alpha}]

--- a/test/llm_db/loader_compatibility_test.exs
+++ b/test/llm_db/loader_compatibility_test.exs
@@ -1,0 +1,82 @@
+defmodule LLMDB.LoaderCompatibilityTest do
+  use ExUnit.Case, async: true
+
+  alias LLMDB.{Loader, Snapshot}
+
+  test "loads old v2 snapshots with legacy cost and reasoning token budgets" do
+    snapshot_path = legacy_snapshot_path()
+
+    on_exit(fn ->
+      File.rm_rf!(snapshot_path)
+    end)
+
+    assert {:ok, loaded} =
+             Loader.load(
+               snapshot_source: {:file, snapshot_path},
+               allow: :all,
+               deny: %{},
+               prefer: [],
+               custom: %{}
+             )
+
+    [model] = loaded.models.test_provider_alpha
+    components = Map.new(model.pricing.components, &{&1.id, &1})
+
+    assert model.id == "legacy-model"
+    assert model.provider == :test_provider_alpha
+    assert model.limits.context == 128_000
+    assert model.limits.output == 4_096
+    refute Map.has_key?(model.limits, :input)
+    assert model.capabilities.reasoning.enabled == true
+    assert model.capabilities.reasoning.token_budget == 4_096
+    assert model.cost.input == 1.0
+    assert model.cost.output == 2.0
+    assert components["token.input"].rate == 1.0
+    assert components["token.output"].rate == 2.0
+  end
+
+  defp legacy_snapshot_path do
+    snapshot_path =
+      Path.join(
+        System.tmp_dir!(),
+        "llm_db-legacy-snapshot-#{System.unique_integer([:positive])}.json"
+      )
+
+    snapshot =
+      %{
+        "schema_version" => 1,
+        "version" => 2,
+        "generated_at" => "2026-01-01T00:00:00Z",
+        "providers" => %{
+          "test_provider_alpha" => %{
+            "id" => "test_provider_alpha",
+            "name" => "Test Provider Alpha",
+            "models" => %{
+              "legacy-model" => %{
+                "id" => "legacy-model",
+                "provider" => "test_provider_alpha",
+                "limits" => %{
+                  "context" => 128_000,
+                  "output" => 4_096
+                },
+                "cost" => %{
+                  "input" => 1.0,
+                  "output" => 2.0
+                },
+                "capabilities" => %{
+                  "reasoning" => %{
+                    "enabled" => true,
+                    "token_budget" => 4_096
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      |> then(fn snapshot -> Map.put(snapshot, "snapshot_id", Snapshot.snapshot_id(snapshot)) end)
+
+    Snapshot.write!(snapshot_path, snapshot)
+    snapshot_path
+  end
+end

--- a/test/llm_db/pricing_test.exs
+++ b/test/llm_db/pricing_test.exs
@@ -149,6 +149,14 @@ defmodule LLMDB.PricingTest do
     assert [%{id: "token.output"}] = updated.pricing.components
   end
 
+  test "components_for returns an empty selection when pricing is missing" do
+    assert %{components: [], unresolved: []} =
+             Pricing.components_for(%LLMDB.Model{id: "m1", provider: :test})
+
+    assert %{components: [], unresolved: []} = Pricing.components_for(%{pricing: nil})
+    assert %{components: [], unresolved: []} = Pricing.components_for(%{}, nil)
+  end
+
   test "components_for selects matching components and reports incomplete conditions" do
     model = %{
       pricing: %{

--- a/test/llm_db/pricing_test.exs
+++ b/test/llm_db/pricing_test.exs
@@ -42,6 +42,34 @@ defmodule LLMDB.PricingTest do
     assert output.rate == 3.0
   end
 
+  test "preserves explicit conditional components when converting legacy cost" do
+    model = %LLMDB.Model{
+      id: "m1",
+      provider: :test,
+      cost: %{input: 5.0},
+      pricing: %{
+        components: [
+          %{
+            id: "token.input.long_context",
+            kind: "token",
+            unit: "token",
+            per: 1_000_000,
+            rate: 10.0,
+            applies_when: %{input_tokens: %{gt: 272_000}},
+            charge_scope: "full_request"
+          }
+        ]
+      }
+    }
+
+    [updated] = Pricing.apply_cost_components([model])
+    components = Map.new(updated.pricing.components, &{&1.id, &1})
+
+    assert components["token.input"].rate == 5.0
+    assert components["token.input.long_context"].applies_when.input_tokens.gt == 272_000
+    assert components["token.input.long_context"].charge_scope == "full_request"
+  end
+
   test "applies provider defaults when model has no pricing" do
     provider = %LLMDB.Provider{
       id: :test,
@@ -119,5 +147,54 @@ defmodule LLMDB.PricingTest do
     [updated] = Pricing.apply_provider_defaults([provider], [model])
 
     assert [%{id: "token.output"}] = updated.pricing.components
+  end
+
+  test "components_for selects matching components and reports incomplete conditions" do
+    model = %{
+      pricing: %{
+        components: [
+          %{id: "token.input", kind: "token", rate: 5.0},
+          %{
+            id: "token.input.long_context",
+            kind: "token",
+            rate: 10.0,
+            applies_when: %{input_tokens: %{gt: 272_000}}
+          },
+          %{
+            id: "token.input.batch",
+            kind: "token",
+            rate: 2.5,
+            applies_when: %{api: "batch"}
+          },
+          %{
+            id: "pricing.data_residency",
+            kind: "other",
+            multiplier: 1.1,
+            applies_to: ["token.*"],
+            applies_when: %{inference_geo: true}
+          }
+        ]
+      }
+    }
+
+    result = Pricing.components_for(model, input_tokens: 900_000)
+
+    assert Enum.map(result.components, & &1.id) == ["token.input", "token.input.long_context"]
+    assert Enum.map(result.unresolved, & &1.id) == ["token.input.batch", "pricing.data_residency"]
+  end
+
+  test "components_for respects excludes_when" do
+    model = %{
+      pricing: %{
+        components: [
+          %{id: "tool.web_search", kind: "tool", excludes_when: %{api: "batch"}}
+        ]
+      }
+    }
+
+    assert %{components: [], unresolved: []} = Pricing.components_for(model, api: "batch")
+
+    assert %{components: [%{id: "tool.web_search"}], unresolved: []} =
+             Pricing.components_for(model, api: "responses")
   end
 end

--- a/test/llm_db/pricing_test.exs
+++ b/test/llm_db/pricing_test.exs
@@ -205,4 +205,18 @@ defmodule LLMDB.PricingTest do
     assert %{components: [%{id: "tool.web_search"}], unresolved: []} =
              Pricing.components_for(model, api: "responses")
   end
+
+  test "components_for treats empty condition maps as absent conditions" do
+    model = %{
+      pricing: %{
+        components: [
+          %{id: "token.input", applies_when: %{}},
+          %{id: "token.output", excludes_when: %{}}
+        ]
+      }
+    }
+
+    assert %{components: components, unresolved: []} = Pricing.components_for(model)
+    assert Enum.map(components, & &1.id) == ["token.input", "token.output"]
+  end
 end

--- a/test/llm_db/schema/model_test.exs
+++ b/test/llm_db/schema/model_test.exs
@@ -107,6 +107,72 @@ defmodule LLMDB.Schema.ModelTest do
       assert result.execution.text.wire_protocol == "openai_chat"
       assert result.execution.text.transport == "http_request"
     end
+
+    test "parses extended limits, capabilities, and pricing component metadata" do
+      input = %{
+        id: "gpt-5.5",
+        provider: :openai,
+        limits: %{context: 1_050_000, input: 1_050_000, output: 128_000},
+        capabilities: %{
+          reasoning: %{
+            enabled: true,
+            effort: %{supported: true, values: ["none", "low", "medium"], default: "medium"},
+            thinking: %{
+              supported: true,
+              types: ["adaptive"],
+              default_type: "adaptive",
+              disable_supported: false,
+              raw_output_supported: false
+            },
+            token_budget: %{min: 0, max: 128_000, default: 16_000}
+          },
+          batch: %{supported: true},
+          citations: %{supported: true},
+          code_execution: %{supported: true},
+          context_management: %{supported: true, features: ["compact"]}
+        },
+        pricing: %{
+          currency: "USD",
+          components: [
+            %{
+              id: "token.input.long_context",
+              kind: "token",
+              unit: "token",
+              per: 1_000_000,
+              rate: 10.0,
+              multiplier: 2.0,
+              derives_from: "token.input",
+              applies_to: ["token.*"],
+              applies_when: %{input_tokens: %{gt: 272_000}},
+              excludes_when: %{api: "batch"},
+              mode: "standard",
+              charge_scope: "full_request",
+              source: "provider_docs",
+              notes: "Long-context tier"
+            }
+          ]
+        }
+      }
+
+      assert {:ok, result} = Model.new(input)
+
+      assert result.limits.input == 1_050_000
+      assert result.capabilities.reasoning.effort.values == ["none", "low", "medium"]
+      assert result.capabilities.reasoning.effort.default == "medium"
+      assert result.capabilities.reasoning.thinking.types == ["adaptive"]
+      assert result.capabilities.reasoning.token_budget.max == 128_000
+      assert result.capabilities.batch.supported == true
+      assert result.capabilities.context_management.features == ["compact"]
+
+      [component] = result.pricing.components
+      assert component.applies_when.input_tokens.gt == 272_000
+      assert component.excludes_when.api == "batch"
+      assert component.multiplier == 2.0
+      assert component.derives_from == "token.input"
+      assert component.applies_to == ["token.*"]
+      assert component.charge_scope == "full_request"
+      assert component.source == "provider_docs"
+    end
   end
 
   describe "defaults" do

--- a/test/llm_db/schema/provider_test.exs
+++ b/test/llm_db/schema/provider_test.exs
@@ -79,6 +79,36 @@ defmodule LLMDB.Schema.ProviderTest do
       assert {:ok, result} = Provider.new(input)
       assert result.runtime.auth.type == "bearer"
     end
+
+    test "parses pricing defaults with conditional component metadata" do
+      input = %{
+        id: :anthropic,
+        pricing_defaults: %{
+          currency: "USD",
+          components: [
+            %{
+              id: "pricing.data_residency",
+              kind: "other",
+              unit: "other",
+              multiplier: 1.1,
+              applies_to: ["token.*"],
+              applies_when: %{inference_geo: true},
+              charge_scope: "full_request",
+              source: "provider_docs"
+            }
+          ]
+        }
+      }
+
+      assert {:ok, result} = Provider.new(input)
+
+      [component] = result.pricing_defaults.components
+      assert component.multiplier == 1.1
+      assert component.applies_to == ["token.*"]
+      assert component.applies_when.inference_geo == true
+      assert component.charge_scope == "full_request"
+      assert component.source == "provider_docs"
+    end
   end
 
   describe "optional fields" do

--- a/test/llm_db/snapshot_test.exs
+++ b/test/llm_db/snapshot_test.exs
@@ -3,6 +3,20 @@ defmodule LLMDB.SnapshotTest do
 
   alias LLMDB.{Model, Provider, Snapshot}
 
+  test "encodes nested maps with stable sorted key order" do
+    encoded = Snapshot.encode(%{"b" => %{"d" => 1, "c" => 2}, "a" => 1})
+
+    assert [
+             "{",
+             "  \"a\": 1,",
+             "  \"b\": {",
+             "    \"c\": 2,",
+             "    \"d\": 1",
+             "  }",
+             "}"
+           ] = String.split(encoded, "\n", trim: true)
+  end
+
   test "omits empty runtime migration fields from snapshot output" do
     provider =
       Provider.new!(%{

--- a/test/llm_db/sources/anthropic_test.exs
+++ b/test/llm_db/sources/anthropic_test.exs
@@ -15,10 +15,33 @@ defmodule LLMDB.Sources.AnthropicTest do
             "max_input_tokens" => 1_000_000,
             "max_tokens" => 128_000,
             "capabilities" => %{
+              "batch" => %{"supported" => true},
+              "citations" => %{"supported" => true},
+              "code_execution" => %{"supported" => true},
+              "context_management" => %{
+                "clear_thinking_20251015" => %{"supported" => true},
+                "clear_tool_uses_20250919" => %{"supported" => true},
+                "compact_20260112" => %{"supported" => true},
+                "supported" => true
+              },
+              "effort" => %{
+                "high" => %{"supported" => true},
+                "low" => %{"supported" => true},
+                "max" => %{"supported" => true},
+                "medium" => %{"supported" => true},
+                "supported" => true,
+                "xhigh" => %{"supported" => true}
+              },
               "image_input" => %{"supported" => true},
               "pdf_input" => %{"supported" => true},
               "structured_outputs" => %{"supported" => true},
-              "thinking" => %{"supported" => true}
+              "thinking" => %{
+                "supported" => true,
+                "types" => %{
+                  "adaptive" => %{"supported" => true},
+                  "enabled" => %{"supported" => false}
+                }
+              }
             }
           }
         ]
@@ -30,11 +53,34 @@ defmodule LLMDB.Sources.AnthropicTest do
       assert model.provider == :anthropic
       assert model.name == "Claude Opus 4.8"
       assert model.release_date == "2026-05-28"
-      assert model.limits == %{context: 1_000_000, output: 128_000}
+      assert model.limits == %{context: 1_000_000, input: 1_000_000, output: 128_000}
       assert model.modalities == %{input: [:text, :image, :pdf], output: [:text]}
       assert model.capabilities.reasoning.enabled == true
+
+      assert model.capabilities.reasoning.effort.values == [
+               "low",
+               "medium",
+               "high",
+               "xhigh",
+               "max"
+             ]
+
+      assert model.capabilities.reasoning.thinking.types == ["adaptive"]
+      assert model.capabilities.reasoning.thinking.default_type == "adaptive"
+      assert model.capabilities.reasoning.thinking.disable_supported == false
       assert model.capabilities.json.schema == true
+      assert model.capabilities.batch.supported == true
+      assert model.capabilities.citations.supported == true
+      assert model.capabilities.code_execution.supported == true
+
+      assert model.capabilities.context_management.features == [
+               "clear_thinking",
+               "clear_tool_uses",
+               "compact"
+             ]
+
       assert model.extra.type == "model"
+      assert model.extra.provider_capabilities["effort"]["max"]["supported"] == true
 
       assert {:ok, validated} = Validate.validate_model_overlay(model)
       assert validated.limits == model.limits


### PR DESCRIPTION
## Description

Implements the first backward-compatible phase of the `%LLMDB.Model{}` evolution for conditional pricing and richer capability metadata.

This PR now includes:
- additive model/provider schema support for `limits.input`, pricing component conditions/modifiers, richer reasoning metadata, and provider capability groups
- `LLMDB.Pricing.components_for/2` for conservative request-context component selection with unresolved conditional components reported separately
- nil-safe pricing component selection so existing `%LLMDB.Model{pricing: nil}` values keep behaving safely
- Anthropic direct Models API mapping for input limits, effort levels, thinking modes, batch/citations/code execution/context management, and raw capability preservation under `extra.provider_capabilities`
- regenerated packaged snapshot data reflecting richer Anthropic metadata, including Claude Fable 5
- deterministic snapshot JSON encoding via `Jason.OrderedObject`, so regenerated snapshots keep stable sorted key order
- docs updated from proposal-only to phase 1 implemented contract notes
- focused regression coverage for schema parsing, sparse overlays, provider defaults, old snapshot loading, Anthropic transform, pricing selection, and snapshot encoding
- low-risk warning cleanup needed to make the repo's warnings-as-errors quality gate pass

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None intended. The changes are additive and keep legacy `cost`, existing pricing components, old integer `reasoning.token_budget`, `pricing: nil`, and `limits.context` behavior intact.

## Testing

- [x] `mix format --check-formatted`
- [x] `git diff --check`
- [x] `MIX_ENV=prod mix llm_db.build --check --install`
- [x] `mix llm_db.build --check --install` in a clean validation clone
- [x] `mix test` - 764 passed, including 41 doctests
- [x] `MIX_ENV=test mix quality`
- [x] `mix quality` in a clean validation clone
- [x] pre-push hook passed (`test` + `quality`) before force-with-lease push

## Notes

OpenAI and Anthropic docs-sourced pricing overlays remain follow-up curation work. This PR lands the schema, validation, source transform, helper, snapshot, and test support needed before those richer pricing facts can be represented without being stripped.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
- [x] I have **NOT** directly edited generated snapshot/history artifacts unless this PR intentionally regenerates them (`priv/llm_db/snapshot.json`, `priv/llm_db/history/**`)

## Related Issues

None.