### PR TITLE
build: compact the packaged snapshot

### DIFF
--- a/guides/package-footprint.md
+++ b/guides/package-footprint.md
@@ -1,0 +1,40 @@
+# Package Footprint
+
+The packaged catalog uses deterministic compact JSON. This changes only JSON
+whitespace: decoded keys, values, array order, schema version, and snapshot ID
+remain unchanged.
+
+## Size comparison
+
+Measured from the same 2026-07 packaged snapshot and package source tree with:
+
+```shell
+wc -c priv/llm_db/snapshot.json
+gzip -n -c priv/llm_db/snapshot.json | wc -c
+mix hex.build
+```
+
+| Artifact | Pretty JSON | Compact package | Change |
+| --- | ---: | ---: | ---: |
+| Raw `snapshot.json` | 12,198,384 bytes | 6,325,229 bytes | -48.1% |
+| Gzip (`gzip -n`) | 582,088 bytes | 455,025 bytes | -21.8% |
+| Hex archive | 756,224 bytes | 623,616 bytes | -17.5% |
+
+These measurements are release-audit evidence, not fixed size budgets; catalog
+growth will change them.
+
+## Hex package manifest
+
+The package deliberately includes:
+
+- `lib` and `mix.exs` for runtime code and supported Mix tasks;
+- `priv/llm_db/snapshot.json` for zero-network catalog use;
+- `config` for the repository-maintainer task defaults retained during the
+  compatibility window;
+- `guides`, `README.md`, and `CHANGELOG.md` for HexDocs and release history;
+- `LICENSE` for licensing.
+
+Repository-only contributor instructions (`AGENTS.md`, `usage-rules.md`) and
+the repository formatter configuration (`.formatter.exs`) are excluded. No
+runtime module, supported task, guide, source configuration, license, or
+packaged metadata is removed.

--- a/lib/llm_db/snapshot.ex
+++ b/lib/llm_db/snapshot.ex
@@ -167,14 +167,17 @@ defmodule LLMDB.Snapshot do
   end
 
   @doc """
-  Encodes a snapshot or metadata document as pretty JSON.
+  Encodes a snapshot or metadata document as deterministic compact JSON.
+
+  Object keys are sorted recursively. Array order and every encoded value are
+  preserved; only insignificant JSON whitespace is omitted.
   """
   @spec encode(map()) :: String.t()
   def encode(document) when is_map(document) do
     document
     |> json_safe()
     |> canonical_json_map()
-    |> Jason.encode!(pretty: true)
+    |> Jason.encode!()
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule LLMDB.MixProject do
           "guides/consumer-integration.md",
           "guides/model-spec-formats.md",
           "guides/model-struct-evolution-proposal.md",
+          "guides/package-footprint.md",
           "guides/pricing-and-billing.md",
           "guides/runtime-and-maintainer-boundaries.md",
           "guides/schema-system.md",
@@ -125,7 +126,7 @@ defmodule LLMDB.MixProject do
         "Website" => "https://agentjido.xyz"
       },
       files:
-        ~w(config guides lib priv/llm_db/snapshot.json mix.exs LICENSE README.md CHANGELOG.md AGENTS.md usage-rules.md .formatter.exs)
+        ~w(config guides lib priv/llm_db/snapshot.json mix.exs LICENSE README.md CHANGELOG.md)
     ]
   end
 

--- a/test/llm_db/package_manifest_test.exs
+++ b/test/llm_db/package_manifest_test.exs
@@ -1,0 +1,23 @@
+defmodule LLMDB.PackageManifestTest do
+  use ExUnit.Case, async: true
+
+  @expected_files ~w(
+    config
+    guides
+    lib
+    priv/llm_db/snapshot.json
+    mix.exs
+    LICENSE
+    README.md
+    CHANGELOG.md
+  )
+
+  test "the Hex manifest keeps runtime/tooling assets and excludes repository-only files" do
+    package_files = Mix.Project.config() |> Keyword.fetch!(:package) |> Keyword.fetch!(:files)
+
+    assert package_files == @expected_files
+    refute "AGENTS.md" in package_files
+    refute "usage-rules.md" in package_files
+    refute ".formatter.exs" in package_files
+  end
+end

--- a/test/llm_db/snapshot_test.exs
+++ b/test/llm_db/snapshot_test.exs
@@ -5,18 +5,19 @@ defmodule LLMDB.SnapshotTest do
 
   import ExUnit.CaptureLog
 
-  test "encodes nested maps with stable sorted key order" do
+  test "encodes nested maps as deterministic compact JSON with sorted keys" do
     encoded = Snapshot.encode(%{"b" => %{"d" => 1, "c" => 2}, "a" => 1})
 
-    assert [
-             "{",
-             "  \"a\": 1,",
-             "  \"b\": {",
-             "    \"c\": 2,",
-             "    \"d\": 1",
-             "  }",
-             "}"
-           ] = String.split(encoded, "\n", trim: true)
+    assert encoded == ~s({"a":1,"b":{"c":2,"d":1}})
+    refute String.contains?(encoded, "\n")
+  end
+
+  test "serializing the same document twice is byte-identical" do
+    document = snapshot_document()
+    rebuilt = document |> Enum.reverse() |> Map.new()
+
+    assert document == rebuilt
+    assert Snapshot.encode(document) == Snapshot.encode(rebuilt)
   end
 
   test "omits empty runtime migration fields from snapshot output" do


### PR DESCRIPTION
Closes #255

## Summary

- Emit recursively key-sorted compact JSON without dropping any field or changing array order.
- Minify the packaged snapshot while preserving its decoded document and snapshot ID exactly.
- Trim AGENTS.md, usage-rules.md, and .formatter.exs from the Hex manifest.
- Keep all runtime code, supported tasks, configuration, guides, license, changelog, and packaged metadata.
- Add deterministic serialization and manifest regression tests.

## Footprint

- Raw snapshot: 12,198,384 to 6,325,229 bytes, down 48.1 percent.
- Gzip: 582,088 to 455,025 bytes, down 21.8 percent.
- Hex archive: 756,224 to 623,616 bytes, down 17.5 percent.

## Validation

- Baseline and compact JSON decode to exactly equal terms.
- Snapshot verification and snapshot ID are unchanged.
- Full mix test suite passed.
- mix quality passed.
- mix docs and mix hex.build passed.
- Unpacked Hex contents were audited.

## Stack

Depends on #257. Merge last.