### PR TITLE
[codex] Add Moonshot execution metadata

### DIFF
--- a/priv/llm_db/local/moonshotai/kimi-k2-0711-preview.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2-0711-preview.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-0711-preview"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai/kimi-k2-0905-preview.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2-0905-preview.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-0905-preview"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai/kimi-k2-thinking-turbo.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2-thinking-turbo.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-thinking-turbo"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai/kimi-k2-thinking.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2-thinking.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-thinking"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai/kimi-k2-turbo-preview.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2-turbo-preview.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-turbo-preview"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai/kimi-k2.5.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/moonshotai/kimi-k2.6.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.6"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.7-code-highspeed"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/moonshotai/kimi-k2.7-code.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.7-code"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/moonshotai/provider.toml
+++ b/priv/llm_db/local/moonshotai/provider.toml
@@ -1,0 +1,15 @@
+# Moonshot AI Provider Definition
+id = "moonshotai"
+name = "Moonshot AI"
+base_url = "https://api.moonshot.ai/v1"
+doc = "https://platform.moonshot.ai/docs/api/chat"
+
+env = ["MOONSHOT_API_KEY"]
+
+[runtime]
+base_url = "https://api.moonshot.ai/v1"
+doc_url = "https://platform.moonshot.ai/docs/api/chat"
+
+[runtime.auth]
+type = "bearer"
+env = ["MOONSHOT_API_KEY"]

--- a/priv/llm_db/local/moonshotai_cn/kimi-k2-0711-preview.toml
+++ b/priv/llm_db/local/moonshotai_cn/kimi-k2-0711-preview.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-0711-preview"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai_cn/kimi-k2-0905-preview.toml
+++ b/priv/llm_db/local/moonshotai_cn/kimi-k2-0905-preview.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-0905-preview"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai_cn/kimi-k2-thinking-turbo.toml
+++ b/priv/llm_db/local/moonshotai_cn/kimi-k2-thinking-turbo.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-thinking-turbo"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai_cn/kimi-k2-thinking.toml
+++ b/priv/llm_db/local/moonshotai_cn/kimi-k2-thinking.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-thinking"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai_cn/kimi-k2-turbo-preview.toml
+++ b/priv/llm_db/local/moonshotai_cn/kimi-k2-turbo-preview.toml
@@ -1,0 +1,7 @@
+id = "kimi-k2-turbo-preview"
+catalog_only = true
+
+[lifecycle]
+status = "retired"
+retires_at = "2026-05-25"
+replacement = "kimi-k2.6"

--- a/priv/llm_db/local/moonshotai_cn/kimi-k2.5.toml
+++ b/priv/llm_db/local/moonshotai_cn/kimi-k2.5.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/moonshotai_cn/kimi-k2.6.toml
+++ b/priv/llm_db/local/moonshotai_cn/kimi-k2.6.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.6"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/moonshotai_cn/kimi-k2.7-code-highspeed.toml
+++ b/priv/llm_db/local/moonshotai_cn/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.7-code-highspeed"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/moonshotai_cn/kimi-k2.7-code.toml
+++ b/priv/llm_db/local/moonshotai_cn/kimi-k2.7-code.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.7-code"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/moonshotai_cn/provider.toml
+++ b/priv/llm_db/local/moonshotai_cn/provider.toml
@@ -1,0 +1,15 @@
+# Moonshot AI (China) Provider Definition
+id = "moonshotai_cn"
+name = "Moonshot AI (China)"
+base_url = "https://api.moonshot.cn/v1"
+doc = "https://platform.moonshot.cn/docs/api/chat"
+
+env = ["MOONSHOT_API_KEY"]
+
+[runtime]
+base_url = "https://api.moonshot.cn/v1"
+doc_url = "https://platform.moonshot.cn/docs/api/chat"
+
+[runtime.auth]
+type = "bearer"
+env = ["MOONSHOT_API_KEY"]

--- a/test/llm_db/packaged_test.exs
+++ b/test/llm_db/packaged_test.exs
@@ -86,6 +86,8 @@ defmodule LLMDB.PackagedTest do
         fireworks = snapshot["providers"]["fireworks_ai"]
         minimax = snapshot["providers"]["minimax"]
         nearai = snapshot["providers"]["nearai"]
+        moonshot = snapshot["providers"]["moonshotai"]
+        moonshot_cn = snapshot["providers"]["moonshotai_cn"]
 
         assert openai["runtime"]["auth"]["type"] == "bearer"
         assert openai["runtime"]["base_url"] == "https://api.openai.com/v1"
@@ -99,6 +101,10 @@ defmodule LLMDB.PackagedTest do
         assert nearai["runtime"]["auth"]["type"] == "bearer"
         assert nearai["runtime"]["auth"]["env"] == ["NEARAI_API_KEY"]
         refute Map.get(nearai, "catalog_only", false)
+        assert moonshot["runtime"]["auth"]["type"] == "bearer"
+        assert moonshot["runtime"]["base_url"] == "https://api.moonshot.ai/v1"
+        assert moonshot_cn["runtime"]["auth"]["type"] == "bearer"
+        assert moonshot_cn["runtime"]["base_url"] == "https://api.moonshot.cn/v1"
       end
     end
 
@@ -183,6 +189,54 @@ defmodule LLMDB.PackagedTest do
           assert model["execution"]["object"]["family"] == "openai_chat_compatible"
           assert model["execution"]["object"]["wire_protocol"] == "openai_chat"
           assert model["execution"]["object"]["path"] == "/chat/completions"
+        end
+      end
+    end
+
+    test "snapshot carries Moonshot OpenAI-chat execution metadata for current models" do
+      snapshot = Packaged.snapshot()
+
+      if snapshot do
+        for provider_id <- ["moonshotai", "moonshotai_cn"],
+            model_id <- [
+              "kimi-k2.5",
+              "kimi-k2.6",
+              "kimi-k2.7-code",
+              "kimi-k2.7-code-highspeed"
+            ] do
+          model = snapshot["providers"][provider_id]["models"][model_id]
+
+          refute model["catalog_only"] == true
+          assert model["execution"]["text"]["family"] == "openai_chat_compatible"
+          assert model["execution"]["text"]["wire_protocol"] == "openai_chat"
+          assert model["execution"]["text"]["path"] == "/chat/completions"
+          assert model["execution"]["object"]["family"] == "openai_chat_compatible"
+          assert model["execution"]["object"]["wire_protocol"] == "openai_chat"
+          assert model["execution"]["object"]["path"] == "/chat/completions"
+        end
+      end
+    end
+
+    test "snapshot keeps discontinued Moonshot K2 models catalog-only" do
+      snapshot = Packaged.snapshot()
+
+      if snapshot do
+        for provider_id <- ["moonshotai", "moonshotai_cn"],
+            model_id <- [
+              "kimi-k2-0711-preview",
+              "kimi-k2-0905-preview",
+              "kimi-k2-thinking",
+              "kimi-k2-thinking-turbo",
+              "kimi-k2-turbo-preview"
+            ] do
+          model = snapshot["providers"][provider_id]["models"][model_id]
+
+          assert model["catalog_only"] == true
+          assert model["execution"] == nil
+          assert model["retired"] == true
+          assert model["lifecycle"]["status"] == "retired"
+          assert model["lifecycle"]["retires_at"] == "2026-05-25"
+          assert model["lifecycle"]["replacement"] == "kimi-k2.6"
         end
       end
     end


### PR DESCRIPTION
## Summary

- Add local TOML runtime contracts for `moonshotai` and `moonshotai_cn` with documented Moonshot API base URLs and bearer auth.
- Add TOML execution metadata for current executable Kimi text/tool models: `kimi-k2.5`, `kimi-k2.6`, `kimi-k2.7-code`, and `kimi-k2.7-code-highspeed`.
- Mark discontinued K2 preview/thinking models catalog-only with retired lifecycle metadata, then rebuild `priv/llm_db/snapshot.json`.
- Add packaged snapshot assertions for Moonshot runtime, OpenAI chat wire protocol, and retired catalog-only behavior.

## Evidence

- Global Kimi API quickstart documents OpenAI SDK usage with `base_url="https://api.moonshot.ai/v1"`: https://platform.moonshot.ai/docs/guide/start-using-kimi-api
- Global chat API reference documents `POST /v1/chat/completions`, bearer auth, and Tool Use support: https://platform.moonshot.ai/docs/api/chat
- China Kimi API quickstart documents `base_url="https://api.moonshot.cn/v1"`: https://platform.moonshot.cn/docs/guide/start-using-kimi-api
- China chat API reference documents `https://api.moonshot.cn/v1/chat/completions`, bearer auth, and tools: https://platform.moonshot.cn/docs/api/chat
- Official model list identifies current K2.5/K2.6/K2.7 Code models and says older `kimi-k2` series models were discontinued on 2026-05-25: https://platform.kimi.ai/docs/models and https://platform.kimi.com/docs/models

## Validation

- `mix llm_db.build --install`
- `mix format`
- `MIX_ENV=test mix do loadconfig tmp/git_hooks_worktree.exs + test test/llm_db/packaged_test.exs`
- pre-push hook: `mix test` and `mix quality`

Closes #226