### PR TITLE
docs: define public API compatibility contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`
 
 ## Docs & Guides
 
+- [API and Support Policy](guides/api-and-support-policy.md) — Stable APIs, extension points, internal modules, and compatibility guarantees
 - [Using the Data](guides/using-the-data.md) — Runtime API and querying
 - [Consumer Integration](guides/consumer-integration.md) — Best practices for libraries using llm_db
 - [Runtime Filters](guides/runtime-filters.md) — Load-time and runtime filtering

--- a/guides/api-and-support-policy.md
+++ b/guides/api-and-support-policy.md
@@ -1,0 +1,72 @@
+# API and Support Policy
+
+LLM DB separates its consumer API from build-time extension points and internal
+implementation modules. This boundary lets the catalog evolve without forcing
+downstream applications to follow internal refactors.
+
+## Stable Runtime API
+
+The following interfaces are covered by the package's backwards-compatibility
+policy:
+
+- The `LLMDB` facade: catalog loading, provider/model lookup, selection,
+  capability queries, filtering policy checks, and model-spec utilities.
+- `LLMDB.Model` and `LLMDB.Provider` structs, constructors, documented fields,
+  and `LLMDB.Model` JSON representation.
+- `LLMDB.Spec` parsing and formatting contracts exposed through `LLMDB`.
+- `LLMDB.History` read APIs and published history bundle readers.
+- Existing snapshot versions accepted by `LLMDB.Snapshot` and `LLMDB.load/1`.
+
+Primary return shapes are:
+
+| Operation | Success | Not found / no match |
+| --- | --- | --- |
+| `LLMDB.load/0,1` | `{:ok, snapshot}` | `{:error, reason}` |
+| `LLMDB.providers/0` | `[%LLMDB.Provider{}]` | `[]` |
+| `LLMDB.provider/1` | `{:ok, %LLMDB.Provider{}}` | `{:error, :not_found}` |
+| `LLMDB.models/0,1` | `[%LLMDB.Model{}]` | `[]` |
+| `LLMDB.model/1,2` | `{:ok, %LLMDB.Model{}}` | `{:error, reason}` |
+| `LLMDB.select/0,1` | `{:ok, {provider, model_id}}` | `{:error, :no_match}` |
+| `LLMDB.candidates/0,1` | `[{provider, model_id}]` | `[]` |
+| `LLMDB.allowed?/1` | boolean | `false` |
+| `LLMDB.capabilities/1` | capability map | `nil` |
+
+Minor releases may add fields or accepted inputs and may correct behavior that
+contradicts documented contracts. They do not remove accepted inputs, struct
+fields, snapshot readers, or supported task names without a deprecation window.
+
+## Supported Artifacts and Extensions
+
+- `LLMDB.Source` is the supported build-time source behaviour. Its canonical
+  output shape and optional `pull/1` callback are extension contracts.
+- `LLMDB.Snapshot` defines the supported snapshot artifact and reader. Existing
+  schema versions remain readable when a new version is introduced.
+- Documented `mix llm_db.*` tasks are supported maintainer entry points.
+
+Direct calls into Engine stages, source adapter internals, snapshot publishing
+helpers, or history rebuild internals are not extension contracts. If a
+published workflow depends on one of these today, it receives a documented
+replacement and deprecation window before removal.
+
+## Internal Implementation
+
+`LLMDB.Store`, `LLMDB.Loader`, `LLMDB.Runtime`, `LLMDB.Query`,
+`LLMDB.Config`, `LLMDB.Packaged`, and the normalization, merge, validation, and
+enrichment modules implement the stable contracts above. Their module layout,
+internal maps, indexes, and call graph may change in a minor release when the
+public behavior remains compatible.
+
+The raw-snapshot accessor on `LLMDB` is intentionally hidden from the public
+facade documentation. Consumers should use the typed query API or the versioned
+`LLMDB.Snapshot` artifact instead.
+
+## Deprecation Policy
+
+Deprecations identify the supported replacement, remain callable for the stated
+window, and are announced in release notes. Removing a stable runtime API,
+struct field, accepted snapshot version, or supported maintainer task requires
+a breaking release unless the API was already documented as transitional.
+
+See [Using the Data](using-the-data.md) for runtime examples and
+[Sources and Engine](sources-and-engine.md) for the build-time extension
+contract.

--- a/guides/schema-system.md
+++ b/guides/schema-system.md
@@ -87,7 +87,7 @@ provider = LLMDB.Provider.new!(provider_data)
 }
 ```
 
-See `LLMDB.Schema.Provider` and `LLMDB.Provider` for details.
+See `LLMDB.Provider` and `LLMDB.Provider.schema/0` for the executable schema.
 
 ## Model Schema
 
@@ -258,7 +258,7 @@ model_data = %{
 {:ok, model} = LLMDB.Model.new(model_data)
 ```
 
-See `LLMDB.Schema.Model` and `LLMDB.Model` for details.
+See `LLMDB.Model` and `LLMDB.Model.schema/0` for the executable schema.
 
 ## Nested Schemas
 
@@ -336,7 +336,7 @@ The `tools` capability object allows precise documentation of provider-specific 
 
 This granularity eliminates the need for client libraries to maintain provider-specific override lists, as the limitations are documented directly in the model metadata.
 
-Defaults applied during Enrich stage: booleans default to `false`, optional values to `nil`. See `LLMDB.Schema.Capabilities`.
+Defaults applied during Enrich stage: booleans default to `false`, optional values to `nil`. The capabilities schema is part of `LLMDB.Model.schema/0`.
 
 ### Limits
 
@@ -348,7 +348,7 @@ Defaults applied during Enrich stage: booleans default to `false`, optional valu
 }
 ```
 
-See `LLMDB.Schema.Limits`.
+The limits schema is part of `LLMDB.Model.schema/0`.
 
 ### Cost
 
@@ -372,7 +372,7 @@ Pricing per million tokens (USD):
 }
 ```
 
-See `LLMDB.Schema.Cost`.
+The legacy cost and additive pricing schemas are part of `LLMDB.Model.schema/0`.
 
 For conditional pricing components and request-context selection, see
 [Pricing and Billing](pricing-and-billing.md). For the rationale behind the

--- a/guides/sources-and-engine.md
+++ b/guides/sources-and-engine.md
@@ -1,94 +1,106 @@
 # Sources and Engine
 
-The Engine runs a build-time ETL pipeline that loads data from sources, normalizes, validates, merges, enriches, and indexes it, then builds a canonical `snapshot.json` artifact. Runtime only loads the packaged or explicitly fetched snapshot.
+`LLMDB.Engine` is the build-time ETL pipeline. It loads only the sources passed
+to it (or returned by `LLMDB.Config.sources!/0`), normalizes and validates their
+data, merges the source layers, enriches the result, and emits a canonical
+snapshot. Consumer runtime loading is separate: `LLMDB.load/1` reads a packaged
+or explicitly configured snapshot, then applies consumer filters and indexes.
 
 ## Source Behaviour
 
-All sources implement the `LLMDB.Source` behaviour:
+Sources implement `LLMDB.Source`:
 
 ```elixir
 @callback load(opts :: map()) :: {:ok, data :: map()} | {:error, term()}
-@callback pull(opts :: map()) :: :ok | {:error, term()}  # Optional
+@callback pull(opts :: map()) ::
+            :noop | {:ok, cache_path :: String.t()} | {:error, term()}
 ```
+
+`pull/1` is optional. Remote sources use it to refresh a local cache; `load/1`
+reads that cache and performs no network request.
 
 ### Canonical Format
 
+Each outer key is a provider ID string. Its value is a provider map with atom
+keys and a `:models` list. Model maps also use atom keys:
+
 ```elixir
 %{
-  "providers" => %{
-    openai: %{
-      "id" => :openai,
-      "name" => "OpenAI",
-      "base_url" => "https://api.openai.com/v1",
-      # ...
-    }
-  },
-  "models" => [
-    %{
-      "id" => "gpt-4",
-      "provider" => :openai,
-      "name" => "GPT-4",
-      # ...
-    },
-    # ...
-  ]
+  "openai" => %{
+    id: :openai,
+    name: "OpenAI",
+    base_url: "https://api.openai.com/v1",
+    models: [
+      %{
+        id: "gpt-4o",
+        provider: :openai,
+        name: "GPT-4o",
+        capabilities: %{chat: true}
+      }
+    ]
+  }
 }
 ```
 
-Outer map uses string keys; provider keys are atoms; model IDs are strings. Use `LLMDB.Source.assert_canonical!/1` for validation.
+Use `LLMDB.Source.assert_canonical!/1` for the fast shape assertion. Full Zoi
+validation happens in the Engine.
 
 ## Built-in Sources
 
-### ModelsDev (Remote)
+### Remote cached sources
+
+Models.dev, OpenRouter, OpenAI, Anthropic, Google, xAI, ZenMux, and Llmfit have
+source adapters. Run `mix llm_db.pull` to refresh their repository-local cache;
+the Engine subsequently reads that cache through each source's `load/1`.
+
+### Local TOML
 
 ```elixir
-{LLMDB.Sources.ModelsDev, %{
-  url: "https://models.dev/api/models",
-  cache_path: "priv/llm_db/cache/models_dev.json"
-}}
+{LLMDB.Sources.Local, %{dir: "priv/llm_db/local"}}
 ```
 
-`pull/1` downloads and caches via Req. `load/1` loads from cache. Transforms models.dev schema to canonical format (`limit` → `limits`, modality strings → atoms, unmapped → `:extra`).
+The directory contains one subdirectory per provider. Each provider directory
+contains `provider.toml` and model TOML files. The adapter injects the provider
+ID from the directory name.
 
-### Local (TOML)
-
-```elixir
-{LLMDB.Sources.Local, %{dir: "priv/llm_db"}}
-```
-
-Structure: `provider.toml` + `models/{provider}/*.toml`. Atomizes keys, injects `:provider` from directory name.
-
-## Configuring Sources
+## Configuring Build-time Sources
 
 ```elixir
 config :llm_db,
   sources: [
     {LLMDB.Sources.ModelsDev, %{}},
-    {LLMDB.Sources.Local, %{dir: "priv/llm_db"}}
+    {LLMDB.Sources.Local, %{dir: "priv/llm_db/local"}}
   ]
 ```
 
-Sources processed in order. Later sources override earlier ones.
+Sources are processed in order and later sources have higher precedence. The
+Engine does not implicitly place the packaged runtime snapshot beneath these
+sources. Passing no sources produces an empty Engine catalog with a warning;
+this does not change the independent runtime default of loading the packaged
+snapshot.
 
 ## ETL Pipeline
 
-`LLMDB.Engine.run/1` executes 7 stages:
+`LLMDB.Engine.run/1` performs these build-time stages:
 
-1. **Ingest**: Load sources, validate canonical format, flatten nested provider data
-2. **Normalize**: Convert provider IDs to atoms, normalize modalities to atoms, parse dates
-3. **Validate**: Zoi validation via `LLMDB.Validate`, drop invalid, log warnings
-4. **Merge**: Last-wins precedence; `:aliases` are unioned, other lists replaced, maps deep merged
-5. **Filter**: Compile allow/deny patterns (deny wins, globs supported)
-6. **Enrich**: Derive `:family`, fill `:provider_model_id`, apply capability defaults
-7. **Index**: Build `providers_by_id`, `models_by_key`, `models_by_provider`, `aliases_by_key`, then v2 snapshot
+1. **Ingest** — load configured sources and assert canonical shape.
+2. **Normalize** — normalize provider IDs, dates, modalities, and source fields.
+3. **Validate** — parse provider/model data with the Zoi schemas.
+4. **Merge** — apply last-source-wins precedence and field merge rules.
+5. **Finalize** — enrich records and nest models beneath providers.
+6. **Ensure viable** — warn when the resulting catalog is empty.
 
-Final check warns if zero providers/models.
+Allow/deny filters, provider preferences, custom runtime overlays, and runtime
+indexes are `LLMDB.load/1` concerns, not Engine stages.
 
-## Mix Tasks
+## Supported Maintainer Tasks
 
-- `mix llm_db.pull` - Fetch and cache remote sources
-- `mix llm_db.build` - Run ETL and build canonical snapshot artifacts
-- `mix llm_db.snapshot.publish` - Publish an immutable content-addressed snapshot to GitHub Releases
+- `mix llm_db.pull` — fetch and cache upstream source data.
+- `mix llm_db.build` — run ETL and build canonical snapshot artifacts.
+- `mix llm_db.snapshot.publish` — publish an immutable snapshot release.
+
+These tasks are maintainer tooling. Downstream applications consume the
+snapshot shipped with the package.
 
 ## Custom Source Example
 
@@ -98,13 +110,26 @@ defmodule MyApp.InternalModels do
 
   @impl true
   def load(_opts) do
-    {:ok, %{
-      "providers" => %{internal: %{"id" => :internal, "name" => "Internal"}},
-      "models" => [%{"id" => "custom-gpt", "provider" => :internal, "capabilities" => %{"chat" => true}}]
-    }}
+    {:ok,
+     %{
+       "internal" => %{
+         id: :internal,
+         name: "Internal",
+         models: [
+           %{
+             id: "custom-gpt",
+             provider: :internal,
+             capabilities: %{chat: true}
+           }
+         ]
+       }
+     }}
   end
 end
 
-# config.exs
 config :llm_db, sources: [{MyApp.InternalModels, %{}}]
 ```
+
+Custom sources are supported build-time extensions. Their output contract is
+stable, while Engine implementation modules are internal and may change behind
+that contract.

--- a/lib/llm_db/config.ex
+++ b/lib/llm_db/config.ex
@@ -9,9 +9,9 @@ defmodule LLMDB.Config do
   @doc """
   Returns the list of sources to load, in precedence order.
 
-  These sources provide raw data that will be merged ON TOP of the packaged
-  base snapshot. The packaged snapshot is always loaded first and is not
-  included in this sources list.
+  These are build-time inputs to `LLMDB.Engine`. The engine processes only the
+  configured sources, in precedence order; it does not automatically merge the
+  packaged runtime snapshot into the source list.
 
   ## Configuration
 
@@ -23,8 +23,9 @@ defmodule LLMDB.Config do
 
   ## Default Behavior
 
-  If not configured, returns an empty list `[]`, meaning only the packaged
-  snapshot will be used (stable, version-pinned behavior).
+  If not configured, returns an empty list `[]`, meaning no build-time sources
+  are configured. Runtime `LLMDB.load/1` independently defaults to the packaged,
+  version-pinned snapshot.
 
   ## Returns
 
@@ -36,7 +37,7 @@ defmodule LLMDB.Config do
 
     case Keyword.get(config, :sources) do
       nil ->
-        # Default: Empty list - only use packaged snapshot (stable mode)
+        # Default: no build-time Engine sources.
         []
 
       sources when is_list(sources) ->

--- a/lib/llm_db/engine.ex
+++ b/lib/llm_db/engine.ex
@@ -71,8 +71,8 @@ defmodule LLMDB.Engine do
   }
   ```
 
-  The snapshot contains ALL models from all sources. Indexes and filters are
-  built at load-time by `LLMDB.load/1` using the `LLMDB.Index` module.
+  The snapshot contains ALL models from all sources. Runtime indexes and filters
+  are built at load-time by `LLMDB.load/1`.
   """
   @spec run(keyword()) :: {:ok, map()} | {:error, term()}
   def run(opts \\ []) do

--- a/lib/llm_db/packaged.ex
+++ b/lib/llm_db/packaged.ex
@@ -3,11 +3,13 @@ defmodule LLMDB.Packaged do
   Provides access to the packaged base snapshot.
 
   This is NOT a Source - it returns the pre-processed, version-stable snapshot
-  that ships with each release. The snapshot has already been through the full
-  ETL pipeline (normalize → validate → merge → enrich → filter → index).
+  that ships with each release. The snapshot has already been normalized,
+  validated, merged, and enriched by the build-time ETL pipeline. Consumer
+  filters and runtime indexes are applied later by `LLMDB.load/1`.
 
-  Sources (ModelsDev, Local, Config) provide raw data that gets merged ON TOP
-  of this base snapshot.
+  Build-time sources produce future packaged snapshots through `LLMDB.Engine`.
+  They are not contacted or merged automatically when consumers load this
+  packaged snapshot at runtime.
 
   ## Loading Strategy
 

--- a/mix.exs
+++ b/mix.exs
@@ -32,8 +32,10 @@ defmodule LLMDB.MixProject do
         main: "readme",
         extras: [
           "README.md",
+          "guides/api-and-support-policy.md",
           "guides/consumer-integration.md",
           "guides/model-spec-formats.md",
+          "guides/model-struct-evolution-proposal.md",
           "guides/pricing-and-billing.md",
           "guides/schema-system.md",
           "guides/sources-and-engine.md",
@@ -44,6 +46,29 @@ defmodule LLMDB.MixProject do
         ],
         groups_for_extras: [
           Guides: ~r/guides\/.+\.md/
+        ],
+        groups_for_modules: [
+          "Stable Runtime API": [
+            LLMDB,
+            LLMDB.History,
+            LLMDB.Model,
+            LLMDB.Provider,
+            LLMDB.Spec
+          ],
+          "Supported Artifacts and Extensions": [
+            LLMDB.Snapshot,
+            LLMDB.Source
+          ],
+          "Maintainer Tooling": [
+            LLMDB.Engine,
+            LLMDB.Snapshot.Builder,
+            LLMDB.Snapshot.ReleaseStore,
+            ~r/^LLMDB\.Sources\./
+          ],
+          "Internal Implementation": [
+            ~r/^LLMDB\.(Application|Config|Enrich|Generated|Loader|Merge|Normalize|Packaged|Pricing|Query|Runtime|Store|Validate)(\.|$)/,
+            ~r/^LLMDB\.History\./
+          ]
         ]
       ]
     ]

--- a/test/llm_db/public_contract_test.exs
+++ b/test/llm_db/public_contract_test.exs
@@ -1,0 +1,164 @@
+defmodule LLMDB.PublicContractTest do
+  use ExUnit.Case, async: false
+
+  alias LLMDB.{Model, Provider, Snapshot, Store}
+
+  @model_fields [
+    :aliases,
+    :base_url,
+    :capabilities,
+    :catalog_only,
+    :cost,
+    :deprecated,
+    :doc_url,
+    :execution,
+    :extra,
+    :family,
+    :id,
+    :knowledge,
+    :last_updated,
+    :lifecycle,
+    :limits,
+    :modalities,
+    :model,
+    :name,
+    :pricing,
+    :provider,
+    :provider_model_id,
+    :release_date,
+    :retired,
+    :tags
+  ]
+
+  @provider_fields [
+    :alias_of,
+    :base_url,
+    :catalog_only,
+    :config_schema,
+    :doc,
+    :env,
+    :exclude_models,
+    :extra,
+    :id,
+    :name,
+    :pricing_defaults,
+    :runtime
+  ]
+
+  setup do
+    Store.clear!()
+
+    provider = Provider.new!(%{id: :contract_provider, name: "Contract Provider"})
+
+    model =
+      Model.new!(%{
+        id: "contract-model",
+        provider: :contract_provider,
+        name: "Contract Model",
+        capabilities: %{chat: true}
+      })
+
+    snapshot = %{
+      providers_by_id: %{contract_provider: provider},
+      models_by_key: %{{:contract_provider, "contract-model"} => model},
+      aliases_by_key: %{},
+      providers: [provider],
+      models: %{contract_provider: [model]},
+      base_models: [model],
+      filters: %{allow: :all, deny: %{}},
+      prefer: [:contract_provider],
+      meta: %{digest: "public-contract"}
+    }
+
+    Store.put!(snapshot, [])
+    on_exit(&Store.clear!/0)
+
+    %{model: model, provider: provider}
+  end
+
+  test "the public facade preserves primary return and error shapes", %{
+    model: model,
+    provider: provider
+  } do
+    assert [^provider] = LLMDB.providers()
+    assert {:ok, ^provider} = LLMDB.provider(:contract_provider)
+    assert {:error, :not_found} = LLMDB.provider(:missing_provider)
+
+    assert [^model] = LLMDB.models()
+    assert [^model] = LLMDB.models(:contract_provider)
+    assert [] = LLMDB.models(:missing_provider)
+    assert {:ok, ^model} = LLMDB.model(:contract_provider, "contract-model")
+    assert {:ok, ^model} = LLMDB.model("contract_provider:contract-model")
+    assert {:error, :not_found} = LLMDB.model(:contract_provider, "missing-model")
+
+    assert {:ok, {:contract_provider, "contract-model"}} = LLMDB.select(require: [chat: true])
+    assert {:error, :no_match} = LLMDB.select(require: [embeddings: true])
+    assert [{:contract_provider, "contract-model"}] = LLMDB.candidates(require: [chat: true])
+    assert [] = LLMDB.candidates(require: [embeddings: true])
+
+    assert LLMDB.allowed?({:contract_provider, "contract-model"})
+    refute LLMDB.allowed?({:contract_provider, "missing-model"})
+    assert %{chat: true} = LLMDB.capabilities({:contract_provider, "contract-model"})
+    assert nil == LLMDB.capabilities({:contract_provider, "missing-model"})
+  end
+
+  test "required public struct and model JSON fields remain present", %{
+    model: model,
+    provider: provider
+  } do
+    assert_required_fields(Map.from_struct(model), @model_fields)
+    assert_required_fields(Map.from_struct(provider), @provider_fields)
+
+    json =
+      model
+      |> Jason.encode!()
+      |> Jason.decode!()
+
+    assert_required_fields(json, Enum.map(@model_fields, &Atom.to_string/1))
+  end
+
+  test "the current snapshot artifact round-trips through the supported reader" do
+    document =
+      Snapshot.from_engine_snapshot(%{
+        version: 2,
+        generated_at: "2026-07-16T00:00:00Z",
+        providers: %{
+          contract_provider: %{
+            id: :contract_provider,
+            name: "Contract Provider",
+            models: %{}
+          }
+        }
+      })
+
+    assert document["schema_version"] == Snapshot.schema_version()
+    assert {:ok, ^document} = document |> Snapshot.encode() |> Snapshot.decode()
+  end
+
+  test "documented maintainer task names remain registered" do
+    tasks = [
+      {"llm_db.pull", Mix.Tasks.LlmDb.Pull},
+      {"llm_db.build", Mix.Tasks.LlmDb.Build},
+      {"llm_db.snapshot.fetch", Mix.Tasks.LlmDb.Snapshot.Fetch},
+      {"llm_db.snapshot.publish", Mix.Tasks.LlmDb.Snapshot.Publish},
+      {"llm_db.history.backfill", Mix.Tasks.LlmDb.History.Backfill},
+      {"llm_db.history.migrate_git", Mix.Tasks.LlmDb.History.MigrateGit},
+      {"llm_db.history.rebuild", Mix.Tasks.LlmDb.History.Rebuild},
+      {"llm_db.history.sync", Mix.Tasks.LlmDb.History.Sync},
+      {"llm_db.history.check", Mix.Tasks.LlmDb.History.Check},
+      {"llm_db.version", Mix.Tasks.LlmDb.Version}
+    ]
+
+    Enum.each(tasks, fn {name, module} ->
+      assert Mix.Task.get(name) == module
+      assert function_exported?(module, :run, 1)
+    end)
+  end
+
+  defp assert_required_fields(actual, required) do
+    missing = MapSet.difference(MapSet.new(required), MapSet.new(Map.keys(actual)))
+
+    assert MapSet.size(missing) == 0,
+           "missing required public fields: #{inspect(MapSet.to_list(missing))}"
+  end
+end


### PR DESCRIPTION
## Summary

- define the stable runtime API, supported artifact/extension points, maintainer tooling, and internal implementation boundary
- add compatibility tests for public return/error shapes, struct fields, model JSON, snapshot decoding, and documented Mix task names
- correct stale source, Engine, packaged snapshot, and schema documentation
- organize ExDoc modules by support level

## Why

The package exposed internal modules alongside consumer APIs and several guides described modules or source shapes that do not exist. Pinning the compatibility boundary first gives the following simplification PRs an executable contract.

## Compatibility

Documentation and tests only. No runtime behavior or public module is removed or changed.

## Validation

- `mix test` — 785 passed (41 doctests, 744 tests)
- `mix docs` — generated without warnings
- `mix quality` — passed
- pre-push test and quality hooks — passed

Closes #239