### PR TITLE
fix: correct runtime metadata for req_llm compatibility

### DIFF
--- a/lib/llm_db/engine/validate.ex
+++ b/lib/llm_db/engine/validate.ex
@@ -300,13 +300,30 @@ defmodule LLMDB.Validate do
   defp implied_operations(%Model{} = model) do
     []
     |> maybe_add_operation(text_like?(model), :text)
-    |> maybe_add_operation(text_like?(model), :object)
+    |> maybe_add_operation(object_like?(model), :object)
     |> maybe_add_operation(embeddings?(model), :embed)
     |> maybe_add_operation(image_generation?(model), :image)
     |> maybe_add_operation(transcription?(model), :transcription)
     |> maybe_add_operation(speech?(model), :speech)
     |> maybe_add_operation(realtime?(model), :realtime)
   end
+
+  defp object_like?(%Model{provider: :anthropic} = model) do
+    text_like?(model) and json_schema_capable?(model)
+  end
+
+  defp object_like?(%Model{} = model), do: text_like?(model)
+
+  defp json_schema_capable?(%Model{capabilities: capabilities}) when is_map(capabilities) do
+    case Map.get(capabilities, :json) do
+      %{schema: true} -> true
+      %{native: true} -> true
+      %{strict: true} -> true
+      _other -> false
+    end
+  end
+
+  defp json_schema_capable?(_model), do: false
 
   defp text_like?(%Model{} = model) do
     cond do

--- a/lib/llm_db/enrich/runtime_contract.ex
+++ b/lib/llm_db/enrich/runtime_contract.ex
@@ -94,6 +94,11 @@ defmodule LLMDB.Enrich.RuntimeContract do
       auth: %{type: "bearer"},
       doc_url: "https://fireworks.ai/docs/"
     },
+    minimax: %{
+      base_url: "https://api.minimax.io/v1",
+      auth: %{type: "bearer"},
+      doc_url: "https://platform.minimax.io/docs/guides/quickstart"
+    },
     friendli: %{
       base_url: "https://api.friendli.ai/serverless/v1",
       auth: %{type: "bearer"},
@@ -364,7 +369,7 @@ defmodule LLMDB.Enrich.RuntimeContract do
   end
 
   defp object_entry(model, provider_id) do
-    if text_object_capable?(model, provider_id) do
+    if object_capable?(model, provider_id) do
       execution_entry(model, provider_id, text_object_family(model, provider_id))
     end
   end
@@ -428,6 +433,23 @@ defmodule LLMDB.Enrich.RuntimeContract do
     family = text_object_family(model, provider_id)
     is_binary(family)
   end
+
+  defp object_capable?(model, :anthropic) do
+    text_object_capable?(model, :anthropic) and json_schema_capable?(model)
+  end
+
+  defp object_capable?(model, provider_id), do: text_object_capable?(model, provider_id)
+
+  defp json_schema_capable?(%Model{capabilities: capabilities}) when is_map(capabilities) do
+    case Map.get(capabilities, :json) do
+      %{schema: true} -> true
+      %{native: true} -> true
+      %{strict: true} -> true
+      _other -> false
+    end
+  end
+
+  defp json_schema_capable?(_model), do: false
 
   defp text_object_family(model, provider_id) do
     cond do

--- a/lib/llm_db/sources/models_dev.ex
+++ b/lib/llm_db/sources/models_dev.ex
@@ -428,8 +428,10 @@ defmodule LLMDB.Sources.ModelsDev do
   end
 
   defp map_provider_base_url(provider, %{"api" => api}) when is_binary(api) do
-    Map.put(provider, :base_url, api)
+    Map.put(provider, :base_url, normalize_base_url(api))
   end
 
   defp map_provider_base_url(provider, _provider_data), do: provider
+
+  defp normalize_base_url(url), do: String.trim_trailing(url, "/")
 end

--- a/priv/llm_db/local/minimax/provider.toml
+++ b/priv/llm_db/local/minimax/provider.toml
@@ -1,0 +1,7 @@
+# MiniMax Provider Definition
+id = "minimax"
+name = "MiniMax"
+base_url = "https://api.minimax.io/v1"
+doc = "https://platform.minimax.io/docs/guides/quickstart"
+
+env = ["MINIMAX_API_KEY"]

--- a/test/llm_db/engine/validate_test.exs
+++ b/test/llm_db/engine/validate_test.exs
@@ -695,6 +695,31 @@ defmodule LLMDB.Engine.ValidateTest do
              } in errors
     end
 
+    test "does not require object execution for Anthropic models without JSON schema support" do
+      providers = [
+        LLMDB.Provider.new!(%{
+          id: :anthropic,
+          runtime: %{
+            base_url: "https://api.anthropic.com",
+            auth: %{type: "x_api_key", env: ["ANTHROPIC_API_KEY"], header_name: "x-api-key"}
+          }
+        })
+      ]
+
+      models = [
+        LLMDB.Model.new!(%{
+          id: "claude-opus-4-20250514",
+          provider: :anthropic,
+          capabilities: %{chat: true, json: %{schema: false, native: false, strict: false}},
+          execution: %{
+            text: %{supported: true, family: "anthropic_messages"}
+          }
+        })
+      ]
+
+      assert :ok = Validate.validate_runtime_contract(providers, models)
+    end
+
     test "rejects unknown execution families" do
       providers = [
         LLMDB.Provider.new!(%{

--- a/test/llm_db/enrich/runtime_contract_test.exs
+++ b/test/llm_db/enrich/runtime_contract_test.exs
@@ -41,6 +41,21 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
       assert [%{name: "account_id", required: true}] = enriched.runtime.config_schema
     end
 
+    test "adds native MiniMax runtime defaults" do
+      provider =
+        Provider.new!(%{
+          id: :minimax,
+          env: ["MINIMAX_API_KEY"]
+        })
+
+      enriched = RuntimeContract.enrich_provider(provider)
+
+      assert enriched.catalog_only == false
+      assert enriched.runtime.base_url == "https://api.minimax.io/v1"
+      assert enriched.runtime.auth.type == "bearer"
+      assert enriched.runtime.auth.env == ["MINIMAX_API_KEY"]
+    end
+
     test "marks unsupported providers catalog only" do
       provider = Provider.new!(%{id: :docs_only_provider})
       enriched = RuntimeContract.enrich_provider(provider)
@@ -83,6 +98,46 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
       assert enriched.execution.text.family == "openai_responses_compatible"
       assert enriched.execution.object.family == "openai_responses_compatible"
       assert enriched.execution.text.path == "/responses"
+    end
+
+    test "does not derive object execution for Anthropic models without JSON schema support" do
+      provider =
+        Provider.new!(%{id: :anthropic, env: ["ANTHROPIC_API_KEY"]})
+        |> RuntimeContract.enrich_provider()
+
+      model =
+        Model.new!(%{
+          id: "claude-opus-4-20250514",
+          provider: :anthropic,
+          capabilities: %{chat: true, json: %{schema: false, native: false, strict: false}},
+          modalities: %{input: [:text], output: [:text]}
+        })
+
+      enriched = RuntimeContract.enrich_model(model, provider)
+
+      assert enriched.catalog_only == false
+      assert enriched.execution.text.family == "anthropic_messages"
+      refute Map.has_key?(enriched.execution, :object)
+    end
+
+    test "derives object execution for Anthropic models with JSON schema support" do
+      provider =
+        Provider.new!(%{id: :anthropic, env: ["ANTHROPIC_API_KEY"]})
+        |> RuntimeContract.enrich_provider()
+
+      model =
+        Model.new!(%{
+          id: "claude-sonnet-4-5-20250929",
+          provider: :anthropic,
+          capabilities: %{chat: true, json: %{schema: true}},
+          modalities: %{input: [:text], output: [:text]}
+        })
+
+      enriched = RuntimeContract.enrich_model(model, provider)
+
+      assert enriched.catalog_only == false
+      assert enriched.execution.text.family == "anthropic_messages"
+      assert enriched.execution.object.family == "anthropic_messages"
     end
 
     test "derives speech execution for dedicated tts models without adding text operations" do

--- a/test/llm_db/packaged_test.exs
+++ b/test/llm_db/packaged_test.exs
@@ -71,11 +71,17 @@ defmodule LLMDB.PackagedTest do
       if snapshot do
         openai = snapshot["providers"]["openai"]
         anthropic = snapshot["providers"]["anthropic"]
+        fireworks = snapshot["providers"]["fireworks_ai"]
+        minimax = snapshot["providers"]["minimax"]
 
         assert openai["runtime"]["auth"]["type"] == "bearer"
         assert openai["runtime"]["base_url"] == "https://api.openai.com/v1"
         assert anthropic["runtime"]["auth"]["type"] == "x_api_key"
         assert anthropic["runtime"]["auth"]["header_name"] == "x-api-key"
+        assert fireworks["base_url"] == "https://api.fireworks.ai/inference/v1"
+        assert fireworks["runtime"]["base_url"] == "https://api.fireworks.ai/inference/v1"
+        assert minimax["base_url"] == "https://api.minimax.io/v1"
+        assert minimax["runtime"]["base_url"] == "https://api.minimax.io/v1"
       end
     end
 
@@ -87,11 +93,18 @@ defmodule LLMDB.PackagedTest do
         speech_model = snapshot["providers"]["openai"]["models"]["gpt-4o-mini-tts"]
         google_model = snapshot["providers"]["google"]["models"]["gemini-2.5-pro"]
         elevenlabs_model = snapshot["providers"]["elevenlabs"]["models"]["eleven_flash_v2_5"]
+        claude_opus_4 = snapshot["providers"]["anthropic"]["models"]["claude-opus-4-20250514"]
+
+        claude_opus_4_1 =
+          snapshot["providers"]["anthropic"]["models"]["claude-opus-4-1-20250805"]
 
         assert responses_model["execution"]["text"]["family"] == "openai_responses_compatible"
         assert speech_model["execution"]["speech"]["family"] == "openai_speech"
         assert google_model["execution"]["text"]["family"] == "google_generate_content"
         assert elevenlabs_model["execution"]["speech"]["family"] == "elevenlabs_speech"
+        assert claude_opus_4["execution"]["text"]["family"] == "anthropic_messages"
+        refute Map.has_key?(claude_opus_4["execution"], "object")
+        assert claude_opus_4_1["execution"]["object"]["family"] == "anthropic_messages"
       end
     end
 

--- a/test/llm_db/sources/models_dev_test.exs
+++ b/test/llm_db/sources/models_dev_test.exs
@@ -143,6 +143,29 @@ defmodule LLMDB.Sources.ModelsDevTest do
       assert hd(provider[:models])[:provider] == "openai"
     end
 
+    test "normalizes provider api base urls without trailing slash" do
+      test_url = "https://test.example.com/api.json"
+
+      cache_data = %{
+        "fireworks_ai" => %{
+          "api" => "https://api.fireworks.ai/inference/v1/",
+          "id" => "fireworks_ai",
+          "name" => "Fireworks AI",
+          "models" => %{}
+        }
+      }
+
+      hash = :crypto.hash(:sha256, test_url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
+      cache_path = "tmp/test/upstream/models-dev-#{hash}.json"
+
+      File.mkdir_p!(Path.dirname(cache_path))
+      File.write!(cache_path, Jason.encode!(cache_data))
+
+      assert {:ok, data} = ModelsDev.load(%{url: test_url})
+
+      assert data["fireworks_ai"][:base_url] == "https://api.fireworks.ai/inference/v1"
+    end
+
     test "returns error when cache file missing" do
       test_url = "https://missing.example.com/api.json"
       assert {:error, :no_cache} = ModelsDev.load(%{url: test_url})


### PR DESCRIPTION
## Summary

- Normalize models.dev provider API base URLs so trailing slashes do not leak into packaged provider metadata.
- Add native MiniMax runtime/provider metadata for `https://api.minimax.io/v1`.
- Stop deriving Anthropic object execution unless the model advertises JSON schema support.
- Rebuild the packaged snapshot with the corrected Fireworks, MiniMax, and Anthropic runtime metadata.

## Why

`req_llm` Dependabot PR #786 bumps `llm_db` to 2026.6.3 and fails its matrix because the packaged metadata changes runtime behavior:

- Fireworks base URL resolves with a trailing slash.
- MiniMax resolves to the models.dev Anthropic endpoint instead of the native MiniMax `/v1` endpoint.
- `claude-opus-4-20250514` advertises object generation despite JSON schema support being false.

## Downstream validation

- `agentjido/req_llm#788` temporarily pins this branch and validates req_llm against the corrected packaged metadata before release.
- Rollout order: merge this PR, publish the next `llm_db` Hex release, then replace the temporary git dependency in `req_llm#788` with the released Hex version.

## Validation

- `mix test test/llm_db/enrich/runtime_contract_test.exs test/llm_db/sources/models_dev_test.exs test/llm_db/engine/validate_test.exs`
- `mix llm_db.build --install`
- `mix test`
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- pre-push `mix quality` hook passed, including full tests, Credo, and Dialyzer