### PR TITLE
fix: restore documented model lookup forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ A `model_spec` is a string in one of two formats:
 
 Both formats are automatically recognized and work interchangeably. Use the `@` format when model specs appear in filenames, CI artifact names, or other filesystem contexts where colons are problematic.
 
-Tuples `{:provider_atom, "id"}` also work, but prefer the string spec.
+Model lookup and parsing also accept tuples such as `{:provider_atom, "id"}` and `{"provider-id", "id"}`, but prefer the string spec. String provider IDs are normalized to the canonical provider atom.
 
 ```elixir
 {:ok, model} = LLMDB.model("openai:gpt-4o-mini")
@@ -119,7 +119,7 @@ LLMDB.allowed?("openai:gpt-4o-mini") #=> true
 
 ## API Cheatsheet
 
-- **`model/1`** — `"provider:model"`, `"model@provider"`, or `{:provider, id}` → `{:ok, %Model{}}` | `{:error, _}`
+- **`model/1`** — `"provider:model"`, `"model@provider"`, `{:provider, id}`, or `{"provider", id}` → `{:ok, %Model{}}` | `{:error, _}`
 - **`model/2`** — `provider` atom + `id` → `{:ok, %Model{}}` | `{:error, _}`
 - **`models/0`** — list all models → `[%Model{}]`
 - **`models/1`** — list provider's models → `[%Model{}]`

--- a/guides/model-spec-formats.md
+++ b/guides/model-spec-formats.md
@@ -96,7 +96,7 @@ All three formats can be used interchangeably throughout the API.
 
 ### Syntax
 - Two-element tuple: `{provider_atom, model_id_string}`
-- Provider is always an atom with underscores (not hyphens)
+- Accepted lookup inputs may use a provider atom or string; parsed tuples always contain the canonical atom with underscores
 - Model ID is always a string
 
 ### When to Use
@@ -110,6 +110,10 @@ All three formats can be used interchangeably throughout the API.
 ```elixir
 # Parse to tuple
 {:openai, "gpt-4o-mini"} = LLMDB.parse!("openai:gpt-4o-mini")
+
+# String providers in tuple inputs normalize to the canonical atom
+{:ok, {:google_vertex, "gemini-1.5-pro"}} =
+  LLMDB.parse({"google-vertex", "gemini-1.5-pro"})
 
 # Format from tuple
 "openai:gpt-4o-mini" = LLMDB.format({:openai, "gpt-4o-mini"})

--- a/lib/llm_db.ex
+++ b/lib/llm_db.ex
@@ -36,7 +36,7 @@ defmodule LLMDB do
 
   - `models/0` - Get all models as list of Model structs
   - `models/1` - Get all models for a provider
-  - `model/1` - Parse "provider:model" spec and get model
+  - `model/1` - Resolve a colon, @, or tuple model spec
   - `model/2` - Get a specific model by provider and ID
 
   ## Selection and Policy
@@ -83,6 +83,7 @@ defmodule LLMDB do
   alias LLMDB.{Loader, Model, Provider, Query, Spec, Store}
 
   @type provider :: atom()
+  @type provider_input :: provider() | String.t()
   @type model_id :: String.t()
   @type model_spec :: {provider(), model_id()} | String.t() | Model.t()
 
@@ -242,13 +243,15 @@ defmodule LLMDB do
   defdelegate models(provider), to: Store
 
   @doc """
-  Parses model spec string and returns the model.
+  Parses a model spec and returns the model.
 
-  Supports both "provider:model" and "model@provider" formats.
+  Supports "provider:model", "model@provider", and tuple formats. Tuple provider
+  identifiers may be atoms or strings and are normalized through the same
+  provider contract as string specs.
 
   ## Parameters
 
-  - `spec` - Model spec string like `"openai:gpt-4o-mini"` or `"gpt-4o-mini@openai"`
+  - `spec` - A string spec or `{provider, model_id}` tuple
 
   ## Returns
 
@@ -259,9 +262,20 @@ defmodule LLMDB do
 
       {:ok, model} = LLMDB.model("openai:gpt-4o-mini")
       {:ok, model} = LLMDB.model("gpt-4o-mini@openai")
+      {:ok, model} = LLMDB.model({:openai, "gpt-4o-mini"})
+      {:ok, model} = LLMDB.model({"openai", "gpt-4o-mini"})
       {:ok, model} = LLMDB.model("anthropic:claude-3-5-sonnet-20241022")
   """
-  @spec model(String.t()) :: {:ok, Model.t()} | {:error, term()}
+  @spec model(String.t() | {provider_input(), model_id()}) ::
+          {:ok, Model.t()} | {:error, term()}
+  def model({provider, model_id})
+      when (is_atom(provider) or is_binary(provider)) and is_binary(model_id) do
+    with {:ok, {normalized_provider, normalized_model_id}} <-
+           Spec.parse_spec({provider, model_id}) do
+      model(normalized_provider, normalized_model_id)
+    end
+  end
+
   def model(spec) when is_binary(spec) do
     with {:ok, {p, id}} <- Spec.parse_spec(spec) do
       model(p, id)
@@ -412,7 +426,7 @@ defmodule LLMDB do
 
   ## Parameters
 
-  - `spec` - String like `"openai:gpt-4o-mini"`, `"gpt-4o-mini@openai"`, or tuple `{:openai, "gpt-4o-mini"}`
+  - `spec` - String like `"openai:gpt-4o-mini"`, `"gpt-4o-mini@openai"`, or a tuple such as `{:openai, "gpt-4o-mini"}` or `{"openai", "gpt-4o-mini"}`
   - `opts` - Keyword list with optional `:format` to explicitly specify `:colon` or `:at`
 
   ## Returns
@@ -426,11 +440,12 @@ defmodule LLMDB do
       {:ok, {:openai, "gpt-4o-mini"}} = LLMDB.parse("gpt-4o-mini@openai")
       {:ok, {:anthropic, "claude-3-5-sonnet-20241022"}} = LLMDB.parse("anthropic:claude-3-5-sonnet-20241022")
       {:ok, {:openai, "gpt-4o"}} = LLMDB.parse({:openai, "gpt-4o"})
+      {:ok, {:openai, "gpt-4o"}} = LLMDB.parse({"openai", "gpt-4o"})
 
       # With explicit format when ambiguous
       {:ok, {:openai, "model@test"}} = LLMDB.parse("openai:model@test", format: :colon)
   """
-  @spec parse(String.t() | {provider(), model_id()}, keyword()) ::
+  @spec parse(String.t() | {provider_input(), model_id()}, keyword()) ::
           {:ok, {provider(), model_id()}} | {:error, term()}
   def parse(spec, opts \\ []), do: Spec.parse_spec(spec, opts)
 
@@ -444,7 +459,8 @@ defmodule LLMDB do
       {:openai, "gpt-4o-mini"} = LLMDB.parse!("openai:gpt-4o-mini")
       {:openai, "gpt-4o-mini"} = LLMDB.parse!("gpt-4o-mini@openai")
   """
-  @spec parse!(String.t() | {provider(), model_id()}, keyword()) :: {provider(), model_id()}
+  @spec parse!(String.t() | {provider_input(), model_id()}, keyword()) ::
+          {provider(), model_id()}
   def parse!(spec, opts \\ []), do: Spec.parse_spec!(spec, opts)
 
   @doc """

--- a/lib/llm_db/spec.ex
+++ b/lib/llm_db/spec.ex
@@ -84,7 +84,8 @@ defmodule LLMDB.Spec do
 
   ## Parameters
 
-  - `spec` - String in "provider:model" or "model@provider" format, or {provider, model_id} tuple
+  - `spec` - String in "provider:model" or "model@provider" format, or a
+    `{provider, model_id}` tuple whose provider is an atom or string
   - `opts` - Keyword list with optional `:format` to explicitly specify format
 
   ## Options
@@ -118,7 +119,7 @@ defmodule LLMDB.Spec do
       iex> LLMDB.Spec.parse_spec("gpt-4")
       {:error, :invalid_format}
   """
-  @spec parse_spec(String.t() | {atom(), String.t()}, keyword()) ::
+  @spec parse_spec(String.t() | {atom() | String.t(), String.t()}, keyword()) ::
           {:ok, {atom(), String.t()}}
           | {:error,
              :invalid_format
@@ -131,6 +132,13 @@ defmodule LLMDB.Spec do
 
   def parse_spec({provider, model_id}, _opts) when is_atom(provider) and is_binary(model_id) do
     {:ok, {provider, model_id}}
+  end
+
+  def parse_spec({provider, model_id}, _opts)
+      when is_binary(provider) and is_binary(model_id) do
+    with {:ok, provider_atom} <- parse_provider(provider) do
+      {:ok, {provider_atom, model_id}}
+    end
   end
 
   def parse_spec(spec, opts) when is_binary(spec) do
@@ -366,7 +374,8 @@ defmodule LLMDB.Spec do
 
   Accepts multiple input formats:
   - "provider:model" string
-  - {provider, model_id} tuple
+  - "model@provider" string
+  - {provider, model_id} tuple with an atom or string provider
   - Bare "model" string with opts[:scope] = provider_atom
 
   Handles alias resolution and validates the model exists in the catalog.
@@ -392,28 +401,24 @@ defmodule LLMDB.Spec do
       iex> LLMDB.Spec.resolve({:openai, "gpt-4"})
       {:ok, {:openai, "gpt-4", %LLMDB.Model{}}}
 
+      iex> LLMDB.Spec.resolve("gpt-4@openai")
+      {:ok, {:openai, "gpt-4", %LLMDB.Model{}}}
+
       iex> LLMDB.Spec.resolve("gpt-4", scope: :openai)
       {:ok, {:openai, "gpt-4", %LLMDB.Model{}}}
 
       iex> LLMDB.Spec.resolve("gpt-4")
       {:error, :ambiguous}
   """
-  @spec resolve(String.t() | {atom(), String.t()}, keyword()) ::
+  @spec resolve(String.t() | {atom() | String.t(), String.t()}, keyword()) ::
           {:ok, {atom(), String.t(), Model.t()}} | {:error, term()}
   def resolve(input, opts \\ [])
 
   def resolve(spec, opts) when is_binary(spec) do
-    case String.contains?(spec, ":") do
-      true ->
-        with {:ok, {provider, model_id}} <- parse_spec(spec) do
-          resolve_model(provider, model_id)
-        end
-
-      false ->
-        case Keyword.get(opts, :scope) do
-          nil -> resolve_bare_model(spec)
-          scope -> resolve_model(scope, spec)
-        end
+    cond do
+      String.contains?(spec, ":") -> resolve_qualified_spec(spec)
+      String.contains?(spec, "@") -> resolve_at_or_bare(spec, opts)
+      true -> resolve_bare_with_scope(spec, opts)
     end
   end
 
@@ -421,9 +426,56 @@ defmodule LLMDB.Spec do
     resolve_model(provider, model_id)
   end
 
+  def resolve({provider, model_id}, _opts)
+      when is_binary(provider) and is_binary(model_id) do
+    with {:ok, provider_atom} <- parse_provider(provider) do
+      resolve_model(provider_atom, model_id)
+    end
+  end
+
   def resolve(_, _), do: {:error, :invalid_format}
 
   # Private helpers
+
+  defp resolve_qualified_spec(spec) do
+    with {:ok, {provider, model_id}} <- parse_spec(spec) do
+      resolve_model(provider, model_id)
+    end
+  end
+
+  # `@` is both the filename-safe qualified separator and a valid character in
+  # model IDs. Prefer an explicit scope, then the qualified form, while falling
+  # back to an exact legacy bare lookup when the qualified target is absent.
+  defp resolve_at_or_bare(spec, opts) do
+    case Keyword.get(opts, :scope) do
+      nil ->
+        qualified_result = resolve_qualified_spec(spec)
+
+        case qualified_result do
+          {:ok, _resolved} ->
+            qualified_result
+
+          {:error, _reason} ->
+            case resolve_bare_model(spec) do
+              {:error, :not_found} -> qualified_result
+              bare_result -> bare_result
+            end
+        end
+
+      scope ->
+        case resolve_model(scope, spec) do
+          {:error, :not_found} -> resolve_qualified_spec(spec)
+          scoped_result -> scoped_result
+        end
+    end
+  end
+
+  defp resolve_bare_with_scope(spec, opts) do
+    case Keyword.get(opts, :scope) do
+      nil -> resolve_bare_model(spec)
+      scope -> resolve_model(scope, spec)
+    end
+  end
 
   defp verify_provider_exists(provider_atom) do
     case Store.snapshot() do

--- a/test/llm_db/api_test.exs
+++ b/test/llm_db/api_test.exs
@@ -111,6 +111,23 @@ defmodule LLMDB.APITest do
     end
   end
 
+  describe "model/1" do
+    test "accepts each documented qualified lookup form" do
+      assert {:ok, colon_model} = LLMDB.model("openai:gpt-4o")
+      assert {:ok, ^colon_model} = LLMDB.model("gpt-4o@openai")
+      assert {:ok, ^colon_model} = LLMDB.model({:openai, "gpt-4o"})
+      assert {:ok, ^colon_model} = LLMDB.model({"openai", "gpt-4o"})
+    end
+
+    test "normalizes string providers and preserves lookup errors" do
+      assert {:ok, model} = LLMDB.model({"openai", "gpt-4o-mini"})
+      assert model.provider == :openai
+
+      assert {:error, :not_found} = LLMDB.model({:openai, "missing"})
+      assert {:error, :unknown_provider} = LLMDB.model({"missing-provider", "missing"})
+    end
+  end
+
   describe "candidates/1" do
     test "returns all matching models in preference order" do
       candidates = LLMDB.candidates(require: [chat: true])

--- a/test/llm_db/spec_test.exs
+++ b/test/llm_db/spec_test.exs
@@ -45,6 +45,12 @@ defmodule LLMDB.SpecTest do
         aliases: []
       },
       %{
+        id: "literal@anthropic",
+        provider: :openai,
+        name: "Model with @ in ID",
+        aliases: []
+      },
+      %{
         id: "shared-model",
         provider: :openai,
         name: "Shared Model OpenAI",
@@ -230,6 +236,10 @@ defmodule LLMDB.SpecTest do
   describe "parse_spec/2 with tuple input" do
     test "accepts tuple format" do
       assert {:ok, {:openai, "gpt-4"}} = Spec.parse_spec({:openai, "gpt-4"})
+      assert {:ok, {:openai, "gpt-4"}} = Spec.parse_spec({"openai", "gpt-4"})
+
+      assert {:ok, {:google_vertex, "gemini-pro"}} =
+               Spec.parse_spec({"google-vertex", "gemini-pro"})
     end
 
     test "ignores format option for tuple input" do
@@ -464,6 +474,37 @@ defmodule LLMDB.SpecTest do
     end
   end
 
+  describe "resolve/2 with model@provider string" do
+    test "matches the equivalent provider:model lookup" do
+      assert {:ok, {:openai, "gpt-4", colon_model}} = Spec.resolve("openai:gpt-4")
+      assert {:ok, {:openai, "gpt-4", ^colon_model}} = Spec.resolve("gpt-4@openai")
+    end
+
+    test "normalizes providers and resolves model aliases" do
+      assert {:ok, {:google_vertex, "gemini-pro", _model}} =
+               Spec.resolve("gemini-pro@google-vertex")
+
+      assert {:ok, {:openai, "gpt-4", model}} = Spec.resolve("gpt-4-0613@openai")
+      assert model.id == "gpt-4"
+    end
+
+    test "preserves qualified lookup errors" do
+      assert {:error, :not_found} = Spec.resolve("missing@openai")
+      assert {:error, :unknown_provider} = Spec.resolve("gpt-4@unknown")
+      assert {:error, :empty_segment} = Spec.resolve("gpt-4@")
+    end
+
+    test "preserves exact bare model IDs containing @" do
+      assert {:ok, {:openai, "literal@anthropic", model}} =
+               Spec.resolve("literal@anthropic")
+
+      assert model.id == "literal@anthropic"
+
+      assert {:ok, {:openai, "literal@anthropic", ^model}} =
+               Spec.resolve("literal@anthropic", scope: :openai)
+    end
+  end
+
   describe "resolve/2 with {provider, model_id} tuple" do
     test "resolves valid tuple" do
       assert {:ok, {:openai, "gpt-4", model}} = Spec.resolve({:openai, "gpt-4"})
@@ -475,6 +516,13 @@ defmodule LLMDB.SpecTest do
                Spec.resolve({:anthropic, "claude-3-opus"})
 
       assert model.id == "claude-3-opus"
+    end
+
+    test "normalizes string provider input" do
+      assert {:ok, {:google_vertex, "gemini-pro", model}} =
+               Spec.resolve({"google-vertex", "gemini-pro"})
+
+      assert model.id == "gemini-pro"
     end
 
     test "returns error for nonexistent model" do
@@ -558,7 +606,7 @@ defmodule LLMDB.SpecTest do
     end
 
     test "returns error for malformed tuple" do
-      assert {:error, :invalid_format} = Spec.resolve({"openai", "gpt-4"})
+      assert {:error, :invalid_format} = Spec.resolve({:openai, "gpt-4", :extra})
       assert {:error, :invalid_format} = Spec.resolve({:openai, :gpt_4})
     end
 


### PR DESCRIPTION
## Summary

- add the documented tuple overload to `LLMDB.model/1`
- accept both atom and string provider identifiers in lookup/parsing tuples, normalizing strings through the provider contract
- route `model@provider` through the same qualified resolution path as `provider:model`
- preserve colon, bare, alias, ambiguous, not-found, and invalid-spec behavior with regression coverage
- align README, API docs, and the model-spec guide with the executable contract

## Compatibility

These are additive accepted input forms. Existing atom tuples, colon specs, bare scoped lookups, and return/error shapes remain unchanged.

## Stack

PR 5 of 5. Based on #261; merge after #261.

## Validation

- 141 focused API/spec/public-contract tests passed
- documentation generated without warnings
- full stack: 806 tests passed (41 doctests, 765 tests)
- Credo clean; Dialyzer reported zero errors

Closes #242