### PR TITLE
fix: invalidate reloads on semantic changes

### DIFF
--- a/lib/llm_db/loader.ex
+++ b/lib/llm_db/loader.ex
@@ -119,24 +119,64 @@ defmodule LLMDB.Loader do
 
   ## Returns
 
-  Integer digest (phash2 hash)
+  Lowercase SHA-256 semantic fingerprint.
   """
-  @spec compute_digest(list(), list(), map()) :: integer()
+  @spec compute_digest(list(), list(), map()) :: String.t()
   def compute_digest(providers, base_models, runtime) do
-    # Stable hash of configuration that affects the final snapshot
-    :erlang.phash2({
-      # Provider IDs (order matters for determinism)
-      Enum.map(providers, & &1.id),
-      # Model keys (provider + id)
-      Enum.map(base_models, fn m -> {m.provider, m.id} end),
-      # Runtime config that affects filtering
-      runtime.raw_allow,
-      runtime.raw_deny,
-      runtime.prefer,
-      # Custom overlay
-      custom_digest(runtime.custom)
+    compute_digest(providers, base_models, runtime, %{
+      source_generated_at: nil,
+      source_snapshot_id: nil
     })
   end
+
+  @doc false
+  @spec compute_digest(list(), list(), map(), map()) :: String.t()
+  def compute_digest(providers, base_models, runtime, source_metadata) do
+    semantic_catalog = %{
+      version: 2,
+      providers: Enum.sort_by(providers, & &1.id),
+      models: Enum.sort_by(base_models, &{&1.provider, &1.id}),
+      filters: runtime.filters,
+      prefer: runtime.prefer,
+      source: source_metadata
+    }
+
+    semantic_catalog
+    |> canonical_digest_term()
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  # Encode maps as sorted entries so digest stability does not depend on the
+  # OTP 24.1+ `:deterministic` option or on a map's internal representation.
+  # Tagged composite values preserve distinctions between maps, lists, and
+  # tuples while recursively removing VM-specific representation details.
+  defp canonical_digest_term(%Regex{source: source, opts: opts}) do
+    {:llm_db_digest_regex, source, canonical_digest_term(opts)}
+  end
+
+  defp canonical_digest_term(term) when is_map(term) do
+    entries =
+      term
+      |> Map.to_list()
+      |> Enum.map(fn {key, value} ->
+        {canonical_digest_term(key), canonical_digest_term(value)}
+      end)
+      |> Enum.sort_by(fn {key, _value} -> :erlang.term_to_binary(key) end)
+
+    {:llm_db_digest_map, entries}
+  end
+
+  defp canonical_digest_term(term) when is_list(term) do
+    {:llm_db_digest_list, Enum.map(term, &canonical_digest_term/1)}
+  end
+
+  defp canonical_digest_term(term) when is_tuple(term) do
+    {:llm_db_digest_tuple, term |> Tuple.to_list() |> Enum.map(&canonical_digest_term/1)}
+  end
+
+  defp canonical_digest_term(term), do: term
 
   # Private helpers
   defp load_packaged(opts) do
@@ -364,7 +404,11 @@ defmodule LLMDB.Loader do
         source_generated_at: generated_at,
         source_snapshot_id: source_snapshot_id,
         loaded_at: DateTime.utc_now() |> DateTime.to_iso8601(),
-        digest: compute_digest(providers, base_models, runtime)
+        digest:
+          compute_digest(providers, base_models, runtime, %{
+            source_generated_at: generated_at,
+            source_snapshot_id: source_snapshot_id
+          })
       }
     }
   end
@@ -403,15 +447,6 @@ defmodule LLMDB.Loader do
       end)
     end)
     |> Map.new()
-  end
-
-  defp custom_digest(%{providers: [], models: []}), do: nil
-
-  defp custom_digest(%{providers: providers, models: models}) do
-    :erlang.phash2({
-      Enum.map(providers, & &1.id),
-      Enum.map(models, fn m -> {m.provider, m.id} end)
-    })
   end
 
   defp summarize_filter(:all), do: ":all"

--- a/test/llm_db/reload_idempotency_test.exs
+++ b/test/llm_db/reload_idempotency_test.exs
@@ -1,0 +1,227 @@
+defmodule LLMDB.ReloadIdempotencyTest do
+  use ExUnit.Case, async: false
+
+  alias LLMDB.{Engine, Loader, Snapshot, Store}
+  alias LLMDB.Sources.Config, as: ConfigSource
+
+  setup do
+    original_config = Application.get_all_env(:llm_db)
+    Store.clear!()
+
+    snapshot_path = write_snapshot!("base")
+
+    on_exit(fn ->
+      File.rm(snapshot_path)
+      Store.clear!()
+
+      Application.get_all_env(:llm_db)
+      |> Keyword.keys()
+      |> Enum.each(&Application.delete_env(:llm_db, &1))
+
+      Application.put_all_env(llm_db: original_config)
+    end)
+
+    %{snapshot_path: snapshot_path}
+  end
+
+  test "reload publishes changed custom provider and model metadata", %{snapshot_path: path} do
+    {:ok, first} = LLMDB.load(load_opts(path, custom("Provider A", "Model A")))
+    first_epoch = LLMDB.epoch()
+
+    assert {:ok, provider} = LLMDB.provider(:digest_custom)
+    assert provider.name == "Provider A"
+    assert {:ok, model} = LLMDB.model(:digest_custom, "same-id")
+    assert model.name == "Model A"
+
+    {:ok, second} = LLMDB.load(load_opts(path, custom("Provider B", "Model B")))
+
+    assert LLMDB.epoch() > first_epoch
+    assert first.meta.digest != second.meta.digest
+    assert {:ok, provider} = LLMDB.provider(:digest_custom)
+    assert provider.name == "Provider B"
+    assert {:ok, model} = LLMDB.model(:digest_custom, "same-id")
+    assert model.name == "Model B"
+  end
+
+  test "equivalent custom maps with different construction order remain a no-op", %{
+    snapshot_path: path
+  } do
+    model_a = Map.new(name: "Same Model", capabilities: %{chat: true})
+    model_b = Map.new(capabilities: %{chat: true}, name: "Same Model")
+
+    custom_a = %{digest_custom: [name: "Same Provider", models: %{"same-id" => model_a}]}
+    custom_b = %{digest_custom: [models: %{"same-id" => model_b}, name: "Same Provider"]}
+
+    {:ok, first} = LLMDB.load(load_opts(path, custom_a))
+    first_epoch = LLMDB.epoch()
+    {:ok, second} = LLMDB.load(load_opts(path, custom_b))
+
+    assert second == first
+    assert LLMDB.epoch() == first_epoch
+  end
+
+  test "equivalent accepted filter forms remain a no-op", %{snapshot_path: path} do
+    atom_key_opts = Keyword.put(load_opts(path), :allow, %{digest_base: ["base-*"]})
+    string_key_opts = Keyword.put(load_opts(path), :allow, %{"digest_base" => ["base-*"]})
+
+    {:ok, first} = LLMDB.load(atom_key_opts)
+    first_epoch = LLMDB.epoch()
+    {:ok, second} = LLMDB.load(string_key_opts)
+
+    assert second == first
+    assert LLMDB.epoch() == first_epoch
+  end
+
+  test "changing the effective filter publishes the new catalog", %{snapshot_path: path} do
+    {:ok, first} = LLMDB.load(load_opts(path))
+    first_epoch = LLMDB.epoch()
+
+    filtered_opts = Keyword.put(load_opts(path), :allow, %{digest_base: ["base-*"]})
+    {:ok, second} = LLMDB.load(filtered_opts)
+
+    assert second.meta.digest != first.meta.digest
+    assert LLMDB.epoch() > first_epoch
+    assert Map.keys(second.models) == [:digest_base]
+    assert {:ok, _model} = LLMDB.model(:digest_base, "base-model")
+    assert {:error, :not_found} = LLMDB.model(:digest_other, "other-model")
+  end
+
+  test "changing provider preference publishes new selection order", %{snapshot_path: path} do
+    first_opts = Keyword.put(load_opts(path), :prefer, [:digest_base, :digest_other])
+    {:ok, first} = LLMDB.load(first_opts)
+    first_epoch = LLMDB.epoch()
+    assert [{:digest_base, "base-model"} | _] = LLMDB.candidates(require: [chat: true])
+
+    second_opts = Keyword.put(load_opts(path), :prefer, [:digest_other, :digest_base])
+    {:ok, second} = LLMDB.load(second_opts)
+
+    assert second.meta.digest != first.meta.digest
+    assert LLMDB.epoch() > first_epoch
+    assert [{:digest_other, "other-model"} | _] = LLMDB.candidates(require: [chat: true])
+  end
+
+  test "a new source snapshot identity invalidates an equivalent catalog" do
+    first_path = write_snapshot!("source-a")
+    second_path = write_snapshot!("source-b")
+
+    on_exit(fn ->
+      File.rm(first_path)
+      File.rm(second_path)
+    end)
+
+    {:ok, first} = LLMDB.load(load_opts(first_path))
+    first_epoch = LLMDB.epoch()
+    {:ok, second} = LLMDB.load(load_opts(second_path))
+
+    assert first.meta.source_snapshot_id != second.meta.source_snapshot_id
+    assert first.meta.digest != second.meta.digest
+    assert LLMDB.epoch() > first_epoch
+    assert first.providers == second.providers
+    assert first.base_models == second.base_models
+  end
+
+  test "equivalent loads have one deterministic fingerprint across processes", %{
+    snapshot_path: path
+  } do
+    opts =
+      path
+      |> load_opts(custom("Stable Provider", "Stable Model"))
+      |> Keyword.put(:allow, %{
+        digest_base: ["base-*"],
+        digest_other: ["other-*"]
+      })
+
+    digests =
+      1..4
+      |> Enum.map(fn _ -> Task.async(fn -> Loader.load(opts) end) end)
+      |> Task.await_many()
+      |> Enum.map(fn {:ok, snapshot} -> snapshot.meta.digest end)
+
+    assert [digest] = Enum.uniq(digests)
+    assert digest =~ ~r/^[a-f0-9]{64}$/
+
+    {:ok, _snapshot} = LLMDB.load(opts)
+    epoch = LLMDB.epoch()
+
+    1..4
+    |> Enum.map(fn _ -> Task.async(fn -> LLMDB.load(opts) end) end)
+    |> Task.await_many()
+    |> Enum.each(fn {:ok, snapshot} -> assert snapshot.meta.digest == digest end)
+
+    assert LLMDB.epoch() == epoch
+  end
+
+  defp load_opts(path, custom \\ %{}) do
+    [
+      snapshot_source: {:file, path},
+      allow: :all,
+      deny: %{},
+      prefer: [],
+      custom: custom
+    ]
+  end
+
+  defp custom(provider_name, model_name) do
+    %{
+      digest_custom: [
+        name: provider_name,
+        models: %{
+          "same-id" => %{
+            name: model_name,
+            capabilities: %{chat: true}
+          }
+        }
+      ]
+    }
+  end
+
+  defp write_snapshot!(nonce) do
+    {:ok, engine_snapshot} =
+      Engine.run(
+        sources: [
+          {ConfigSource,
+           %{
+             overrides: %{
+               digest_base: %{
+                 name: "Digest Base",
+                 models: [
+                   %{
+                     id: "base-model",
+                     provider: :digest_base,
+                     capabilities: %{chat: true}
+                   }
+                 ]
+               },
+               digest_other: %{
+                 name: "Digest Other",
+                 models: [
+                   %{
+                     id: "other-model",
+                     provider: :digest_other,
+                     capabilities: %{chat: true}
+                   }
+                 ]
+               }
+             }
+           }}
+        ]
+      )
+
+    document =
+      engine_snapshot
+      |> Map.put(:generated_at, "2026-07-16T00:00:00Z")
+      |> Snapshot.from_engine_snapshot()
+      |> Map.delete("snapshot_id")
+      |> Map.put("test_revision_nonce", nonce)
+      |> then(fn snapshot -> Map.put(snapshot, "snapshot_id", Snapshot.snapshot_id(snapshot)) end)
+
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "llm-db-reload-#{nonce}-#{System.unique_integer([:positive])}.json"
+      )
+
+    Snapshot.write!(path, document)
+    path
+  end
+end


### PR DESCRIPTION
## Summary

- replace the ID-only reload digest with a deterministic SHA-256 fingerprint of effective catalog content
- include normalized providers, models, filters, preferences, and source snapshot identity
- keep semantically equivalent reordered input idempotent
- add regression coverage for metadata-only changes, source identity changes, cross-process determinism, and concurrent warm reloads

## Compatibility

`LLMDB.load/1` and snapshot result shapes stay unchanged. Reloads still no-op when the effective inputs are equivalent, but now publish when metadata changes without an ID change.

## Stack

PR 3 of 5. Based on #259; merge after #259.

## Validation

- 14 focused loader/reload tests passed
- full stack: 806 tests passed (41 doctests, 765 tests)
- Credo clean; Dialyzer reported zero errors

Closes #240