### PR TITLE
fix: apply filters to custom catalog entries

### DIFF
--- a/lib/llm_db/config.ex
+++ b/lib/llm_db/config.ex
@@ -128,14 +128,22 @@ defmodule LLMDB.Config do
 
   `{%{allow: compiled_patterns, deny: compiled_patterns}, unknown_providers}`
 
-  Where `compiled_patterns` is either `:all` or `%{provider => [%Regex{}]}`,
+  Where allow patterns are `:all`, `:none`, or
+  `%{provider => :all | [%Regex{}]}`,
   and `unknown_providers` is a list of provider keys that were ignored.
   """
   @spec compile_filters(allow :: :all | map(), deny :: map(), known_providers :: [atom()] | nil) ::
-          {%{allow: :all | map(), deny: map()}, unknown: [term()]}
+          {%{allow: :all | :none | map(), deny: map()}, unknown: [term()]}
   def compile_filters(allow, deny, known_providers \\ nil) do
     {compiled_allow, unknown_allow} = compile_patterns(allow, known_providers)
     {compiled_deny, unknown_deny} = compile_patterns(deny, known_providers)
+
+    compiled_allow =
+      if is_map(allow) and map_size(allow) > 0 and compiled_allow == %{} do
+        :none
+      else
+        compiled_allow
+      end
 
     unknown = Enum.uniq(unknown_allow ++ unknown_deny)
 
@@ -158,22 +166,7 @@ defmodule LLMDB.Config do
                                           {acc_compiled, acc_unknown} ->
         case resolve_provider_key(provider, known_providers) do
           {:ok, provider_atom} ->
-            # Ensure patterns_list is a list
-            list = List.wrap(patterns_list)
-
-            # Compile each pattern (string glob or Regex)
-            compiled =
-              Enum.map(list, fn
-                %Regex{} = r ->
-                  r
-
-                s when is_binary(s) ->
-                  LLMDB.Merge.compile_pattern(s)
-
-                other ->
-                  raise ArgumentError,
-                        "llm_db: filter pattern must be string or Regex, got: #{inspect(other)} for provider #{inspect(provider_atom)}"
-              end)
+            compiled = compile_provider_patterns(patterns_list, provider_atom)
 
             {Map.put(acc_compiled, provider_atom, compiled), acc_unknown}
 
@@ -187,6 +180,24 @@ defmodule LLMDB.Config do
   end
 
   defp compile_patterns(_, _known_providers), do: {%{}, []}
+
+  defp compile_provider_patterns(:all, _provider), do: :all
+
+  defp compile_provider_patterns(patterns, provider) do
+    patterns
+    |> List.wrap()
+    |> Enum.map(fn
+      %Regex{} = regex ->
+        regex
+
+      pattern when is_binary(pattern) ->
+        LLMDB.Merge.compile_pattern(pattern)
+
+      other ->
+        raise ArgumentError,
+              "llm_db: filter pattern must be string, Regex, or :all, got: #{inspect(other)} for provider #{inspect(provider)}"
+    end)
+  end
 
   defp resolve_provider_key(provider, known_providers) when is_atom(provider) do
     # If known_providers specified, validate; otherwise trust the atom

--- a/lib/llm_db/engine.ex
+++ b/lib/llm_db/engine.ex
@@ -287,7 +287,7 @@ defmodule LLMDB.Engine do
       # Deny wins - check first
       deny_patterns = Map.get(deny, provider, [])
 
-      if matches_patterns?(model_id, deny_patterns) do
+      if deny_patterns == :all or matches_patterns?(model_id, deny_patterns) do
         false
       else
         # Then check allow
@@ -295,13 +295,15 @@ defmodule LLMDB.Engine do
           :all ->
             true
 
-          allow_map when is_map(allow_map) ->
-            allow_patterns = Map.get(allow_map, provider, [])
+          :none ->
+            false
 
-            if map_size(allow_map) > 0 and allow_patterns == [] do
-              false
-            else
-              allow_patterns == [] or matches_patterns?(model_id, allow_patterns)
+          allow_map when is_map(allow_map) ->
+            case Map.fetch(allow_map, provider) do
+              {:ok, :all} -> true
+              {:ok, []} -> false
+              {:ok, allow_patterns} -> matches_patterns?(model_id, allow_patterns)
+              :error -> map_size(allow_map) == 0
             end
         end
       end

--- a/lib/llm_db/loader.ex
+++ b/lib/llm_db/loader.ex
@@ -52,8 +52,8 @@ defmodule LLMDB.Loader do
   def load(opts \\ []) do
     with {:ok, {providers, models, generated_at, source_snapshot_id}} <- load_packaged(opts),
          runtime <- Runtime.compile(opts ++ [provider_ids: Enum.map(providers, & &1.id)]),
-         :ok <- warn_unknown_providers(runtime.unknown, providers),
          {providers2, models2} <- merge_custom({providers, models}, runtime.custom),
+         :ok <- warn_unknown_providers(runtime.unknown, providers2),
          models3 <- Pricing.apply_cost_components(models2),
          models4 <- Pricing.apply_provider_defaults(providers2, models3),
          filtered_models <- Engine.apply_filters(models4, runtime.filters),

--- a/lib/llm_db/runtime.ex
+++ b/lib/llm_db/runtime.ex
@@ -87,7 +87,7 @@ defmodule LLMDB.Runtime do
     deny = normalize_deny(Keyword.get(opts, :deny, base.deny))
     prefer = Keyword.get(opts, :prefer, base.prefer) || []
     custom = normalize_custom(Keyword.get(opts, :custom, base.custom))
-    provider_ids = Keyword.get(opts, :provider_ids)
+    provider_ids = include_custom_provider_ids(Keyword.get(opts, :provider_ids), custom.providers)
 
     # Compile filters (deferred if provider_ids not provided)
     {filters, unknown: unknown} =
@@ -207,6 +207,13 @@ defmodule LLMDB.Runtime do
   end
 
   defp normalize_custom(_), do: %{providers: [], models: []}
+
+  defp include_custom_provider_ids(nil, _custom_providers), do: nil
+
+  defp include_custom_provider_ids(provider_ids, custom_providers) do
+    custom_ids = Enum.map(custom_providers, & &1.id)
+    Enum.uniq(provider_ids ++ custom_ids)
+  end
 
   # Helper to conditionally add non-nil values to a map
   defp maybe_put(map, _key, nil), do: map

--- a/test/llm_db/config_test.exs
+++ b/test/llm_db/config_test.exs
@@ -113,6 +113,30 @@ defmodule LLMDB.ConfigTest do
       assert unknown == []
     end
 
+    test "preserves provider-wide :all sentinels" do
+      {result, unknown: []} =
+        LLMDB.Config.compile_filters(
+          %{openai: :all},
+          %{anthropic: :all},
+          [:openai, :anthropic]
+        )
+
+      assert result.allow == %{openai: :all}
+      assert result.deny == %{anthropic: :all}
+    end
+
+    test "does not turn a non-empty unknown allow map into allow all" do
+      {result, unknown: unknown} =
+        LLMDB.Config.compile_filters(
+          %{unknown_filter_provider: :all},
+          %{},
+          [:openai]
+        )
+
+      assert result.allow == :none
+      assert unknown == [:unknown_filter_provider]
+    end
+
     test "compiled patterns match correctly" do
       allow = %{openai: ["gpt-4*"]}
       {result, _unknown_info} = LLMDB.Config.compile_filters(allow, %{})
@@ -180,7 +204,7 @@ defmodule LLMDB.ConfigTest do
       allow = %{anthropic: [123]}
 
       assert_raise ArgumentError,
-                   ~r/llm_db: filter pattern must be string or Regex/,
+                   ~r/llm_db: filter pattern must be string, Regex, or :all/,
                    fn ->
                      LLMDB.Config.compile_filters(allow, %{})
                    end

--- a/test/llm_db/consumer_filtering_test.exs
+++ b/test/llm_db/consumer_filtering_test.exs
@@ -106,6 +106,30 @@ defmodule LLMDB.ConsumerFilteringTest do
              end) =~ "unknown provider(s) in filter: [:unknown_provider]"
     end
 
+    test "does not widen an allow map containing only unknown providers" do
+      test_data = %{
+        anthropic: %{
+          id: :anthropic,
+          models: [%{id: "claude-3-haiku-20240307", provider: :anthropic}]
+        }
+      }
+
+      Application.put_env(:llm_db, :filter, %{
+        allow: %{unknown_provider: :all}
+      })
+
+      assert capture_log(fn ->
+               assert {:error, error_msg} =
+                        LLMDB.load(
+                          runtime_overrides: %{
+                            sources: [{ConfigSource, %{overrides: test_data}}]
+                          }
+                        )
+
+               assert error_msg =~ "filters eliminated all models"
+             end) =~ "unknown provider(s) in filter: [:unknown_provider]"
+    end
+
     test "fails fast when filter with explicit allow map eliminates all models" do
       # Use test data with known providers
       test_data = %{
@@ -209,6 +233,104 @@ defmodule LLMDB.ConsumerFilteringTest do
   end
 
   describe "consumer use case: custom providers via app config" do
+    test "allows only a custom provider without leaking packaged providers" do
+      snapshot_path =
+        write_test_snapshot!(%{
+          providers: [%{id: :filter_packaged, name: "Packaged"}],
+          models: [
+            %{id: "packaged-model", provider: :filter_packaged, capabilities: %{chat: true}}
+          ]
+        })
+
+      on_exit(fn -> File.rm(snapshot_path) end)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, snapshot} =
+                   LLMDB.load(
+                     snapshot_source: {:file, snapshot_path},
+                     allow: %{filter_local: :all},
+                     custom: %{
+                       filter_local: [
+                         name: "Local",
+                         models: %{
+                           "local-model" => %{capabilities: %{chat: true}}
+                         }
+                       ]
+                     }
+                   )
+
+          assert Map.keys(snapshot.models) == [:filter_local]
+        end)
+
+      refute log =~ "unknown provider"
+      assert {:ok, _model} = LLMDB.model(:filter_local, "local-model")
+      assert {:error, :not_found} = LLMDB.model(:filter_packaged, "packaged-model")
+    end
+
+    test "provider-wide deny applies to custom providers" do
+      snapshot_path =
+        write_test_snapshot!(%{
+          providers: [%{id: :filter_packaged, name: "Packaged"}],
+          models: [
+            %{id: "packaged-model", provider: :filter_packaged, capabilities: %{chat: true}}
+          ]
+        })
+
+      on_exit(fn -> File.rm(snapshot_path) end)
+
+      assert {:ok, snapshot} =
+               LLMDB.load(
+                 snapshot_source: {:file, snapshot_path},
+                 allow: :all,
+                 deny: %{filter_local: :all},
+                 custom: %{
+                   filter_local: [
+                     models: %{
+                       "local-model" => %{capabilities: %{chat: true}}
+                     }
+                   ]
+                 }
+               )
+
+      assert Map.keys(snapshot.models) == [:filter_packaged]
+      assert {:error, :not_found} = LLMDB.model(:filter_local, "local-model")
+      assert {:ok, _model} = LLMDB.model(:filter_packaged, "packaged-model")
+    end
+
+    test "filters custom model additions to an existing packaged provider" do
+      snapshot_path =
+        write_test_snapshot!(%{
+          providers: [%{id: :filter_packaged, name: "Packaged"}],
+          models: [
+            %{id: "base-model", provider: :filter_packaged, capabilities: %{chat: true}}
+          ]
+        })
+
+      on_exit(fn -> File.rm(snapshot_path) end)
+
+      assert {:ok, snapshot} =
+               LLMDB.load(
+                 snapshot_source: {:file, snapshot_path},
+                 allow: %{filter_packaged: ["custom-*"]},
+                 custom: %{
+                   filter_packaged: [
+                     models: %{
+                       "custom-model" => %{
+                         aliases: ["friendly-model"],
+                         capabilities: %{chat: true}
+                       }
+                     }
+                   ]
+                 }
+               )
+
+      assert Enum.map(snapshot.models.filter_packaged, & &1.id) == ["custom-model"]
+      assert {:error, :not_found} = LLMDB.model(:filter_packaged, "base-model")
+      assert {:ok, model} = LLMDB.model(:filter_packaged, "friendly-model")
+      assert model.id == "custom-model"
+    end
+
     test "loads custom provider and models from app env config" do
       Application.put_env(:llm_db, :custom, %{
         local_llm: [

--- a/test/llm_db/engine_test.exs
+++ b/test/llm_db/engine_test.exs
@@ -201,6 +201,32 @@ defmodule LLMDB.EngineTest do
       assert length(filtered) == 2
     end
 
+    test "treats an empty allow map as allow all" do
+      models = [
+        %{id: "model-1", provider: :provider_a},
+        %{id: "model-2", provider: :provider_b}
+      ]
+
+      assert Engine.apply_filters(models, %{allow: %{}, deny: %{}}) == models
+    end
+
+    test "supports provider-wide allow and deny sentinels" do
+      models = [
+        %{id: "model-a", provider: :provider_a},
+        %{id: "model-b", provider: :provider_b}
+      ]
+
+      filters = %{allow: %{provider_a: :all, provider_b: []}, deny: %{provider_b: :all}}
+
+      assert Engine.apply_filters(models, filters) == [hd(models)]
+    end
+
+    test "allows no models with the compiled :none sentinel" do
+      models = [%{id: "model-a", provider: :provider_a}]
+
+      assert Engine.apply_filters(models, %{allow: :none, deny: %{}}) == []
+    end
+
     test "filters by allow patterns" do
       models = [
         %{id: "model-a1", provider: :provider_a},


### PR DESCRIPTION
## Summary

- compile filters against the effective provider set, including normalized custom providers
- apply provider-wide `:all` allow and deny entries consistently
- preserve explicit empty allow-map behavior while preventing typo-only allow maps from widening to all models
- validate unknown providers after custom entries are merged
- cover custom-only allow, custom deny, custom models on packaged providers, aliases, and packaged filtering behavior

## Compatibility

The existing filter configuration and public result shapes are unchanged. This corrects the case where `allow: %{local: :all}` could discard the custom key and leak the full packaged catalog.

## Stack

PR 4 of 5. Based on #260; merge after #260.

## Validation

- 56 focused config/filter/runtime/reload tests passed
- full stack: 806 tests passed (41 doctests, 765 tests)
- Credo clean; Dialyzer reported zero errors

Closes #241