### PR TITLE
[codex] Preserve models.dev provider API URLs

### DIFF
--- a/lib/llm_db/sources/models_dev.ex
+++ b/lib/llm_db/sources/models_dev.ex
@@ -390,7 +390,10 @@ defmodule LLMDB.Sources.ModelsDev do
     content
     |> Enum.reduce(%{}, fn {provider_id, provider_data}, acc ->
       # Convert provider string keys to atom keys (keep models for now)
-      provider_atomized = atomize_keys(provider_data, [:id, :name, :env, :doc])
+      provider_atomized =
+        provider_data
+        |> atomize_keys([:id, :name, :env, :doc])
+        |> map_provider_base_url(provider_data)
 
       # Extract models from nested map and convert to list
       models_map = Map.get(provider_data, "models", %{})
@@ -423,4 +426,10 @@ defmodule LLMDB.Sources.ModelsDev do
       end
     end)
   end
+
+  defp map_provider_base_url(provider, %{"api" => api}) when is_binary(api) do
+    Map.put(provider, :base_url, api)
+  end
+
+  defp map_provider_base_url(provider, _provider_data), do: provider
 end

--- a/test/llm_db/sources/models_dev_test.exs
+++ b/test/llm_db/sources/models_dev_test.exs
@@ -28,6 +28,7 @@ defmodule LLMDB.Sources.ModelsDevTest do
       # models.dev format: providers as top-level keys with nested models
       body = %{
         "openai" => %{
+          "api" => "https://api.openai.example/v1",
           "id" => "openai",
           "name" => "OpenAI",
           "models" => %{
@@ -110,6 +111,7 @@ defmodule LLMDB.Sources.ModelsDevTest do
       # Create cache file in models.dev format
       cache_data = %{
         "openai" => %{
+          "api" => "https://api.openai.example/v1",
           "id" => "openai",
           "name" => "OpenAI",
           "models" => %{
@@ -134,6 +136,7 @@ defmodule LLMDB.Sources.ModelsDevTest do
       provider = data["openai"]
       assert provider[:id] == "openai"
       assert provider[:name] == "OpenAI"
+      assert provider[:base_url] == "https://api.openai.example/v1"
       assert is_list(provider[:models])
       assert length(provider[:models]) == 1
       assert hd(provider[:models])[:id] == "gpt-4o"


### PR DESCRIPTION
## Summary
- Map provider-level `api` from models.dev into canonical `base_url`.
- Preserve MiniMax Token Plan endpoint metadata in the generated snapshot.
- Add a regression assertion for models.dev provider API URL mapping.

## Evidence
- MiniMax Token Plan docs: https://platform.minimax.io/docs/token-plan/intro
- MiniMax model invocation docs show `https://api.minimax.io/anthropic` and `https://api.minimax.io/v1` base URLs: https://platform.minimax.io/docs/guides/text-generation
- models.dev feed provides `minimax-coding-plan.api` as `https://api.minimax.io/anthropic/v1`.

## Validation
- `mix test test/llm_db/sources/models_dev_test.exs`
- `mix llm_db.build --install`
- `mix test`
- pre-push hook: `mix test` and `mix quality`

Closes #215