### PR TITLE
fix: bound snapshot atom creation

### DIFF
--- a/lib/llm_db/generated/provider_registry.ex
+++ b/lib/llm_db/generated/provider_registry.ex
@@ -1,0 +1,38 @@
+defmodule LLMDB.Generated.ProviderRegistry do
+  @moduledoc false
+
+  @snapshot_path Path.expand("../../../priv/llm_db/snapshot.json", __DIR__)
+  @external_resource @snapshot_path
+
+  # Provider atoms are created while compiling the trusted package artifact,
+  # never from a runtime snapshot. This preserves the atom-based public API
+  # without allowing untrusted JSON to grow the VM atom table.
+  @providers (case File.read(@snapshot_path) do
+                {:ok, content} ->
+                  case Jason.decode(content) do
+                    {:ok, %{"providers" => providers}} when is_map(providers) ->
+                      providers
+                      |> Map.keys()
+                      |> Enum.sort()
+                      |> Enum.map(fn provider_id ->
+                        {provider_id, String.to_atom(provider_id)}
+                      end)
+
+                    _other ->
+                      []
+                  end
+
+                {:error, _reason} ->
+                  []
+              end)
+
+  @providers_by_name Map.new(@providers)
+
+  @spec fetch(String.t()) :: {:ok, atom()} | :error
+  def fetch(provider_id) when is_binary(provider_id) do
+    Map.fetch(@providers_by_name, provider_id)
+  end
+
+  @spec list() :: [atom()]
+  def list, do: Enum.map(@providers, &elem(&1, 1))
+end

--- a/lib/llm_db/generated/valid_modalities.ex
+++ b/lib/llm_db/generated/valid_modalities.ex
@@ -16,8 +16,15 @@ defmodule LLMDB.Generated.ValidModalities do
     :code,
     :document,
     :embedding,
+    :embeddings,
+    :file,
+    :rerank,
+    :speech,
+    :transcription,
     :pdf
   ]
+
+  @modalities_by_name Map.new(@modalities, &{Atom.to_string(&1), &1})
 
   @doc """
   Returns the list of all valid modality atoms.
@@ -30,4 +37,14 @@ defmodule LLMDB.Generated.ValidModalities do
   """
   @spec member?(atom()) :: boolean()
   def member?(atom), do: atom in @modalities
+
+  @doc false
+  @spec fetch(String.t() | atom()) :: {:ok, atom()} | :error
+  def fetch(modality) when is_atom(modality) do
+    if member?(modality), do: {:ok, modality}, else: :error
+  end
+
+  def fetch(modality) when is_binary(modality) do
+    Map.fetch(@modalities_by_name, modality)
+  end
 end

--- a/lib/llm_db/loader.ex
+++ b/lib/llm_db/loader.ex
@@ -10,9 +10,148 @@ defmodule LLMDB.Loader do
   """
 
   alias LLMDB.{Engine, Merge, Model, Packaged, Pricing, Provider, Runtime, Snapshot, Validate}
+  alias LLMDB.Generated.{ProviderRegistry, ValidModalities}
   alias LLMDB.Snapshot.ReleaseStore
 
   require Logger
+
+  @known_snapshot_keys [
+    :alias_of,
+    :aliases,
+    :applies_to,
+    :applies_when,
+    :audio,
+    :auth,
+    :base_url,
+    :batch,
+    :cache_read,
+    :cache_write,
+    :caching,
+    :capabilities,
+    :catalog_only,
+    :charge_scope,
+    :chat,
+    :citations,
+    :code_execution,
+    :components,
+    :config_schema,
+    :context,
+    :context_management,
+    :cost,
+    :currency,
+    :default,
+    :default_dimensions,
+    :default_headers,
+    :default_query,
+    :default_type,
+    :deprecated,
+    :deprecated_at,
+    :derives_from,
+    :disable_supported,
+    :doc,
+    :doc_url,
+    :effort,
+    :embed,
+    :embeddings,
+    :enabled,
+    :encrypted_supported,
+    :env,
+    :exclude_models,
+    :excludes_when,
+    :execution,
+    :extra,
+    :family,
+    :features,
+    :forced_choice,
+    :header_name,
+    :headers,
+    :id,
+    :image,
+    :input,
+    :input_audio,
+    :input_video,
+    :json,
+    :knowledge,
+    :kind,
+    :last_updated,
+    :lifecycle,
+    :limits,
+    :max,
+    :max_dimensions,
+    :merge,
+    :meter,
+    :min,
+    :min_dimensions,
+    :modalities,
+    :mode,
+    :model,
+    :multiplier,
+    :name,
+    :native,
+    :notes,
+    :object,
+    :output,
+    :output_audio,
+    :output_video,
+    :parallel,
+    :path,
+    :per,
+    :pricing,
+    :pricing_defaults,
+    :provider,
+    :provider_model_id,
+    :query_name,
+    :rate,
+    :raw_output_supported,
+    :realtime,
+    :reasoning,
+    :release_date,
+    :replacement,
+    :request,
+    :required,
+    :rerank,
+    :retired,
+    :retires_at,
+    :runtime,
+    :schema,
+    :size_class,
+    :source,
+    :speech,
+    :status,
+    :storage,
+    :streaming,
+    :strict,
+    :summary_supported,
+    :supported,
+    :tags,
+    :text,
+    :thinking,
+    :token_budget,
+    :tool,
+    :tool_calls,
+    :tools,
+    :training,
+    :transcription,
+    :transport,
+    :type,
+    :types,
+    :unit,
+    :value,
+    :values,
+    :video,
+    :wire_protocol
+  ]
+
+  @known_snapshot_keys_by_name Map.new(@known_snapshot_keys, &{Atom.to_string(&1), &1})
+  @known_snapshot_key_set MapSet.new(@known_snapshot_keys)
+  @opaque_snapshot_keys MapSet.new([
+                          :applies_when,
+                          :default,
+                          :default_headers,
+                          :default_query,
+                          :excludes_when,
+                          :extra
+                        ])
 
   @doc """
   Loads the packaged snapshot and applies runtime configuration.
@@ -180,54 +319,57 @@ defmodule LLMDB.Loader do
 
   # Private helpers
   defp load_packaged(opts) do
-    case load_snapshot_document(snapshot_source(opts)) do
-      nil ->
-        {:error, :no_snapshot}
+    with {:ok, snapshot} <- load_snapshot_document(snapshot_source(opts)) do
+      deserialize_snapshot_document(snapshot)
+    end
+  end
 
-      %{version: 2, providers: nested_providers, generated_at: generated_at} = snapshot ->
-        # V2 snapshot with nested providers
-        {providers, models} = flatten_nested_providers(nested_providers)
+  defp deserialize_snapshot_document(
+         %{version: 2, providers: nested_providers, generated_at: generated_at} = snapshot
+       ) do
+    {providers, models} = flatten_nested_providers(nested_providers)
+    deserialize_snapshot_items(providers, models, generated_at, snapshot_snapshot_id(snapshot))
+  end
 
-        {:ok,
-         {deserialize_json_atoms(providers, :provider), deserialize_json_atoms(models, :model),
-          generated_at, snapshot_snapshot_id(snapshot)}}
+  defp deserialize_snapshot_document(
+         %{"version" => 2, "providers" => nested_providers, "generated_at" => generated_at} =
+           snapshot
+       ) do
+    {providers, models} = flatten_nested_providers(nested_providers)
+    deserialize_snapshot_items(providers, models, generated_at, snapshot_snapshot_id(snapshot))
+  end
 
-      %{"version" => 2, "providers" => nested_providers, "generated_at" => generated_at} =
-          snapshot ->
-        {providers, models} = flatten_nested_providers(nested_providers)
+  defp deserialize_snapshot_document(
+         %{providers: providers, models: models, generated_at: generated_at} = snapshot
+       )
+       when is_list(providers) and is_list(models) do
+    deserialize_snapshot_items(providers, models, generated_at, snapshot_snapshot_id(snapshot))
+  end
 
-        {:ok,
-         {deserialize_json_atoms(providers, :provider), deserialize_json_atoms(models, :model),
-          generated_at, snapshot_snapshot_id(snapshot)}}
+  defp deserialize_snapshot_document(
+         %{"providers" => providers, "models" => models, "generated_at" => generated_at} =
+           snapshot
+       )
+       when is_list(providers) and is_list(models) do
+    deserialize_snapshot_items(providers, models, generated_at, snapshot_snapshot_id(snapshot))
+  end
 
-      %{providers: providers, models: models, generated_at: generated_at} = snapshot
-      when is_list(providers) and is_list(models) ->
-        # V1 snapshot with generated_at
-        {:ok,
-         {deserialize_json_atoms(providers, :provider), deserialize_json_atoms(models, :model),
-          generated_at, snapshot_snapshot_id(snapshot)}}
+  defp deserialize_snapshot_document(%{providers: providers, models: models} = snapshot)
+       when is_list(providers) and is_list(models) do
+    deserialize_snapshot_items(providers, models, nil, snapshot_snapshot_id(snapshot))
+  end
 
-      %{"providers" => providers, "models" => models, "generated_at" => generated_at} = snapshot
-      when is_list(providers) and is_list(models) ->
-        {:ok,
-         {deserialize_json_atoms(providers, :provider), deserialize_json_atoms(models, :model),
-          generated_at, snapshot_snapshot_id(snapshot)}}
+  defp deserialize_snapshot_document(%{"providers" => providers, "models" => models} = snapshot)
+       when is_list(providers) and is_list(models) do
+    deserialize_snapshot_items(providers, models, nil, snapshot_snapshot_id(snapshot))
+  end
 
-      %{providers: providers, models: models} = snapshot
-      when is_list(providers) and is_list(models) ->
-        # V1 snapshot without generated_at
-        {:ok,
-         {deserialize_json_atoms(providers, :provider), deserialize_json_atoms(models, :model),
-          nil, snapshot_snapshot_id(snapshot)}}
+  defp deserialize_snapshot_document(_snapshot), do: {:error, :invalid_snapshot_format}
 
-      %{"providers" => providers, "models" => models} = snapshot
-      when is_list(providers) and is_list(models) ->
-        {:ok,
-         {deserialize_json_atoms(providers, :provider), deserialize_json_atoms(models, :model),
-          nil, snapshot_snapshot_id(snapshot)}}
-
-      _ ->
-        {:error, :invalid_snapshot_format}
+  defp deserialize_snapshot_items(providers, models, generated_at, snapshot_id) do
+    with {:ok, providers} <- deserialize_json_atoms(providers, :provider),
+         {:ok, models} <- deserialize_json_atoms(models, :model) do
+      {:ok, {providers, models, generated_at, snapshot_id}}
     end
   end
 
@@ -264,34 +406,39 @@ defmodule LLMDB.Loader do
   end
 
   defp deserialize_json_atoms(items, :provider) do
-    Enum.map(items, fn provider ->
-      provider_map = normalize_provider_item(provider)
-
-      # Validate and create Provider struct
-      case provider_map do
-        %Provider{} = normalized -> normalized
-        _ -> Provider.new!(provider_map)
-      end
-    end)
+    deserialize_items(items, &normalize_provider_item/1, &Provider.new/1, :provider)
   end
 
   defp deserialize_json_atoms(items, :model) do
-    Enum.map(items, fn model ->
-      model_map = normalize_model_item(model)
+    deserialize_items(items, &normalize_model_item/1, &Model.new/1, :model)
+  end
 
-      # Validate and create Model struct
-      case model_map do
-        %Model{} = normalized -> normalized
-        _ -> Model.new!(model_map)
+  defp deserialize_items(items, normalize, validate, type) do
+    Enum.reduce_while(items, {:ok, []}, fn item, {:ok, acc} ->
+      with {:ok, normalized} <- normalize.(item),
+           {:ok, value} <- validate.(normalized) do
+        {:cont, {:ok, [value | acc]}}
+      else
+        {:error, reason} -> {:halt, {:error, {:invalid_snapshot_item, type, reason}}}
       end
     end)
+    |> case do
+      {:ok, values} -> {:ok, Enum.reverse(values)}
+      error -> error
+    end
   end
 
   defp deserialize_modality_list(list) when is_list(list) do
-    Enum.map(list, fn
-      s when is_binary(s) -> safe_existing_atom(s)
-      a when is_atom(a) -> a
+    Enum.reduce_while(list, {:ok, []}, fn modality, {:ok, acc} ->
+      case ValidModalities.fetch(modality) do
+        {:ok, atom} -> {:cont, {:ok, [atom | acc]}}
+        :error -> {:halt, {:error, {:unknown_modality, modality}}}
+      end
     end)
+    |> case do
+      {:ok, modalities} -> {:ok, Enum.reverse(modalities)}
+      error -> error
+    end
   end
 
   defp merge_custom({providers, models}, %{providers: [], models: []}) do
@@ -318,17 +465,25 @@ defmodule LLMDB.Loader do
 
   defp validate_custom_overlays!(items, :provider) when is_list(items) do
     Enum.map(items, fn provider ->
-      provider
-      |> normalize_provider_item()
-      |> validate_custom_overlay!(&Validate.validate_provider_overlay/1, "custom provider")
+      with {:ok, normalized} <- normalize_provider_item(provider) do
+        validate_custom_overlay!(
+          normalized,
+          &Validate.validate_provider_overlay/1,
+          "custom provider"
+        )
+      else
+        {:error, reason} -> raise ArgumentError, "Invalid custom provider: #{inspect(reason)}"
+      end
     end)
   end
 
   defp validate_custom_overlays!(items, :model) when is_list(items) do
     Enum.map(items, fn model ->
-      model
-      |> normalize_model_item()
-      |> validate_custom_overlay!(&Validate.validate_model_overlay/1, "custom model")
+      with {:ok, normalized} <- normalize_model_item(model) do
+        validate_custom_overlay!(normalized, &Validate.validate_model_overlay/1, "custom model")
+      else
+        {:error, reason} -> raise ArgumentError, "Invalid custom model: #{inspect(reason)}"
+      end
     end)
   end
 
@@ -470,28 +625,29 @@ defmodule LLMDB.Loader do
     Keyword.get(opts, :snapshot_source, base.snapshot_source)
   end
 
-  defp load_snapshot_document(:packaged), do: Packaged.snapshot()
+  defp load_snapshot_document(:packaged), do: Packaged.load()
 
   defp load_snapshot_document({:file, path}) when is_binary(path) do
-    case Snapshot.read(path) do
-      {:ok, snapshot} -> snapshot
-      {:error, _reason} -> nil
-    end
+    Snapshot.read(path, integrity_policy: integrity_policy())
   end
 
   defp load_snapshot_document({:github_releases, store_opts}) do
     {ref, overrides} = release_ref_and_overrides(store_opts)
 
     case ReleaseStore.fetch_snapshot(ref, overrides) do
-      {:ok, %{snapshot: snapshot}} -> snapshot
-      {:error, _reason} -> nil
+      {:ok, %{snapshot: snapshot}} -> {:ok, snapshot}
+      {:error, reason} -> {:error, reason}
     end
   end
 
   defp load_snapshot_document(other) when is_binary(other),
     do: load_snapshot_document({:file, other})
 
-  defp load_snapshot_document(_), do: Packaged.snapshot()
+  defp load_snapshot_document(_), do: Packaged.load()
+
+  defp integrity_policy do
+    Application.get_env(:llm_db, :integrity_policy, :strict)
+  end
 
   defp release_ref_and_overrides(store_opts) do
     normalized =
@@ -518,65 +674,79 @@ defmodule LLMDB.Loader do
     snapshot["snapshot_id"] || snapshot[:snapshot_id]
   end
 
+  defp provider_atom(provider) when is_atom(provider), do: {:ok, provider}
+
   defp provider_atom(provider) when is_binary(provider) do
-    safe_existing_atom(provider, true)
+    case ProviderRegistry.fetch(provider) do
+      {:ok, atom} ->
+        {:ok, atom}
+
+      :error ->
+        try do
+          {:ok, String.to_existing_atom(provider)}
+        rescue
+          ArgumentError -> {:error, {:unknown_provider_id, provider}}
+        end
+    end
   end
+
+  defp provider_atom(provider), do: {:error, {:invalid_provider_id, provider}}
 
   defp normalize_provider_item(provider) do
-    normalized_id =
-      case get_value(provider, :id) do
-        id when is_atom(id) -> id
-        id when is_binary(id) -> provider_atom(id)
-      end
+    case provider do
+      %Provider{} ->
+        {:ok, provider}
 
-    provider
-    |> deep_atomize_keys()
-    |> Map.put(:id, normalized_id)
+      provider when is_map(provider) ->
+        with {:ok, normalized_id} <- provider_atom(get_value(provider, :id)) do
+          {:ok,
+           provider
+           |> atomize_known_keys()
+           |> Map.put(:id, normalized_id)}
+        end
+
+      _other ->
+        {:error, :invalid_provider}
+    end
   end
 
-  defp normalize_model_item(model) do
-    normalized_provider =
-      case get_value(model, :provider) do
-        provider when is_atom(provider) -> provider
-        provider when is_binary(provider) -> provider_atom(provider)
-      end
+  defp normalize_model_item(%Model{} = model), do: {:ok, model}
 
-    model
-    |> normalize_model_modalities()
-    |> put_value(:provider, normalized_provider)
-    |> deep_atomize_keys()
+  defp normalize_model_item(model) when is_map(model) do
+    with {:ok, normalized_provider} <- provider_atom(get_value(model, :provider)),
+         {:ok, normalized_model} <- normalize_model_modalities(model) do
+      {:ok,
+       normalized_model
+       |> atomize_known_keys()
+       |> Map.put(:provider, normalized_provider)}
+    end
   end
+
+  defp normalize_model_item(_model), do: {:error, :invalid_model}
 
   defp normalize_model_modalities(model) do
     case get_value(model, :modalities) do
       modalities when is_map(modalities) ->
-        normalized =
-          modalities
-          |> maybe_normalize_modality(:input)
-          |> maybe_normalize_modality(:output)
-
-        put_value(model, :modalities, normalized)
+        with {:ok, normalized} <- maybe_normalize_modality(modalities, :input),
+             {:ok, normalized} <- maybe_normalize_modality(normalized, :output) do
+          {:ok, put_value(model, :modalities, normalized)}
+        end
 
       _other ->
-        model
+        {:ok, model}
     end
   end
 
   defp maybe_normalize_modality(modalities, key) do
     case get_value(modalities, key) do
-      list when is_list(list) -> put_value(modalities, key, deserialize_modality_list(list))
-      _other -> modalities
+      list when is_list(list) ->
+        with {:ok, normalized} <- deserialize_modality_list(list) do
+          {:ok, put_value(modalities, key, normalized)}
+        end
+
+      _other ->
+        {:ok, modalities}
     end
-  end
-
-  defp safe_existing_atom(value, allow_create \\ false)
-
-  defp safe_existing_atom(value, allow_create) when is_binary(value) do
-    String.to_existing_atom(value)
-  rescue
-    ArgumentError ->
-      _ = allow_create
-      String.to_atom(value)
   end
 
   defp get_value(map, key) when is_map(map) do
@@ -611,20 +781,29 @@ defmodule LLMDB.Loader do
     |> Map.delete(Atom.to_string(key))
   end
 
-  defp deep_atomize_keys(%_{} = struct), do: struct
+  defp atomize_known_keys(%_{} = struct), do: struct
 
-  defp deep_atomize_keys(map) when is_map(map) do
+  defp atomize_known_keys(map) when is_map(map) do
     Map.new(map, fn {key, value} ->
-      normalized_key =
-        case key do
-          key when is_atom(key) -> key
-          key when is_binary(key) -> safe_existing_atom(key, true)
+      normalized_key = normalize_known_key(key)
+
+      normalized_value =
+        cond do
+          MapSet.member?(@opaque_snapshot_keys, normalized_key) -> value
+          MapSet.member?(@known_snapshot_key_set, normalized_key) -> atomize_known_keys(value)
+          true -> value
         end
 
-      {normalized_key, deep_atomize_keys(value)}
+      {normalized_key, normalized_value}
     end)
   end
 
-  defp deep_atomize_keys(list) when is_list(list), do: Enum.map(list, &deep_atomize_keys/1)
-  defp deep_atomize_keys(value), do: value
+  defp atomize_known_keys(list) when is_list(list), do: Enum.map(list, &atomize_known_keys/1)
+  defp atomize_known_keys(value), do: value
+
+  defp normalize_known_key(key) when is_atom(key), do: key
+
+  defp normalize_known_key(key) when is_binary(key) do
+    Map.get(@known_snapshot_keys_by_name, key, key)
+  end
 end

--- a/lib/llm_db/model.ex
+++ b/lib/llm_db/model.ex
@@ -51,6 +51,9 @@ defmodule LLMDB.Model do
 
   The `:cost` field is automatically converted to `:pricing.components` at load time
   for backward compatibility. See `LLMDB.Pricing` and the [Pricing and Billing guide](pricing-and-billing.md).
+
+  Snapshot-loaded `:extra` metadata retains its JSON string keys. Treat that
+  field as provider-owned opaque data rather than a schema-keyed map.
   """
 
   @limits_schema Zoi.object(%{

--- a/lib/llm_db/packaged.ex
+++ b/lib/llm_db/packaged.ex
@@ -17,16 +17,19 @@ defmodule LLMDB.Packaged do
   - `true` - Snapshot embedded at compile-time (zero runtime IO, recommended for production)
   - `false` - Snapshot loaded at runtime from priv directory with integrity checking
 
-  ## Security
+  ## Integrity and atom safety
 
-  Production deployments should use `compile_embed: true` to eliminate runtime atom
-  creation and file I/O. Runtime mode includes SHA-256 integrity verification to
-  prevent tampering with the snapshot file.
+  Production deployments can use `compile_embed: true` to eliminate runtime file
+  I/O. Embedded and file-based documents pass through the same checksum,
+  migration, structural-validation, and bounded atom-decoding contract.
+
+  Snapshot IDs detect accidental corruption or content mismatch. They do not
+  authenticate the snapshot or its publisher.
 
   ### Integrity Policy
 
   The `:integrity_policy` config option controls integrity check behavior:
-  - `:strict` (default) - Fail on hash mismatch, treating it as tampering
+  - `:strict` (default) - Fail on snapshot ID mismatch
   - `:warn` - Log warning and continue, useful in dev when snapshot regenerates frequently
   - `:off` - Skip mismatch warnings entirely
 
@@ -57,8 +60,17 @@ defmodule LLMDB.Packaged do
                 do: Jason.decode!(File.read!(@snapshot_compile_path)),
                 else: nil
 
+    @doc false
+    @spec load() :: {:ok, map()} | {:error, term()}
+    def load do
+      case @snapshot do
+        nil -> {:error, :no_snapshot}
+        snapshot -> Snapshot.prepare(snapshot, integrity_policy: integrity_policy())
+      end
+    end
+
     @doc """
-    Returns the packaged base snapshot (compile-time embedded).
+    Returns the verified packaged base snapshot (compile-time embedded).
 
     This snapshot is the pre-processed output of the ETL pipeline and serves
     as the stable foundation for this package version.
@@ -68,108 +80,40 @@ defmodule LLMDB.Packaged do
     Fully indexed snapshot map with providers, models, and indexes, or `nil` if not available.
     """
     @spec snapshot() :: map() | nil
-    def snapshot, do: @snapshot
+    def snapshot, do: unwrap_snapshot(load())
   else
+    @doc false
+    @spec load() :: {:ok, map()} | {:error, term()}
+    def load do
+      Snapshot.read(snapshot_path(), integrity_policy: integrity_policy())
+    end
+
     @doc """
-    Returns the packaged base snapshot (runtime loaded with integrity check).
+    Returns the packaged base snapshot loaded from the runtime file.
 
     This snapshot is the pre-processed output of the ETL pipeline and serves
     as the stable foundation for this package version.
 
-    Includes SHA-256 integrity verification to prevent tampering.
+    The same checksum, migration, structural validation, and atom-safety
+    boundary used by compile-time embedded snapshots is applied.
 
     ## Returns
 
     Fully indexed snapshot map with providers, models, and indexes, or `nil` if not available.
     """
     @spec snapshot() :: map() | nil
-    def snapshot do
-      with {:ok, content} <- File.read(snapshot_path()) do
-        case Snapshot.decode(content) do
-          {:ok, snapshot} ->
-            validate_schema(snapshot)
-            snapshot
+    def snapshot, do: unwrap_snapshot(load())
+  end
 
-          {:error, reason} ->
-            load_unverified_snapshot(content, reason)
-        end
-      else
-        {:error, :enoent} ->
-          # Snapshot doesn't exist yet (e.g., during build process)
-          nil
+  defp integrity_policy do
+    Application.get_env(:llm_db, :integrity_policy, :strict)
+  end
 
-        {:error, reason} ->
-          Logger.warning("llm_db: failed to load snapshot: #{inspect(reason)}")
-          nil
-      end
-    end
+  defp unwrap_snapshot({:ok, snapshot}), do: snapshot
+  defp unwrap_snapshot({:error, reason}) when reason in [:enoent, :no_snapshot], do: nil
 
-    defp integrity_policy do
-      Application.get_env(:llm_db, :integrity_policy, :strict)
-    end
-
-    defp load_unverified_snapshot(content, reason) do
-      case integrity_policy() do
-        :strict ->
-          Logger.error(
-            "llm_db: snapshot integrity check failed - refusing to load packaged snapshot: #{inspect(reason)}"
-          )
-
-          nil
-
-        mode when mode in [:warn, :off] ->
-          if mode == :warn do
-            Logger.warning(
-              "llm_db: snapshot integrity check failed in warn mode: #{inspect(reason)}. " <>
-                "Loading unverified snapshot content."
-            )
-          end
-
-          case Jason.decode(content) do
-            {:ok, snapshot} ->
-              validate_schema(snapshot)
-              snapshot
-
-            {:error, decode_reason} ->
-              Logger.warning(
-                "llm_db: failed to decode unverified snapshot: #{inspect(decode_reason)}"
-              )
-
-              nil
-          end
-      end
-    end
-
-    defp validate_schema(snapshot) do
-      providers =
-        case snapshot do
-          %{"providers" => providers} when is_map(providers) -> providers
-          %{providers: providers} when is_map(providers) -> providers
-          _ -> %{}
-        end
-
-      # Lightweight schema checks to prevent atom/memory exhaustion
-      provider_count = map_size(providers)
-
-      if provider_count > 1000 do
-        Logger.warning(
-          "llm_db: snapshot contains unusually large number of providers: #{provider_count}. " <>
-            "Expected < 1000. Potential DoS attempt."
-        )
-      end
-
-      # Check provider IDs match safe regex
-      Enum.each(providers, fn {provider_id, _data} ->
-        provider_id_str = to_string(provider_id)
-
-        unless provider_id_str =~ ~r/^[a-z0-9][a-z0-9_:-]{0,63}$/ do
-          Logger.warning(
-            "llm_db: snapshot contains suspicious provider ID: #{inspect(provider_id)}"
-          )
-        end
-      end)
-
-      :ok
-    end
+  defp unwrap_snapshot({:error, reason}) do
+    Logger.error("llm_db: refusing to load packaged snapshot: #{inspect(reason)}")
+    nil
   end
 end

--- a/lib/llm_db/provider.ex
+++ b/lib/llm_db/provider.ex
@@ -15,7 +15,7 @@ defmodule LLMDB.Provider do
   - `:doc` - Documentation URL
   - `:pricing_defaults` - Default pricing components applied to all models (see below)
   - `:exclude_models` - Model IDs to exclude from upstream sources
-  - `:extra` - Additional provider-specific data
+  - `:extra` - Additional provider-specific data; snapshot JSON keys remain strings
   - `:alias_of` - Primary provider ID if this is an alias
 
   ## Pricing Defaults

--- a/lib/llm_db/snapshot.ex
+++ b/lib/llm_db/snapshot.ex
@@ -33,6 +33,10 @@ defmodule LLMDB.Snapshot do
 
   @provider_id_regex ~r/^[a-z0-9][a-z0-9_:-]{0,63}$/
 
+  require Logger
+
+  @type integrity_policy :: :strict | :warn | :off
+
   @doc """
   Returns the canonical snapshot schema version.
   """
@@ -174,23 +178,39 @@ defmodule LLMDB.Snapshot do
   end
 
   @doc """
-  Decodes and verifies a snapshot document from JSON.
+  Decodes, verifies, migrates, and validates a snapshot document from JSON.
+
+  The optional `:integrity_policy` controls checksum mismatch handling. A
+  snapshot ID detects accidental corruption or content mismatch; it does not
+  authenticate the snapshot publisher.
   """
-  @spec decode(binary()) :: {:ok, map()} | {:error, term()}
-  def decode(content) when is_binary(content) do
+  @spec decode(binary(), keyword()) :: {:ok, map()} | {:error, term()}
+  def decode(content, opts \\ []) when is_binary(content) and is_list(opts) do
     with {:ok, snapshot} <- Jason.decode(content),
-         :ok <- verify(snapshot) do
-      {:ok, snapshot}
+         {:ok, prepared} <- prepare(snapshot, opts) do
+      {:ok, prepared}
     end
   end
 
   @doc """
-  Reads and verifies a snapshot document from disk.
+  Reads, verifies, migrates, and validates a snapshot document from disk.
   """
-  @spec read(String.t()) :: {:ok, map()} | {:error, term()}
-  def read(path) when is_binary(path) do
+  @spec read(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def read(path, opts \\ []) when is_binary(path) and is_list(opts) do
     with {:ok, content} <- File.read(path) do
-      decode(content)
+      decode(content, opts)
+    end
+  end
+
+  @doc false
+  @spec prepare(map(), keyword()) :: {:ok, map()} | {:error, term()}
+  def prepare(snapshot, opts \\ []) when is_map(snapshot) and is_list(opts) do
+    policy = Keyword.get(opts, :integrity_policy, :strict)
+
+    with :ok <- apply_integrity_policy(snapshot, policy),
+         {:ok, migrated} <- migrate(snapshot),
+         :ok <- validate_document(migrated) do
+      {:ok, migrated}
     end
   end
 
@@ -207,18 +227,27 @@ defmodule LLMDB.Snapshot do
   end
 
   @doc """
-  Verifies snapshot integrity and provider ID safety.
+  Verifies snapshot checksum consistency and document safety.
+
+  Snapshot IDs detect corruption or mismatched content. They are not an
+  authenticity or trust guarantee.
   """
   @spec verify(map()) :: :ok | {:error, term()}
   def verify(snapshot) when is_map(snapshot) do
     with :ok <- verify_snapshot_id(snapshot),
-         :ok <- validate_provider_ids(snapshot) do
+         {:ok, migrated} <- migrate(snapshot),
+         :ok <- validate_document(migrated) do
       :ok
     end
   end
 
-  defp verify_snapshot_id(%{"snapshot_id" => embedded_id} = snapshot)
-       when is_binary(embedded_id) do
+  defp verify_snapshot_id(snapshot) do
+    embedded_id = snapshot["snapshot_id"] || snapshot[:snapshot_id]
+
+    verify_snapshot_id(snapshot, embedded_id)
+  end
+
+  defp verify_snapshot_id(snapshot, embedded_id) when is_binary(embedded_id) do
     computed_id = snapshot_id(snapshot)
 
     if embedded_id == computed_id do
@@ -228,14 +257,65 @@ defmodule LLMDB.Snapshot do
     end
   end
 
-  defp verify_snapshot_id(_snapshot), do: {:error, :missing_snapshot_id}
+  defp verify_snapshot_id(_snapshot, _embedded_id), do: {:error, :missing_snapshot_id}
 
-  defp validate_provider_ids(snapshot) do
-    providers = provider_map(snapshot)
+  defp apply_integrity_policy(snapshot, policy) when policy in [:strict, :warn, :off] do
+    case verify_snapshot_id(snapshot) do
+      :ok ->
+        :ok
 
+      {:error, reason} when policy == :strict ->
+        {:error, reason}
+
+      {:error, reason} when policy == :warn ->
+        Logger.warning(
+          "llm_db: snapshot checksum check failed: #{inspect(reason)}. " <>
+            "Loading because integrity_policy is :warn. Snapshot IDs detect " <>
+            "corruption or mismatch; they do not authenticate publishers."
+        )
+
+        :ok
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp apply_integrity_policy(_snapshot, policy),
+    do: {:error, {:invalid_integrity_policy, policy}}
+
+  # Schema version 1 is already the canonical in-memory document. Keeping the
+  # migration step explicit gives embedded, packaged-file, and configured-file
+  # sources one contract when future wire migrations are introduced.
+  defp migrate(snapshot) do
+    case snapshot["schema_version"] || snapshot[:schema_version] do
+      nil -> {:ok, snapshot}
+      @schema_version -> {:ok, snapshot}
+      version -> {:error, {:unsupported_schema_version, version}}
+    end
+  end
+
+  defp validate_document(snapshot) do
+    providers = snapshot["providers"] || snapshot[:providers]
+    models = snapshot["models"] || snapshot[:models]
+    version = snapshot["version"] || snapshot[:version]
+
+    cond do
+      version == 2 and is_map(providers) ->
+        validate_provider_ids(providers)
+
+      is_list(providers) and is_list(models) ->
+        validate_legacy_provider_ids(providers)
+
+      true ->
+        {:error, :invalid_snapshot_format}
+    end
+  end
+
+  defp validate_provider_ids(providers) when is_map(providers) do
     case Enum.find(providers, fn {provider_id, provider} ->
            provider_id_str = to_string(provider_id)
-           provider_doc_id = provider["id"] || provider[:id]
+           provider_doc_id = is_map(provider) && (provider["id"] || provider[:id])
 
            not String.match?(provider_id_str, @provider_id_regex) or
              not is_binary(provider_doc_id) or provider_doc_id != provider_id_str
@@ -244,6 +324,21 @@ defmodule LLMDB.Snapshot do
       {provider_id, _provider} -> {:error, {:invalid_provider_id, provider_id}}
     end
   end
+
+  defp validate_legacy_provider_ids(providers) do
+    case Enum.find(providers, fn provider ->
+           provider_id = is_map(provider) && (provider["id"] || provider[:id])
+
+           not is_binary(provider_id) or
+             not String.match?(provider_id, @provider_id_regex)
+         end) do
+      nil -> :ok
+      provider -> {:error, {:invalid_provider_id, provider_id(provider)}}
+    end
+  end
+
+  defp provider_id(provider) when is_map(provider), do: provider["id"] || provider[:id]
+  defp provider_id(_provider), do: nil
 
   defp provider_map(%{"providers" => providers}) when is_map(providers), do: providers
   defp provider_map(%{providers: providers}) when is_map(providers), do: providers

--- a/test/llm_db/loader_snapshot_safety_test.exs
+++ b/test/llm_db/loader_snapshot_safety_test.exs
@@ -1,0 +1,111 @@
+defmodule LLMDB.LoaderSnapshotSafetyTest do
+  use ExUnit.Case, async: true
+
+  alias LLMDB.{Loader, Snapshot}
+
+  test "unknown nested keys remain strings and do not create atoms" do
+    unknown_key = unique_identifier("unknown_nested_key")
+    assert_not_existing_atom(unknown_key)
+
+    path =
+      write_snapshot!(%{
+        "test_provider_alpha" => %{
+          "id" => "test_provider_alpha",
+          "name" => "Test Provider",
+          "extra" => %{unknown_key => %{"id" => "opaque"}},
+          "models" => %{
+            "safe-model" => %{
+              "id" => "safe-model",
+              "provider" => "test_provider_alpha",
+              "extra" => %{unknown_key => %{"capabilities" => "opaque"}}
+            }
+          }
+        }
+      })
+
+    on_exit(fn -> File.rm(path) end)
+
+    assert {:ok, snapshot} = Loader.load(snapshot_source: {:file, path})
+    provider = snapshot.providers_by_id.test_provider_alpha
+    model = snapshot.models_by_key[{:test_provider_alpha, "safe-model"}]
+
+    assert provider.extra == %{unknown_key => %{"id" => "opaque"}}
+    assert model.extra == %{unknown_key => %{"capabilities" => "opaque"}}
+    assert_not_existing_atom(unknown_key)
+  end
+
+  test "unknown provider IDs are rejected without creating atoms" do
+    provider_id = unique_identifier("unknown_provider")
+    assert_not_existing_atom(provider_id)
+
+    path =
+      write_snapshot!(%{
+        provider_id => %{
+          "id" => provider_id,
+          "name" => "Unknown Provider",
+          "models" => %{}
+        }
+      })
+
+    on_exit(fn -> File.rm(path) end)
+
+    assert {:error, {:invalid_snapshot_item, :provider, {:unknown_provider_id, ^provider_id}}} =
+             Loader.load(snapshot_source: {:file, path})
+
+    assert_not_existing_atom(provider_id)
+  end
+
+  test "unknown modalities are rejected without creating atoms" do
+    modality = unique_identifier("unknown_modality")
+    assert_not_existing_atom(modality)
+
+    path =
+      write_snapshot!(%{
+        "test_provider_alpha" => %{
+          "id" => "test_provider_alpha",
+          "name" => "Test Provider",
+          "models" => %{
+            "unsafe-model" => %{
+              "id" => "unsafe-model",
+              "provider" => "test_provider_alpha",
+              "modalities" => %{"input" => [modality], "output" => ["text"]}
+            }
+          }
+        }
+      })
+
+    on_exit(fn -> File.rm(path) end)
+
+    assert {:error, {:invalid_snapshot_item, :model, {:unknown_modality, ^modality}}} =
+             Loader.load(snapshot_source: {:file, path})
+
+    assert_not_existing_atom(modality)
+  end
+
+  defp write_snapshot!(providers) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "llm-db-safe-snapshot-#{System.unique_integer([:positive])}.json"
+      )
+
+    document = %{
+      "schema_version" => Snapshot.schema_version(),
+      "version" => 2,
+      "generated_at" => "2026-07-16T00:00:00Z",
+      "providers" => providers
+    }
+
+    document = Map.put(document, "snapshot_id", Snapshot.snapshot_id(document))
+    Snapshot.write!(path, document)
+    path
+  end
+
+  defp unique_identifier(prefix) do
+    "#{prefix}_#{System.unique_integer([:positive])}"
+  end
+
+  defp assert_not_existing_atom(value) do
+    assert_raise ArgumentError, fn -> String.to_existing_atom(value) end
+  end
+end

--- a/test/llm_db/snapshot_test.exs
+++ b/test/llm_db/snapshot_test.exs
@@ -3,6 +3,8 @@ defmodule LLMDB.SnapshotTest do
 
   alias LLMDB.{Model, Provider, Snapshot}
 
+  import ExUnit.CaptureLog
+
   test "encodes nested maps with stable sorted key order" do
     encoded = Snapshot.encode(%{"b" => %{"d" => 1, "c" => 2}, "a" => 1})
 
@@ -90,5 +92,71 @@ defmodule LLMDB.SnapshotTest do
     assert model_json["catalog_only"] == true
     assert model_json["execution"]["text"]["family"] == "openai_chat_compatible"
     assert model_json["execution"]["text"]["path"] == "/chat/completions"
+  end
+
+  test "strict integrity rejects mismatched snapshot content" do
+    snapshot = snapshot_document()
+    mismatched = put_in(snapshot, ["providers", "test_provider", "name"], "Changed")
+
+    assert {:error, {:snapshot_id_mismatch, details}} =
+             mismatched
+             |> Jason.encode!()
+             |> Snapshot.decode()
+
+    assert details[:expected] == snapshot["snapshot_id"]
+    assert details[:computed] != details[:expected]
+  end
+
+  test "warn and off integrity policies preserve validation" do
+    snapshot = snapshot_document()
+    mismatched = put_in(snapshot, ["providers", "test_provider", "name"], "Changed")
+    encoded = Jason.encode!(mismatched)
+
+    log =
+      capture_log(fn ->
+        assert {:ok, ^mismatched} = Snapshot.decode(encoded, integrity_policy: :warn)
+      end)
+
+    assert log =~ "checksum check failed"
+    assert log =~ "do not authenticate publishers"
+    assert {:ok, ^mismatched} = Snapshot.decode(encoded, integrity_policy: :off)
+
+    malformed = Map.put(mismatched, "providers", [])
+
+    assert {:error, :invalid_snapshot_format} =
+             malformed
+             |> Jason.encode!()
+             |> Snapshot.decode(integrity_policy: :warn)
+  end
+
+  test "embedded documents and JSON content use the same preparation contract" do
+    snapshot = snapshot_document()
+
+    assert {:ok, prepared} = Snapshot.prepare(snapshot)
+    assert {:ok, decoded} = snapshot |> Jason.encode!() |> Snapshot.decode()
+    assert prepared == decoded
+  end
+
+  test "rejects unsupported schema versions after checksum verification" do
+    snapshot =
+      snapshot_document()
+      |> Map.put("schema_version", Snapshot.schema_version() + 1)
+      |> then(fn document -> Map.put(document, "snapshot_id", Snapshot.snapshot_id(document)) end)
+
+    assert {:error, {:unsupported_schema_version, 2}} = Snapshot.prepare(snapshot)
+  end
+
+  defp snapshot_document do
+    Snapshot.from_engine_snapshot(%{
+      version: 2,
+      generated_at: "2026-03-26T00:00:00Z",
+      providers: %{
+        test_provider: %{
+          id: :test_provider,
+          name: "Test Provider",
+          models: %{}
+        }
+      }
+    })
   end
 end

--- a/test/llm_db_test.exs
+++ b/test/llm_db_test.exs
@@ -1064,7 +1064,7 @@ defmodule LLMDBTest do
       assert model.modalities.output == [:audio]
       assert model.capabilities.chat == false
       assert model.capabilities.embeddings == false
-      assert model.extra.api == "tts"
+      assert model.extra["api"] == "tts"
     end
   end
 end


### PR DESCRIPTION
Closes #243

## Summary

- Decode only schema-known keys, registered providers, and registered modalities into atoms.
- Preserve opaque provider metadata with string keys.
- Route embedded, packaged-file, and configured-file snapshots through one verify, migrate, and validate contract.
- Return structured errors for unknown identifiers without growing the atom table.

## Compatibility

Existing snapshot versions and public query shapes are preserved. Snapshot IDs continue to detect corruption or content mismatch and are not presented as publisher authentication.

## Validation

- Full mix test suite passed.
- mix quality passed.
- Adversarial atom-growth, unknown-key, and integrity-policy coverage added.

## Stack

Base layer; merge first.