### PR TITLE
[codex] add OpenAI o3 snapshot deprecations

### DIFF
--- a/priv/llm_db/local/openai/o3-2025-04-16.toml
+++ b/priv/llm_db/local/openai/o3-2025-04-16.toml
@@ -7,3 +7,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-06-11"
+retires_at = "2026-12-11"
+replacement = "gpt-5.5"

--- a/priv/llm_db/local/openai/o3-pro-2025-06-10.toml
+++ b/priv/llm_db/local/openai/o3-pro-2025-06-10.toml
@@ -7,3 +7,9 @@ protocol = "openai_responses"
 token_limit_key = "max_completion_tokens"
 temperature = "unsupported"
 reasoning_effort = "supported"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-06-11"
+retires_at = "2026-12-11"
+replacement = "gpt-5.5-pro"

--- a/test/llm_db/openai_deprecations_test.exs
+++ b/test/llm_db/openai_deprecations_test.exs
@@ -265,6 +265,11 @@ defmodule LLMDB.OpenAIDeprecationsTest do
       retires_at: "2026-10-23",
       replacement: "gpt-5.5-pro"
     },
+    "o3-2025-04-16" => %{
+      deprecated_at: "2026-06-11",
+      retires_at: "2026-12-11",
+      replacement: "gpt-5.5"
+    },
     "o3-deep-research-2025-06-26" => %{
       deprecated_at: "2026-04-22",
       retires_at: "2026-07-23",
@@ -275,6 +280,11 @@ defmodule LLMDB.OpenAIDeprecationsTest do
       deprecated_at: "2026-04-22",
       retires_at: "2026-10-23",
       replacement: "gpt-5.5"
+    },
+    "o3-pro-2025-06-10" => %{
+      deprecated_at: "2026-06-11",
+      retires_at: "2026-12-11",
+      replacement: "gpt-5.5-pro"
     },
     "o4-mini" => %{
       deprecated_at: "2026-04-22",


### PR DESCRIPTION
## Summary

- Add lifecycle metadata for deprecated OpenAI o3 dated snapshots:
  - `o3-2025-04-16` -> `gpt-5.5`
  - `o3-pro-2025-06-10` -> `gpt-5.5-pro`
- Extend the OpenAI deprecation expectations test for these models.
- Regenerate `priv/llm_db/snapshot.json` after rebasing on #234 so the generated artifact includes both the GPT-5 and o3 deprecation batches.

## Evidence

Official OpenAI deprecations docs list these two o3 snapshots under `2026-06-11: GPT-5 and o3 model deprecations`, with removal from the API on December 11, 2026 and the replacements above:

https://developers.openai.com/api/docs/deprecations#2026-06-11-gpt-5-and-o3-model-deprecations

Note: issue #233 was created from an OpenAI email that said shutdown is December 10, 2026. The public docs currently say December 11, 2026, so this PR uses the official public docs date.

## Validation

- `mix llm_db.build --install`
- `mix test test/llm_db/openai_deprecations_test.exs`
- `mix quality`
- `mix hex.audit`
- pre-push `mix quality`

Closes #233