### PR TITLE
[codex] Add NEAR AI execution metadata overrides

### DIFF
--- a/priv/llm_db/local/nearai/anthropic_claude-haiku-4-5.toml
+++ b/priv/llm_db/local/nearai/anthropic_claude-haiku-4-5.toml
@@ -1,0 +1,4 @@
+id = "anthropic/claude-haiku-4-5"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/anthropic_claude-opus-4-6.toml
+++ b/priv/llm_db/local/nearai/anthropic_claude-opus-4-6.toml
@@ -1,0 +1,4 @@
+id = "anthropic/claude-opus-4-6"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/anthropic_claude-opus-4-7.toml
+++ b/priv/llm_db/local/nearai/anthropic_claude-opus-4-7.toml
@@ -1,0 +1,4 @@
+id = "anthropic/claude-opus-4-7"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/anthropic_claude-sonnet-4-5.toml
+++ b/priv/llm_db/local/nearai/anthropic_claude-sonnet-4-5.toml
@@ -1,0 +1,4 @@
+id = "anthropic/claude-sonnet-4-5"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/anthropic_claude-sonnet-4-6.toml
+++ b/priv/llm_db/local/nearai/anthropic_claude-sonnet-4-6.toml
@@ -1,0 +1,4 @@
+id = "anthropic/claude-sonnet-4-6"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/google_gemini-2.5-flash-lite.toml
+++ b/priv/llm_db/local/nearai/google_gemini-2.5-flash-lite.toml
@@ -1,0 +1,4 @@
+id = "google/gemini-2.5-flash-lite"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/google_gemini-2.5-flash.toml
+++ b/priv/llm_db/local/nearai/google_gemini-2.5-flash.toml
@@ -1,0 +1,4 @@
+id = "google/gemini-2.5-flash"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/google_gemini-2.5-pro.toml
+++ b/priv/llm_db/local/nearai/google_gemini-2.5-pro.toml
@@ -1,0 +1,4 @@
+id = "google/gemini-2.5-pro"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/google_gemini-3.1-flash-lite.toml
+++ b/priv/llm_db/local/nearai/google_gemini-3.1-flash-lite.toml
@@ -1,0 +1,4 @@
+id = "google/gemini-3.1-flash-lite"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/google_gemini-3.5-flash.toml
+++ b/priv/llm_db/local/nearai/google_gemini-3.5-flash.toml
@@ -1,0 +1,4 @@
+id = "google/gemini-3.5-flash"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/google_gemma-4-31b-it.toml
+++ b/priv/llm_db/local/nearai/google_gemma-4-31b-it.toml
@@ -1,0 +1,4 @@
+id = "google/gemma-4-31B-it"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-4.1-mini.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-4.1-mini.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-4.1-mini"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-4.1-nano.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-4.1-nano.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-4.1-nano"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-4.1.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-4.1.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-4.1"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-5-mini.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-5-mini.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-5-mini"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-5-nano.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-5-nano.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-5-nano"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-5.1.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-5.1.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-5.1"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-5.2.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-5.2.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-5.2"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-5.4-mini.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-5.4-mini.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-5.4-mini"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-5.4-nano.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-5.4-nano.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-5.4-nano"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-5.4.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-5.4.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-5.4"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-5.5.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-5.5.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-5.5"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-5.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-5.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-5"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_gpt-oss-120b.toml
+++ b/priv/llm_db/local/nearai/openai_gpt-oss-120b.toml
@@ -1,0 +1,4 @@
+id = "openai/gpt-oss-120b"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_o3-mini.toml
+++ b/priv/llm_db/local/nearai/openai_o3-mini.toml
@@ -1,0 +1,4 @@
+id = "openai/o3-mini"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_o3.toml
+++ b/priv/llm_db/local/nearai/openai_o3.toml
@@ -1,0 +1,4 @@
+id = "openai/o3"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/openai_o4-mini.toml
+++ b/priv/llm_db/local/nearai/openai_o4-mini.toml
@@ -1,0 +1,4 @@
+id = "openai/o4-mini"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/provider.toml
+++ b/priv/llm_db/local/nearai/provider.toml
@@ -1,0 +1,9 @@
+id = "nearai"
+
+[runtime]
+base_url = "https://cloud-api.near.ai/v1"
+doc_url = "https://docs.near.ai/cloud/guides/openai-compatibility/"
+
+[runtime.auth]
+type = "bearer"
+env = ["NEARAI_API_KEY"]

--- a/priv/llm_db/local/nearai/qwen_qwen3-30b-a3b-instruct-2507.toml
+++ b/priv/llm_db/local/nearai/qwen_qwen3-30b-a3b-instruct-2507.toml
@@ -1,0 +1,4 @@
+id = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/qwen_qwen3-vl-30b-a3b-instruct.toml
+++ b/priv/llm_db/local/nearai/qwen_qwen3-vl-30b-a3b-instruct.toml
@@ -1,0 +1,4 @@
+id = "Qwen/Qwen3-VL-30B-A3B-Instruct"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/qwen_qwen3.5-122b-a10b.toml
+++ b/priv/llm_db/local/nearai/qwen_qwen3.5-122b-a10b.toml
@@ -1,0 +1,4 @@
+id = "Qwen/Qwen3.5-122B-A10B"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/qwen_qwen3.6-35b-a3b-fp8.toml
+++ b/priv/llm_db/local/nearai/qwen_qwen3.6-35b-a3b-fp8.toml
@@ -1,0 +1,4 @@
+id = "Qwen/Qwen3.6-35B-A3B-FP8"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/priv/llm_db/local/nearai/zai-org_glm-5.1-fp8.toml
+++ b/priv/llm_db/local/nearai/zai-org_glm-5.1-fp8.toml
@@ -1,0 +1,4 @@
+id = "zai-org/GLM-5.1-FP8"
+
+[extra.wire]
+protocol = "openai_chat"

--- a/test/llm_db/packaged_test.exs
+++ b/test/llm_db/packaged_test.exs
@@ -14,6 +14,18 @@ defmodule LLMDB.PackagedTest do
                                    |> Map.fetch!("id")
                                  end)
                                  |> Enum.sort()
+  @local_nearai_dir Path.expand("../../priv/llm_db/local/nearai", __DIR__)
+  @local_nearai_chat_model_ids "*.toml"
+                               |> then(&Path.join(@local_nearai_dir, &1))
+                               |> Path.wildcard()
+                               |> Enum.reject(&String.ends_with?(&1, "/provider.toml"))
+                               |> Enum.map(fn path ->
+                                 path
+                                 |> File.read!()
+                                 |> Toml.decode!()
+                                 |> Map.fetch!("id")
+                               end)
+                               |> Enum.sort()
 
   describe "snapshot_path/0" do
     test "returns correct snapshot path" do
@@ -73,6 +85,7 @@ defmodule LLMDB.PackagedTest do
         anthropic = snapshot["providers"]["anthropic"]
         fireworks = snapshot["providers"]["fireworks_ai"]
         minimax = snapshot["providers"]["minimax"]
+        nearai = snapshot["providers"]["nearai"]
 
         assert openai["runtime"]["auth"]["type"] == "bearer"
         assert openai["runtime"]["base_url"] == "https://api.openai.com/v1"
@@ -82,6 +95,10 @@ defmodule LLMDB.PackagedTest do
         assert fireworks["runtime"]["base_url"] == "https://api.fireworks.ai/inference/v1"
         assert minimax["base_url"] == "https://api.minimax.io/v1"
         assert minimax["runtime"]["base_url"] == "https://api.minimax.io/v1"
+        assert nearai["runtime"]["base_url"] == "https://cloud-api.near.ai/v1"
+        assert nearai["runtime"]["auth"]["type"] == "bearer"
+        assert nearai["runtime"]["auth"]["env"] == ["NEARAI_API_KEY"]
+        refute Map.get(nearai, "catalog_only", false)
       end
     end
 
@@ -140,6 +157,32 @@ defmodule LLMDB.PackagedTest do
           assert model["execution"]["object"]["family"] == "openai_responses_compatible"
           assert model["execution"]["object"]["wire_protocol"] == "openai_responses"
           assert model["execution"]["object"]["path"] == "/responses"
+        end
+      end
+    end
+
+    test "snapshot carries NEAR AI chat execution metadata for local runtime overrides" do
+      snapshot = Packaged.snapshot()
+
+      if snapshot do
+        assert Enum.any?(@local_nearai_chat_model_ids)
+
+        nearai_models = snapshot["providers"]["nearai"]["models"]
+
+        for model_id <- @local_nearai_chat_model_ids do
+          model = nearai_models[model_id]
+
+          assert is_map(model),
+                 "expected local NEAR AI chat model #{inspect(model_id)} in packaged snapshot"
+
+          assert model["id"] == model_id
+          refute Map.get(model, "catalog_only", false)
+          assert model["execution"]["text"]["family"] == "openai_chat_compatible"
+          assert model["execution"]["text"]["wire_protocol"] == "openai_chat"
+          assert model["execution"]["text"]["path"] == "/chat/completions"
+          assert model["execution"]["object"]["family"] == "openai_chat_compatible"
+          assert model["execution"]["object"]["wire_protocol"] == "openai_chat"
+          assert model["execution"]["object"]["path"] == "/chat/completions"
         end
       end
     end


### PR DESCRIPTION
## Summary

- Add local TOML runtime metadata for `nearai` using the NEAR AI Cloud OpenAI-compatible gateway.
- Add sparse local TOML wire-protocol hints for 32 packaged NEAR AI chat/text models so generated metadata exposes `execution.text.wire_protocol = "openai_chat"`.
- Rebuild `priv/llm_db/snapshot.json` and add packaged snapshot assertions for the NEAR AI runtime/execution contract.

## Evidence

- NEAR AI OpenAI compatibility docs state the gateway base URL is `https://cloud-api.near.ai/v1`, uses a NEAR AI API key, and supports OpenAI-compatible chat completions, models, embeddings, responses, and related endpoints: https://docs.near.ai/cloud/guides/openai-compatibility/
- NEAR AI quickstart shows `Authorization: Bearer YOUR_API_KEY` against `https://cloud-api.near.ai/v1/chat/completions` and passes slash-prefixed model IDs unchanged in requests: https://docs.near.ai/cloud/quickstart/
- NEAR AI models docs state `/v1/models` reports model metadata including supported features such as `tools`, modalities, and limits: https://docs.near.ai/cloud/models/
- Public model discovery endpoint checked on 2026-07-05: https://cloud-api.near.ai/v1/models
- Direct completions endpoint list confirms exact direct model IDs for Qwen/GLM/GPT-OSS hosted models: https://completions.near.ai/endpoints

## Validation

- `MIX_ENV=prod mix llm_db.build --install`
- `MIX_ENV=test mix test test/llm_db/packaged_test.exs`
- Commit hook: `mix llm_db.build --check --install`
- Pre-push hook: `mix test` and `mix quality`

Closes #225