### PR TITLE
[codex] Update MiniMax M3 token limits

### DIFF
--- a/priv/llm_db/local/minimax/minimax-m3.toml
+++ b/priv/llm_db/local/minimax/minimax-m3.toml
@@ -1,0 +1,5 @@
+id = "MiniMax-M3"
+
+[limits]
+context = 1000000
+output = 524288

--- a/priv/llm_db/local/minimax_cn/minimax-m3.toml
+++ b/priv/llm_db/local/minimax_cn/minimax-m3.toml
@@ -1,0 +1,5 @@
+id = "MiniMax-M3"
+
+[limits]
+context = 1000000
+output = 524288

--- a/priv/llm_db/local/minimax_cn_coding_plan/minimax-m3.toml
+++ b/priv/llm_db/local/minimax_cn_coding_plan/minimax-m3.toml
@@ -1,0 +1,5 @@
+id = "MiniMax-M3"
+
+[limits]
+context = 1000000
+output = 524288

--- a/priv/llm_db/local/minimax_coding_plan/minimax-m3.toml
+++ b/priv/llm_db/local/minimax_coding_plan/minimax-m3.toml
@@ -1,0 +1,5 @@
+id = "MiniMax-M3"
+
+[limits]
+context = 1000000
+output = 524288


### PR DESCRIPTION
## Summary
- Add sparse local overrides for `MiniMax-M3` under the direct MiniMax providers.
- Update generated snapshot limits from 512,000 context / 128,000 output to 1,000,000 context / 524,288 output.
- Cover `minimax`, `minimax_cn`, `minimax_coding_plan`, and `minimax_cn_coding_plan` without hand-editing upstream cache files.

## Evidence
- MiniMax model invocation docs list `MiniMax-M3` with a 1,000,000-token context window: https://platform.minimax.io/docs/guides/text-generation
- MiniMax API reference lists the M3 maximum generation length as 524,288 tokens: https://platform.minimax.io/docs/api-reference/text-chat-openai
- MiniMax Token Plan docs note OpenCode has built-in MiniMax-M3 support via MiniMax Token Plan: https://platform.minimax.io/docs/token-plan/other-tools

## Validation
- `mix llm_db.build --install`
- `jq` snapshot check for all four MiniMax M3 provider entries
- `mix test`
- pre-push hook: `mix test` and `mix quality`

Closes #216