### PR TITLE
fix: update OpenAI GPT-5 response protocols

### DIFF
--- a/priv/llm_db/local/openai/gpt-5.3-chat-latest.toml
+++ b/priv/llm_db/local/openai/gpt-5.3-chat-latest.toml
@@ -1,5 +1,8 @@
 id = "gpt-5.3-chat-latest"
 
+[extra.wire]
+protocol = "openai_responses"
+
 [lifecycle]
 status = "deprecated"
 deprecated_at = "2026-05-08"

--- a/priv/llm_db/local/openai/gpt-5.3-codex-spark.toml
+++ b/priv/llm_db/local/openai/gpt-5.3-codex-spark.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.3-codex-spark"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.3-codex.toml
+++ b/priv/llm_db/local/openai/gpt-5.3-codex.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.3-codex"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.4-2026-03-05.toml
+++ b/priv/llm_db/local/openai/gpt-5.4-2026-03-05.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.4-2026-03-05"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.4-mini-2026-03-17.toml
+++ b/priv/llm_db/local/openai/gpt-5.4-mini-2026-03-17.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.4-mini-2026-03-17"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.4-mini.toml
+++ b/priv/llm_db/local/openai/gpt-5.4-mini.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.4-mini"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.4-nano-2026-03-17.toml
+++ b/priv/llm_db/local/openai/gpt-5.4-nano-2026-03-17.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.4-nano-2026-03-17"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.4-nano.toml
+++ b/priv/llm_db/local/openai/gpt-5.4-nano.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.4-nano"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.4-pro-2026-03-05.toml
+++ b/priv/llm_db/local/openai/gpt-5.4-pro-2026-03-05.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.4-pro-2026-03-05"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.4-pro.toml
+++ b/priv/llm_db/local/openai/gpt-5.4-pro.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.4-pro"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.4.toml
+++ b/priv/llm_db/local/openai/gpt-5.4.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.4"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.5-2026-04-23.toml
+++ b/priv/llm_db/local/openai/gpt-5.5-2026-04-23.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.5-2026-04-23"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.5-pro-2026-04-23.toml
+++ b/priv/llm_db/local/openai/gpt-5.5-pro-2026-04-23.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.5-pro-2026-04-23"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.5-pro.toml
+++ b/priv/llm_db/local/openai/gpt-5.5-pro.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.5-pro"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/priv/llm_db/local/openai/gpt-5.5.toml
+++ b/priv/llm_db/local/openai/gpt-5.5.toml
@@ -1,0 +1,4 @@
+id = "gpt-5.5"
+
+[extra.wire]
+protocol = "openai_responses"

--- a/test/llm_db/packaged_test.exs
+++ b/test/llm_db/packaged_test.exs
@@ -108,6 +108,42 @@ defmodule LLMDB.PackagedTest do
       end
     end
 
+    test "snapshot maps recent OpenAI GPT-5 text and tool models to Responses API" do
+      snapshot = Packaged.snapshot()
+
+      if snapshot do
+        openai_models = snapshot["providers"]["openai"]["models"]
+
+        for model_id <- [
+              "gpt-5.3-chat-latest",
+              "gpt-5.3-codex",
+              "gpt-5.3-codex-spark",
+              "gpt-5.4",
+              "gpt-5.4-2026-03-05",
+              "gpt-5.4-mini",
+              "gpt-5.4-mini-2026-03-17",
+              "gpt-5.4-nano",
+              "gpt-5.4-nano-2026-03-17",
+              "gpt-5.4-pro",
+              "gpt-5.4-pro-2026-03-05",
+              "gpt-5.5",
+              "gpt-5.5-2026-04-23",
+              "gpt-5.5-pro",
+              "gpt-5.5-pro-2026-04-23"
+            ] do
+          model = openai_models[model_id]
+
+          assert is_map(model), "expected #{model_id} in packaged OpenAI snapshot"
+          assert model["execution"]["text"]["family"] == "openai_responses_compatible"
+          assert model["execution"]["text"]["wire_protocol"] == "openai_responses"
+          assert model["execution"]["text"]["path"] == "/responses"
+          assert model["execution"]["object"]["family"] == "openai_responses_compatible"
+          assert model["execution"]["object"]["wire_protocol"] == "openai_responses"
+          assert model["execution"]["object"]["path"] == "/responses"
+        end
+      end
+    end
+
     test "snapshot carries rerank capability metadata for packaged local rerank models" do
       snapshot = Packaged.snapshot()
 


### PR DESCRIPTION
## Summary

- Add sparse OpenAI local TOML overrides so the issue-listed GPT-5.3/GPT-5.4/GPT-5.5 text and tool models use `openai_responses`.
- Rebuild the packaged snapshot so text/object execution metadata resolves to `openai_responses_compatible` with `/responses`.
- Add a packaged snapshot regression test for all 15 affected model IDs.

## Evidence

- OpenAI model docs list Responses support for the affected public API model families and snapshots: [GPT-5.3 Chat](https://developers.openai.com/api/docs/models/gpt-5.3-chat-latest), [GPT-5.3-Codex](https://developers.openai.com/api/docs/models/gpt-5.3-codex), [GPT-5.4](https://developers.openai.com/api/docs/models/gpt-5.4), [GPT-5.4 mini](https://developers.openai.com/api/docs/models/gpt-5.4-mini), [GPT-5.4 nano](https://developers.openai.com/api/docs/models/gpt-5.4-nano), [GPT-5.4 Pro](https://developers.openai.com/api/docs/models/gpt-5.4-pro), [GPT-5.5](https://developers.openai.com/api/docs/models/gpt-5.5), and [GPT-5.5 Pro](https://developers.openai.com/api/docs/models/gpt-5.5-pro).
- OpenAI guidance says GPT-5.5/reasoning/tool-heavy/multi-turn workloads work best with the Responses API: [latest model guide](https://developers.openai.com/api/docs/guides/latest-model) and [reasoning models guide](https://developers.openai.com/api/docs/guides/reasoning).
- `gpt-5.3-codex-spark` does not appear to have a granular public API model endpoint page; OpenAI Codex docs identify it as a Codex model, so this follows the existing local TOML precedent for GPT-5/GPT-5.1/GPT-5.2 Codex models using Responses: [Codex models](https://developers.openai.com/codex/models) and [Codex speed](https://developers.openai.com/codex/speed).
- Repo precedent: #100 / #101 captured OpenAI response-protocol facts in sparse local TOML `[extra.wire]` overrides instead of changing runtime enrichment.

## Validation

- `mix deps.get`
- `mix llm_db.build --install` (attempted in dev; blocked by `git_hooks` resolving the shared main worktree instead of this linked worktree)
- `MIX_ENV=prod mix llm_db.build --install` (regenerated full source snapshot: 149 providers, 5592 models)
- `mix format --check-formatted`
- `git diff --check`
- `MIX_ENV=test mix test test/llm_db/packaged_test.exs` (8 passed)

Closes #227