### PR TITLE
fix: scope dotenv loading to metadata pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,6 @@ The packaged snapshot loads automatically at app start. Optional runtime filters
 ```elixir
 # config/runtime.exs
 config :llm_db,
-  load_dotenv: true,                  # set false to skip .env loading
-  dotenv_override: false,             # set true to let .env override existing env vars
   filter: %{
     allow: :all,                     # :all or %{provider => [patterns]}
     deny: %{openai: ["*-preview"]}   # deny patterns override allow
@@ -227,7 +225,18 @@ config :llm_db,
   }
 ```
 
-**`.env` loading:** When `load_dotenv` is `true` (the default), LLM DB loads variables from a `.env` file at application start. Environment variables already set by the OS, shell, or tools like `direnv` are not overwritten unless `dotenv_override: true` is set. Set `load_dotenv: false` to skip `.env` loading entirely. Maintainer metadata pulls load the repo-local `.env` with override enabled so stale global API keys do not shadow local refresh credentials.
+**Runtime environment:** Starting or querying LLM DB never reads a host `.env`
+file. Applications own their runtime configuration and may use Dotenvy, direnv,
+or another mechanism before starting dependencies.
+
+The maintainer-only `mix llm_db.pull` task loads the repository-local `.env`
+before contacting upstream providers. These settings apply only to that task:
+
+```elixir
+config :llm_db,
+  load_dotenv: true,       # set false to skip .env during metadata pulls
+  dotenv_override: true   # repo credentials override the maintainer shell
+```
 
 ### Filter Examples
 

--- a/guides/api-and-support-policy.md
+++ b/guides/api-and-support-policy.md
@@ -35,6 +35,11 @@ Minor releases may add fields or accepted inputs and may correct behavior that
 contradicts documented contracts. They do not remove accepted inputs, struct
 fields, snapshot readers, or supported task names without a deprecation window.
 
+Runtime catalog loading reads a packaged or explicitly configured snapshot. It
+does not pull upstream provider metadata, read a host `.env`, or own application
+environment setup. The maintainer-only `mix llm_db.pull` task is the sole
+automatic dotenv boundary.
+
 ## Supported Artifacts and Extensions
 
 - `LLMDB.Source` is the supported build-time source behaviour. Its canonical

--- a/lib/llm_db/application.ex
+++ b/lib/llm_db/application.ex
@@ -17,7 +17,6 @@ defmodule LLMDB.Application do
   end
 
   defp load_catalog do
-    LLMDB.Dotenv.load!()
     _ = LLMDB.Generated.ValidModalities.list()
 
     if Application.get_env(:llm_db, :skip_packaged_load, false) do

--- a/lib/mix/tasks/llm_db.pull.ex
+++ b/lib/mix/tasks/llm_db.pull.ex
@@ -128,7 +128,9 @@ defmodule Mix.Tasks.LlmDb.Pull do
     # Load runtime.exs before consulting :load_dotenv so runtime configuration
     # can disable dotenv loading for this task.
     Mix.Task.run("app.config")
-    LLMDB.Dotenv.load!(override: true)
+
+    override? = Application.get_env(:llm_db, :dotenv_override, true)
+    LLMDB.Dotenv.load!(override: override?)
   end
 
   @doc false

--- a/test/llm_db/application_test.exs
+++ b/test/llm_db/application_test.exs
@@ -1,6 +1,8 @@
 defmodule LLMDB.ApplicationTest do
   use ExUnit.Case, async: false
 
+  @dotenv_path Path.expand(".env")
+
   describe "start/2" do
     test "returns a supervisor compatible with release_handler" do
       master = :application_controller.get_master(:llm_db)
@@ -12,33 +14,53 @@ defmodule LLMDB.ApplicationTest do
     end
   end
 
-  describe "load_dotenv configuration" do
-    test "load_dotenv defaults to true" do
-      original = Application.get_env(:llm_db, :load_dotenv)
+  describe "runtime environment boundary" do
+    test "application startup does not load the repository dotenv file" do
+      key = "LLMDB_RUNTIME_MUST_NOT_LOAD_DOTENV"
+      original_dotenv = dotenv_file()
+      original_env = System.get_env(key)
 
       try do
-        Application.delete_env(:llm_db, :load_dotenv)
-        assert Application.get_env(:llm_db, :load_dotenv, true) == true
+        File.write!(@dotenv_path, "#{key}=from_dotenv\n")
+        System.delete_env(key)
+
+        assert {:error, {:already_started, _pid}} = LLMDB.Application.start(:normal, [])
+        assert System.get_env(key) == nil
       after
-        if original do
-          Application.put_env(:llm_db, :load_dotenv, original)
-        end
+        restore_dotenv_file(original_dotenv)
+        restore_system_env(key, original_env)
       end
     end
 
-    test "load_dotenv can be set to false" do
-      original = Application.get_env(:llm_db, :load_dotenv)
+    test "catalog loading and queries do not load the repository dotenv file" do
+      key = "LLMDB_RUNTIME_LOAD_MUST_NOT_LOAD_DOTENV"
+      original_dotenv = dotenv_file()
+      original_env = System.get_env(key)
 
       try do
-        Application.put_env(:llm_db, :load_dotenv, false)
-        assert Application.get_env(:llm_db, :load_dotenv, true) == false
+        File.write!(@dotenv_path, "#{key}=from_dotenv\n")
+        System.delete_env(key)
+
+        assert {:ok, _snapshot} = LLMDB.load()
+        assert is_list(LLMDB.providers())
+        assert System.get_env(key) == nil
       after
-        if original do
-          Application.put_env(:llm_db, :load_dotenv, original)
-        else
-          Application.delete_env(:llm_db, :load_dotenv)
-        end
+        restore_dotenv_file(original_dotenv)
+        restore_system_env(key, original_env)
       end
     end
   end
+
+  defp dotenv_file do
+    case File.read(@dotenv_path) do
+      {:ok, contents} -> {:ok, contents}
+      {:error, :enoent} -> :missing
+    end
+  end
+
+  defp restore_dotenv_file({:ok, contents}), do: File.write!(@dotenv_path, contents)
+  defp restore_dotenv_file(:missing), do: File.rm(@dotenv_path)
+
+  defp restore_system_env(key, nil), do: System.delete_env(key)
+  defp restore_system_env(key, value), do: System.put_env(key, value)
 end

--- a/test/mix/tasks/llm_db.pull_test.exs
+++ b/test/mix/tasks/llm_db.pull_test.exs
@@ -30,6 +30,68 @@ defmodule Mix.Tasks.LlmDb.PullTest do
     end
   end
 
+  test "load_runtime_config_and_dotenv honors task-scoped override configuration" do
+    original_dotenv = dotenv_file()
+    original_runtime = runtime_file()
+    original_env = System.get_env("LLMDB_DOTENV_TEST_KEY")
+    original_load_dotenv = Application.get_env(:llm_db, :load_dotenv, :unset)
+    original_override = Application.get_env(:llm_db, :dotenv_override, :unset)
+
+    try do
+      File.write!(@dotenv_path, "LLMDB_DOTENV_TEST_KEY=from_dotenv\n")
+
+      File.write!(
+        @runtime_path,
+        "import Config\nconfig :llm_db, load_dotenv: true, dotenv_override: false\n"
+      )
+
+      Application.delete_env(:llm_db, :load_dotenv)
+      Application.delete_env(:llm_db, :dotenv_override)
+      System.put_env("LLMDB_DOTENV_TEST_KEY", "from_shell")
+      Mix.Task.reenable("app.config")
+
+      Mix.Tasks.LlmDb.Pull.load_runtime_config_and_dotenv()
+
+      assert Application.get_env(:llm_db, :load_dotenv) == true
+      assert Application.get_env(:llm_db, :dotenv_override) == false
+      assert System.get_env("LLMDB_DOTENV_TEST_KEY") == "from_shell"
+    after
+      restore_dotenv_file(original_dotenv)
+      restore_runtime_file(original_runtime)
+      restore_application_env(:load_dotenv, original_load_dotenv)
+      restore_application_env(:dotenv_override, original_override)
+      restore_system_env("LLMDB_DOTENV_TEST_KEY", original_env)
+    end
+  end
+
+  test "load_runtime_config_and_dotenv defaults to repository credentials winning" do
+    original_dotenv = dotenv_file()
+    original_runtime = runtime_file()
+    original_env = System.get_env("LLMDB_DOTENV_TEST_KEY")
+    original_load_dotenv = Application.get_env(:llm_db, :load_dotenv, :unset)
+    original_override = Application.get_env(:llm_db, :dotenv_override, :unset)
+
+    try do
+      File.write!(@dotenv_path, "LLMDB_DOTENV_TEST_KEY=from_dotenv\n")
+      File.write!(@runtime_path, "import Config\nconfig :llm_db, load_dotenv: true\n")
+
+      Application.delete_env(:llm_db, :load_dotenv)
+      Application.delete_env(:llm_db, :dotenv_override)
+      System.put_env("LLMDB_DOTENV_TEST_KEY", "from_shell")
+      Mix.Task.reenable("app.config")
+
+      Mix.Tasks.LlmDb.Pull.load_runtime_config_and_dotenv()
+
+      assert System.get_env("LLMDB_DOTENV_TEST_KEY") == "from_dotenv"
+    after
+      restore_dotenv_file(original_dotenv)
+      restore_runtime_file(original_runtime)
+      restore_application_env(:load_dotenv, original_load_dotenv)
+      restore_application_env(:dotenv_override, original_override)
+      restore_system_env("LLMDB_DOTENV_TEST_KEY", original_env)
+    end
+  end
+
   test "ensure_no_failed_sources! accepts skips and successful pulls" do
     results = [
       {LLMDB.Sources.Google, {:ok, "priv/llm_db/remote/google.json"}},
@@ -74,8 +136,10 @@ defmodule Mix.Tasks.LlmDb.PullTest do
   defp restore_runtime_file({:ok, contents}), do: File.write!(@runtime_path, contents)
   defp restore_runtime_file(:missing), do: File.rm(@runtime_path)
 
-  defp restore_application_env(:unset), do: Application.delete_env(:llm_db, :load_dotenv)
-  defp restore_application_env(value), do: Application.put_env(:llm_db, :load_dotenv, value)
+  defp restore_application_env(value), do: restore_application_env(:load_dotenv, value)
+
+  defp restore_application_env(key, :unset), do: Application.delete_env(:llm_db, key)
+  defp restore_application_env(key, value), do: Application.put_env(:llm_db, key, value)
 
   defp restore_system_env(key, nil), do: System.delete_env(key)
   defp restore_system_env(key, value), do: System.put_env(key, value)


### PR DESCRIPTION
## Summary

- remove automatic dotenv loading from `LLMDB.Application` startup
- load Mix application config, then dotenv, only inside `mix llm_db.pull`
- preserve `:dotenv_override` behavior, including the current default
- add regression coverage proving normal application startup and catalog queries do not read a repository `.env`

## Compatibility

Public runtime APIs and return shapes are unchanged. This narrows an implicit host-environment side effect to the existing maintainer metadata-sync task, which is the boundary that needs provider credentials.

## Stack

PR 2 of 5. Based on #258; merge after #258.

## Validation

- 11 focused dotenv/application/pull tests passed
- full stack: 806 tests passed (41 doctests, 765 tests)
- Credo clean; Dialyzer reported zero errors

Closes #246