### PR TITLE
test: isolate llm db test configuration

### DIFF
--- a/test/llm_db_test.exs
+++ b/test/llm_db_test.exs
@@ -4,13 +4,18 @@ defmodule LLMDBTest do
   alias LLMDB.Store
 
   setup do
+    reset_test_state!()
+    on_exit(&reset_test_state!/0)
+    :ok
+  end
+
+  defp reset_test_state! do
     Store.clear!()
-    # Clear any polluted application env
+
     Application.delete_env(:llm_db, :allow)
     Application.delete_env(:llm_db, :deny)
     Application.delete_env(:llm_db, :prefer)
     Application.delete_env(:llm_db, :filter)
-    :ok
   end
 
   # Helper to load test data directly via Engine (bypassing packaged snapshot)


### PR DESCRIPTION
## Summary

- reset `LLMDBTest` store and filter configuration before and after every test
- prevent test-order leakage into application boundary checks
- fix the Elixir 1.18 matrix failure from main run 29511374946

## Validation

- `mix test --seed 548673` — 810 passed
- `mix quality`
- pre-push `mix test` — 810 passed with an independent seed
- pre-push `mix quality`