### PR TITLE
fix: add OpenCode Zen execution metadata

### DIFF
--- a/priv/llm_db/local/opencode/big-pickle.toml
+++ b/priv/llm_db/local/opencode/big-pickle.toml
@@ -1,0 +1,16 @@
+id = "big-pickle"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/claude-fable-5.toml
+++ b/priv/llm_db/local/opencode/claude-fable-5.toml
@@ -1,0 +1,16 @@
+id = "claude-fable-5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/claude-haiku-4-5.toml
+++ b/priv/llm_db/local/opencode/claude-haiku-4-5.toml
@@ -1,0 +1,16 @@
+id = "claude-haiku-4-5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/claude-opus-4-5.toml
+++ b/priv/llm_db/local/opencode/claude-opus-4-5.toml
@@ -1,0 +1,16 @@
+id = "claude-opus-4-5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/claude-opus-4-6.toml
+++ b/priv/llm_db/local/opencode/claude-opus-4-6.toml
@@ -1,0 +1,16 @@
+id = "claude-opus-4-6"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/claude-opus-4-7.toml
+++ b/priv/llm_db/local/opencode/claude-opus-4-7.toml
@@ -1,0 +1,16 @@
+id = "claude-opus-4-7"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/claude-opus-4-8.toml
+++ b/priv/llm_db/local/opencode/claude-opus-4-8.toml
@@ -1,0 +1,16 @@
+id = "claude-opus-4-8"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/claude-sonnet-4-5.toml
+++ b/priv/llm_db/local/opencode/claude-sonnet-4-5.toml
@@ -1,0 +1,16 @@
+id = "claude-sonnet-4-5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/claude-sonnet-4-6.toml
+++ b/priv/llm_db/local/opencode/claude-sonnet-4-6.toml
@@ -1,0 +1,16 @@
+id = "claude-sonnet-4-6"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/claude-sonnet-5.toml
+++ b/priv/llm_db/local/opencode/claude-sonnet-5.toml
@@ -1,0 +1,16 @@
+id = "claude-sonnet-5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/deepseek-v4-flash-free.toml
+++ b/priv/llm_db/local/opencode/deepseek-v4-flash-free.toml
@@ -1,0 +1,16 @@
+id = "deepseek-v4-flash-free"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/deepseek-v4-flash.toml
+++ b/priv/llm_db/local/opencode/deepseek-v4-flash.toml
@@ -1,0 +1,16 @@
+id = "deepseek-v4-flash"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/deepseek-v4-pro.toml
+++ b/priv/llm_db/local/opencode/deepseek-v4-pro.toml
@@ -1,0 +1,16 @@
+id = "deepseek-v4-pro"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/gemini-3-flash.toml
+++ b/priv/llm_db/local/opencode/gemini-3-flash.toml
@@ -1,0 +1,16 @@
+id = "gemini-3-flash"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "google_generate_content"
+wire_protocol = "google_generate_content"
+transport = "http_request"
+path = "/models/gemini-3-flash"
+
+[execution.object]
+supported = true
+family = "google_generate_content"
+wire_protocol = "google_generate_content"
+transport = "http_request"
+path = "/models/gemini-3-flash"

--- a/priv/llm_db/local/opencode/gemini-3.1-pro.toml
+++ b/priv/llm_db/local/opencode/gemini-3.1-pro.toml
@@ -1,0 +1,16 @@
+id = "gemini-3.1-pro"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "google_generate_content"
+wire_protocol = "google_generate_content"
+transport = "http_request"
+path = "/models/gemini-3.1-pro"
+
+[execution.object]
+supported = true
+family = "google_generate_content"
+wire_protocol = "google_generate_content"
+transport = "http_request"
+path = "/models/gemini-3.1-pro"

--- a/priv/llm_db/local/opencode/gemini-3.5-flash.toml
+++ b/priv/llm_db/local/opencode/gemini-3.5-flash.toml
@@ -1,0 +1,16 @@
+id = "gemini-3.5-flash"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "google_generate_content"
+wire_protocol = "google_generate_content"
+transport = "http_request"
+path = "/models/gemini-3.5-flash"
+
+[execution.object]
+supported = true
+family = "google_generate_content"
+wire_protocol = "google_generate_content"
+transport = "http_request"
+path = "/models/gemini-3.5-flash"

--- a/priv/llm_db/local/opencode/glm-5.1.toml
+++ b/priv/llm_db/local/opencode/glm-5.1.toml
@@ -1,0 +1,16 @@
+id = "glm-5.1"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/glm-5.2.toml
+++ b/priv/llm_db/local/opencode/glm-5.2.toml
@@ -1,0 +1,16 @@
+id = "glm-5.2"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/glm-5.toml
+++ b/priv/llm_db/local/opencode/glm-5.toml
@@ -1,0 +1,16 @@
+id = "glm-5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/gpt-5-codex.toml
+++ b/priv/llm_db/local/opencode/gpt-5-codex.toml
@@ -1,0 +1,16 @@
+id = "gpt-5-codex"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5-nano.toml
+++ b/priv/llm_db/local/opencode/gpt-5-nano.toml
@@ -1,0 +1,16 @@
+id = "gpt-5-nano"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.1-codex-max.toml
+++ b/priv/llm_db/local/opencode/gpt-5.1-codex-max.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.1-codex-max"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.1-codex-mini.toml
+++ b/priv/llm_db/local/opencode/gpt-5.1-codex-mini.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.1-codex-mini"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.1-codex.toml
+++ b/priv/llm_db/local/opencode/gpt-5.1-codex.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.1-codex"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.1.toml
+++ b/priv/llm_db/local/opencode/gpt-5.1.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.1"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.2-codex.toml
+++ b/priv/llm_db/local/opencode/gpt-5.2-codex.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.2-codex"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.2.toml
+++ b/priv/llm_db/local/opencode/gpt-5.2.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.2"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.3-codex-spark.toml
+++ b/priv/llm_db/local/opencode/gpt-5.3-codex-spark.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.3-codex-spark"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.3-codex.toml
+++ b/priv/llm_db/local/opencode/gpt-5.3-codex.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.3-codex"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.4-mini.toml
+++ b/priv/llm_db/local/opencode/gpt-5.4-mini.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.4-mini"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.4-nano.toml
+++ b/priv/llm_db/local/opencode/gpt-5.4-nano.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.4-nano"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.4-pro.toml
+++ b/priv/llm_db/local/opencode/gpt-5.4-pro.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.4-pro"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.4.toml
+++ b/priv/llm_db/local/opencode/gpt-5.4.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.4"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.5-pro.toml
+++ b/priv/llm_db/local/opencode/gpt-5.5-pro.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.5-pro"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.5.toml
+++ b/priv/llm_db/local/opencode/gpt-5.5.toml
@@ -1,0 +1,16 @@
+id = "gpt-5.5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/gpt-5.toml
+++ b/priv/llm_db/local/opencode/gpt-5.toml
@@ -1,0 +1,16 @@
+id = "gpt-5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"
+
+[execution.object]
+supported = true
+family = "openai_responses_compatible"
+wire_protocol = "openai_responses"
+transport = "http_request"
+path = "/responses"

--- a/priv/llm_db/local/opencode/grok-build-0.1.toml
+++ b/priv/llm_db/local/opencode/grok-build-0.1.toml
@@ -1,0 +1,16 @@
+id = "grok-build-0.1"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/kimi-k2.5.toml
+++ b/priv/llm_db/local/opencode/kimi-k2.5.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/kimi-k2.6.toml
+++ b/priv/llm_db/local/opencode/kimi-k2.6.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.6"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/kimi-k2.7-code.toml
+++ b/priv/llm_db/local/opencode/kimi-k2.7-code.toml
@@ -1,0 +1,16 @@
+id = "kimi-k2.7-code"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/mimo-v2.5-free.toml
+++ b/priv/llm_db/local/opencode/mimo-v2.5-free.toml
@@ -1,0 +1,16 @@
+id = "mimo-v2.5-free"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/minimax-m2.5.toml
+++ b/priv/llm_db/local/opencode/minimax-m2.5.toml
@@ -1,0 +1,16 @@
+id = "minimax-m2.5"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/minimax-m2.7.toml
+++ b/priv/llm_db/local/opencode/minimax-m2.7.toml
@@ -1,0 +1,16 @@
+id = "minimax-m2.7"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/minimax-m3.toml
+++ b/priv/llm_db/local/opencode/minimax-m3.toml
@@ -1,0 +1,16 @@
+id = "minimax-m3"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/nemotron-3-ultra-free.toml
+++ b/priv/llm_db/local/opencode/nemotron-3-ultra-free.toml
@@ -1,0 +1,16 @@
+id = "nemotron-3-ultra-free"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/north-mini-code-free.toml
+++ b/priv/llm_db/local/opencode/north-mini-code-free.toml
@@ -1,0 +1,16 @@
+id = "north-mini-code-free"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/opencode/provider.toml
+++ b/priv/llm_db/local/opencode/provider.toml
@@ -1,0 +1,15 @@
+id = "opencode"
+name = "OpenCode Zen"
+base_url = "https://opencode.ai/zen/v1"
+doc = "https://opencode.ai/docs/zen/"
+catalog_only = false
+
+env = ["OPENCODE_API_KEY"]
+
+[runtime]
+base_url = "https://opencode.ai/zen/v1"
+doc_url = "https://opencode.ai/docs/zen/"
+
+[runtime.auth]
+type = "bearer"
+env = ["OPENCODE_API_KEY"]

--- a/priv/llm_db/local/opencode/qwen3.5-plus.toml
+++ b/priv/llm_db/local/opencode/qwen3.5-plus.toml
@@ -1,0 +1,16 @@
+id = "qwen3.5-plus"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/priv/llm_db/local/opencode/qwen3.6-plus.toml
+++ b/priv/llm_db/local/opencode/qwen3.6-plus.toml
@@ -1,0 +1,16 @@
+id = "qwen3.6-plus"
+catalog_only = false
+
+[execution.text]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"
+
+[execution.object]
+supported = true
+family = "anthropic_messages"
+wire_protocol = "anthropic_messages"
+transport = "http_request"
+path = "/messages"

--- a/test/llm_db/packaged_test.exs
+++ b/test/llm_db/packaged_test.exs
@@ -26,6 +26,18 @@ defmodule LLMDB.PackagedTest do
                                  |> Map.fetch!("id")
                                end)
                                |> Enum.sort()
+  @local_opencode_dir Path.expand("../../priv/llm_db/local/opencode", __DIR__)
+  @local_opencode_execution_model_ids "*.toml"
+                                      |> then(&Path.join(@local_opencode_dir, &1))
+                                      |> Path.wildcard()
+                                      |> Enum.reject(&String.ends_with?(&1, "/provider.toml"))
+                                      |> Enum.map(fn path ->
+                                        path
+                                        |> File.read!()
+                                        |> Toml.decode!()
+                                        |> Map.fetch!("id")
+                                      end)
+                                      |> Enum.sort()
 
   describe "snapshot_path/0" do
     test "returns correct snapshot path" do
@@ -88,6 +100,7 @@ defmodule LLMDB.PackagedTest do
         nearai = snapshot["providers"]["nearai"]
         moonshot = snapshot["providers"]["moonshotai"]
         moonshot_cn = snapshot["providers"]["moonshotai_cn"]
+        opencode = snapshot["providers"]["opencode"]
 
         assert openai["runtime"]["auth"]["type"] == "bearer"
         assert openai["runtime"]["base_url"] == "https://api.openai.com/v1"
@@ -105,6 +118,10 @@ defmodule LLMDB.PackagedTest do
         assert moonshot["runtime"]["base_url"] == "https://api.moonshot.ai/v1"
         assert moonshot_cn["runtime"]["auth"]["type"] == "bearer"
         assert moonshot_cn["runtime"]["base_url"] == "https://api.moonshot.cn/v1"
+        assert opencode["runtime"]["auth"]["type"] == "bearer"
+        assert opencode["runtime"]["auth"]["env"] == ["OPENCODE_API_KEY"]
+        assert opencode["runtime"]["base_url"] == "https://opencode.ai/zen/v1"
+        refute Map.get(opencode, "catalog_only", false)
       end
     end
 
@@ -237,6 +254,50 @@ defmodule LLMDB.PackagedTest do
           assert model["lifecycle"]["status"] == "retired"
           assert model["lifecycle"]["retires_at"] == "2026-05-25"
           assert model["lifecycle"]["replacement"] == "kimi-k2.6"
+        end
+      end
+    end
+
+    test "snapshot carries OpenCode Zen execution metadata for documented live models" do
+      snapshot = Packaged.snapshot()
+
+      if snapshot do
+        assert length(@local_opencode_execution_model_ids) == 48
+
+        opencode_models = snapshot["providers"]["opencode"]["models"]
+
+        samples = [
+          {"gpt-5.5", "openai_responses_compatible", "openai_responses", "/responses"},
+          {"claude-fable-5", "anthropic_messages", "anthropic_messages", "/messages"},
+          {"gemini-3.5-flash", "google_generate_content", "google_generate_content",
+           "/models/gemini-3.5-flash"},
+          {"deepseek-v4-pro", "openai_chat_compatible", "openai_chat", "/chat/completions"}
+        ]
+
+        for {model_id, family, wire_protocol, path} <- samples do
+          model = opencode_models[model_id]
+
+          assert is_map(model), "expected OpenCode model #{inspect(model_id)} in snapshot"
+          refute Map.get(model, "catalog_only", false)
+          assert model["execution"]["text"]["family"] == family
+          assert model["execution"]["text"]["wire_protocol"] == wire_protocol
+          assert model["execution"]["text"]["path"] == path
+        end
+      end
+    end
+
+    test "snapshot leaves unverified OpenCode Zen models catalog-only" do
+      snapshot = Packaged.snapshot()
+
+      if snapshot do
+        opencode_models = snapshot["providers"]["opencode"]["models"]
+
+        for model_id <- ["claude-3-5-haiku", "qwen3-coder"] do
+          model = opencode_models[model_id]
+
+          assert is_map(model), "expected OpenCode model #{inspect(model_id)} in snapshot"
+          assert model["catalog_only"] == true
+          assert model["execution"] == nil
         end
       end
     end


### PR DESCRIPTION
## Summary
- add OpenCode Zen provider runtime metadata using `OPENCODE_API_KEY` bearer auth
- add sparse local execution overrides for 48 OpenCode Zen models verified in both the live `/models` API and the official Zen docs
- regenerate the packaged snapshot and add packaged tests for representative protocol families plus stale catalog-only models

## Verification
- `mix llm_db.build --install`
- `MIX_ENV=test mix do loadconfig tmp/git_hooks_worktree.exs + test test/llm_db/packaged_test.exs`
- `MIX_ENV=test mix do loadconfig tmp/git_hooks_worktree.exs + test`
- pre-push `mix quality` hook passed

## Notes
- Evidence: https://opencode.ai/docs/zen/ and https://opencode.ai/zen/v1/models
- Added execution metadata only for the docs + live API + snapshot intersection.
- Skipped docs-only rows not present in the live API/snapshot: `qwen3.7-max`, `qwen3.7-plus`.
- Left live-only rows without docs endpoint evidence catalog-only for now: `claude-opus-4-1`, `claude-sonnet-4`.
- Left stale snapshot-only OpenCode models catalog-only.

Closes #224