### PR TITLE
docs: define the maintainer tooling boundary

### DIFF
--- a/guides/api-and-support-policy.md
+++ b/guides/api-and-support-policy.md
@@ -43,8 +43,8 @@ automatic dotenv boundary.
 The catalog initializes on the first public query without an llm_db supervisor
 or worker. Strict integrity errors therefore surface as `LLMDB.LoadError` at
 first use; explicit `LLMDB.load/1` calls retain their `{:error, reason}` shape.
-`LLMDB.Application.start/2` is a deprecated compatibility shim for one minor
-release and is no longer registered as the package's OTP callback.
+The `LLMDB.Application` callback is a deprecated compatibility shim for one
+minor release and is no longer registered as the package's OTP callback.
 
 ## Supported Artifacts and Extensions
 
@@ -80,4 +80,5 @@ a breaking release unless the API was already documented as transitional.
 
 See [Using the Data](using-the-data.md) for runtime examples and
 [Sources and Engine](sources-and-engine.md) for the build-time extension
-contract.
+contract. See [Runtime and Maintainer Boundaries](runtime-and-maintainer-boundaries.md)
+for the complete module/dependency inventory and extraction sequence.

--- a/guides/runtime-and-maintainer-boundaries.md
+++ b/guides/runtime-and-maintainer-boundaries.md
@@ -1,0 +1,114 @@
+# Runtime and Maintainer Boundaries
+
+LLM DB is a read-mostly runtime catalog. Building, refreshing, publishing, and
+reconstructing that catalog are repository-maintainer workflows. This guide is
+the inventory and compatibility plan for keeping those two concerns separate.
+
+## Supported runtime surface
+
+These modules are covered by the runtime compatibility policy:
+
+| Modules | Ownership |
+| --- | --- |
+| `LLMDB`, `LLMDB.Model`, `LLMDB.Provider`, `LLMDB.Spec` | Typed catalog queries and model-spec handling |
+| `LLMDB.History` | Read-only access to installed history artifacts |
+| `LLMDB.LoadError` | First-use catalog initialization failure |
+| `LLMDB.Snapshot` | Versioned snapshot artifact reading and writing |
+| `LLMDB.Source` | Supported build-time source extension behaviour |
+
+Runtime implementation modules are internal even though they remain shipped:
+
+| Modules | Ownership |
+| --- | --- |
+| LLMDB.Catalog, LLMDB.Loader, LLMDB.Packaged, LLMDB.Query, LLMDB.Runtime | Lazy loading, indexing, storage, and query execution |
+| LLMDB.Config, LLMDB.Merge, LLMDB.Normalize, LLMDB.Pricing | Shared runtime normalization, filtering, and pricing support |
+| LLMDB.Generated.ProviderRegistry, LLMDB.Generated.ValidModalities | Generated bounded decode registries |
+| `LLMDB.Snapshot.ReleaseStore` | Shared remote snapshot/history transport used by configured runtime readers and maintainer tasks |
+
+The internal module layout and raw map/index shapes are not compatibility
+contracts. Consumers should enter through `LLMDB`, `LLMDB.History`, or the
+versioned `LLMDB.Snapshot` format.
+
+## Supported tooling entry points
+
+The supported command surface is the Mix task name, not the implementation
+module it currently calls:
+
+| Task | Ownership |
+| --- | --- |
+| `mix llm_db.models` | Read-only catalog inspection |
+| `mix llm_db.install` | Optional Igniter-based consumer installation |
+| `mix llm_db.snapshot.fetch` | Fetch/install a published snapshot |
+| `mix llm_db.pull` | Maintainer-only upstream synchronization and the sole automatic dotenv boundary |
+| `mix llm_db.build`, `mix llm_db.snapshot.build` | Maintainer-only canonical snapshot build (`snapshot.build` is a supported alias) |
+| `mix llm_db.snapshot.publish` | Maintainer-only snapshot publication |
+| `mix llm_db.history.backfill` | Legacy Git-history backfill kept for compatibility |
+| `mix llm_db.history.migrate_git` | One-time migration to snapshot-store history |
+| `mix llm_db.history.rebuild`, `mix llm_db.history.sync`, `mix llm_db.history.check` | Published history maintenance |
+| `mix llm_db.version` | Maintainer-only CalVer bump |
+
+The corresponding task modules are `Mix.Tasks.LlmDb.Build`,
+`Mix.Tasks.LlmDb.History.Backfill`, `Mix.Tasks.LlmDb.History.Check`,
+`Mix.Tasks.LlmDb.History.MigrateGit`, `Mix.Tasks.LlmDb.History.Rebuild`,
+`Mix.Tasks.LlmDb.History.Sync`, `Mix.Tasks.LlmDb.Install`,
+`Mix.Tasks.LlmDb.Models`, `Mix.Tasks.LlmDb.Pull`,
+`Mix.Tasks.LlmDb.Snapshot.Build`, `Mix.Tasks.LlmDb.Snapshot.Fetch`,
+`Mix.Tasks.LlmDb.Snapshot.Publish`, and `Mix.Tasks.LlmDb.Version`.
+Mix.Tasks.LlmDb.Install.Docs is an internal helper for the conditional install
+task.
+
+## Compatibility facades and direct tooling internals
+
+No module or task is removed in this minor release.
+
+| Current direct call | Supported replacement | Status |
+| --- | --- | --- |
+| `LLMDB.Application` direct callback | Rely on lazy queries; use `LLMDB.load/1` for explicit loading | Compiler-deprecated for one minor release |
+| `LLMDB.Dotenv.load!/1` | `mix llm_db.pull` | Compiler-deprecated; pull remains task-scoped |
+| `LLMDB.Store` query calls | Equivalent `LLMDB` query/load calls | Compatibility facade; direct use is documentation-deprecated |
+| `LLMDB.Engine.run/1`, `LLMDB.Snapshot.Builder` | `mix llm_db.build` | Documentation-deprecated maintainer orchestration |
+| `LLMDB.History.Backfill`, `LLMDB.History.Migrator`, `LLMDB.History.Rebuilder`, `LLMDB.History.Bundle` | Corresponding `mix llm_db.history.*` task | Documentation-deprecated maintainer orchestration |
+| `LLMDB.Snapshot.ReleaseStore` mutation/publishing calls | `mix llm_db.snapshot.publish` or `mix llm_db.history.rebuild --publish` | Internal shared transport; runtime fetch behavior remains supported through configuration |
+| `LLMDB.Enrich`, `LLMDB.Validate`, `LLMDB.Enrich.AzureWireProtocol`, `LLMDB.Enrich.RuntimeContract` | `mix llm_db.build` | Internal ETL stages |
+| LLMDB.Sources.Anthropic, LLMDB.Sources.Google, LLMDB.Sources.Llmfit, LLMDB.Sources.Local, LLMDB.Sources.ModelsDev, LLMDB.Sources.OpenAI, LLMDB.Sources.OpenRouter, LLMDB.Sources.XAI, LLMDB.Sources.Zenmux | `LLMDB.Source` for extensions; `mix llm_db.pull`/`build` for workflows | Internal bundled adapters |
+
+Documentation-only deprecation avoids warnings inside the still-supported task
+wrappers during the extraction window. It does not grant these modules a new
+public compatibility guarantee.
+
+## Dependency ownership
+
+Every direct dependency remains available in this minor release:
+
+| Dependency | Current owner and plan |
+| --- | --- |
+| `zoi` | Runtime schemas and validation; remains required |
+| `jason` | Runtime snapshot decoding plus tooling serialization; remains required |
+| `req` | Remote release snapshot/history reads and maintainer source transport; remains required until remote transport is extracted or replaced |
+| `toml` | Maintainer source ingestion; candidate for a companion tooling package, but remains required while tasks ship here |
+| `dotenvy` | Deprecated `LLMDB.Dotenv` facade and `mix llm_db.pull`; remains required through the compatibility window |
+| `igniter` | Optional install-task integration; remains optional |
+| `plug`, `meck` | Test-only dependencies |
+| `ex_doc`, `git_ops`, `git_hooks`, `usage_rules` | Development/release tooling with `runtime: false` where applicable |
+| `dialyxir`, `credo` | Development/test quality tooling with `runtime: false` |
+
+## Extraction and removal sequence
+
+1. This minor release documents the boundary, keeps every task/module working,
+   and deprecates direct compatibility calls with concrete replacements.
+2. A later compatible release may introduce a companion package and have the
+   existing Mix tasks delegate to it. Task names and options remain stable
+   during that transition.
+3. After at least one minor deprecation window, the next major release may
+   remove maintainer implementation modules and compatibility facades from the
+   core package.
+4. `LLMDB.Dotenv` and core `dotenvy` can be removed only in that major release,
+   after `mix llm_db.pull` owns an equivalent task-private or companion
+   implementation.
+5. `toml` can move with source ingestion. `req` can leave the runtime dependency
+   graph only after configured GitHub-release snapshot/history reads are moved
+   behind an equivalent adapter or companion dependency.
+
+Upstream synchronization never runs during application startup, lazy catalog
+initialization, explicit `LLMDB.load/1`, or queries. Provider credentials and
+dotenv parsing remain exclusively inside the maintainer pull workflow.

--- a/lib/llm_db/dotenv.ex
+++ b/lib/llm_db/dotenv.ex
@@ -1,6 +1,14 @@
 defmodule LLMDB.Dotenv do
-  @moduledoc false
+  @moduledoc """
+  Deprecated compatibility facade for maintainer dotenv loading.
 
+  Dotenv loading belongs exclusively to `mix llm_db.pull`; runtime startup,
+  loading, and queries never call this module. Direct calls remain functional
+  for this minor release and can be removed no earlier than the next major
+  release, together with the core `Dotenvy` dependency.
+  """
+
+  @deprecated "dotenv loading is owned by the mix llm_db.pull maintainer task"
   def load!(opts \\ []) do
     if Application.get_env(:llm_db, :load_dotenv, true) do
       env_path = Keyword.get(opts, :path, Path.join(File.cwd!(), ".env"))

--- a/lib/llm_db/engine.ex
+++ b/lib/llm_db/engine.ex
@@ -9,6 +9,14 @@ defmodule LLMDB.Engine do
   complete, unfiltered snapshots from remote/local sources that will be
   packaged into the library.
 
+  ## Maintainer boundary
+
+  Direct orchestration through `run/1` is documentation-deprecated. Maintainers
+  should use `mix llm_db.build`; custom source implementations should target
+  the supported `LLMDB.Source` behaviour. This module remains callable during
+  the compatibility window and can move or be removed no earlier than the next
+  major release.
+
   ## Pipeline Stages
 
   1. **Ingest** - Load data from configured sources

--- a/lib/llm_db/history/backfill.ex
+++ b/lib/llm_db/history/backfill.ex
@@ -5,6 +5,10 @@ defmodule LLMDB.History.Backfill do
   This module is intentionally git-driven and infrastructure-free: it reads
   `priv/llm_db/providers/*.json` from commit history and writes append-only
   NDJSON event files under a local history directory.
+
+  Direct use is documentation-deprecated. Use
+  `mix llm_db.history.backfill`; new snapshot-store migrations should use
+  `mix llm_db.history.migrate_git`.
   """
 
   @providers_dir "priv/llm_db/providers"

--- a/lib/llm_db/history/bundle.ex
+++ b/lib/llm_db/history/bundle.ex
@@ -1,6 +1,9 @@
 defmodule LLMDB.History.Bundle do
   @moduledoc """
   Snapshot-store helpers for local history bundles.
+
+  Direct use is documentation-deprecated. Use `mix llm_db.history.rebuild` to
+  create a bundle and `mix llm_db.history.sync` to install one.
   """
   @dialyzer {:nowarn_function, create_archive: 2}
 

--- a/lib/llm_db/history/migrator.ex
+++ b/lib/llm_db/history/migrator.ex
@@ -6,6 +6,9 @@ defmodule LLMDB.History.Migrator do
   materializes immutable snapshot artifacts by content hash, deduplicates adjacent
   identical states, and then rebuilds local history artifacts from the resulting
   snapshot observation chain.
+
+  Direct use is documentation-deprecated in favor of
+  `mix llm_db.history.migrate_git`.
   """
 
   alias LLMDB.{History.Rebuilder, Snapshot}

--- a/lib/llm_db/history/rebuilder.ex
+++ b/lib/llm_db/history/rebuilder.ex
@@ -5,6 +5,9 @@ defmodule LLMDB.History.Rebuilder do
   The observation chain is typically sourced from `snapshot-index.json` and contains
   entries keyed by immutable `snapshot_id`, with optional provenance such as
   `captured_at`, `source_commit`, and `parent_snapshot_id`.
+
+  Direct use is documentation-deprecated in favor of
+  `mix llm_db.history.rebuild`.
   """
 
   alias LLMDB.{History.Backfill, Snapshot}

--- a/lib/llm_db/snapshot/builder.ex
+++ b/lib/llm_db/snapshot/builder.ex
@@ -1,6 +1,11 @@
 defmodule LLMDB.Snapshot.Builder do
   @moduledoc """
   Builds canonical snapshot artifacts from configured sources.
+
+  This is maintainer-internal orchestration. Direct use is
+  documentation-deprecated in favor of `mix llm_db.build` (or
+  `mix llm_db.snapshot.publish` when publishing). The module remains callable
+  through the current major release.
   """
 
   alias LLMDB.{Config, Engine, Snapshot}

--- a/lib/llm_db/snapshot/release_store.ex
+++ b/lib/llm_db/snapshot/release_store.ex
@@ -6,6 +6,11 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   GitHub Releases API and downloads public assets via Req. Publishing is
   handled with the `gh` CLI, intended for local maintainer workflows and
   GitHub Actions.
+
+  This shared transport is internal. Runtime consumers configure snapshot
+  sources through `LLMDB.load/1`; maintainers use the supported
+  `mix llm_db.snapshot.*` and `mix llm_db.history.*` tasks. Direct publishing
+  calls are documentation-deprecated through the current major release.
   """
 
   alias LLMDB.Snapshot

--- a/lib/llm_db/store.ex
+++ b/lib/llm_db/store.ex
@@ -3,6 +3,11 @@ defmodule LLMDB.Store do
   Manages persistent_term storage for LLM model snapshots with atomic swaps.
 
   Uses `:persistent_term` for fast, concurrent reads with atomic updates tracked by monotonic epochs.
+
+  This module is a compatibility facade over the internal catalog boundary.
+  Consumers should use `LLMDB` query and load functions. Raw store access has
+  no backwards-compatibility guarantee and can be removed no earlier than the
+  next major release.
   """
 
   alias LLMDB.{Catalog, Model, Provider}

--- a/lib/mix/tasks/llm_db.models.ex
+++ b/lib/mix/tasks/llm_db.models.ex
@@ -6,10 +6,10 @@ defmodule Mix.Tasks.LlmDb.Models do
 
   ## Usage
 
-      mix llmdb.models              # List all models
-      mix llmdb.models "anthropic:*"     # List all Anthropic models
-      mix llmdb.models "openai:gpt-4o"   # List specific model
-      mix llmdb.models "*:*"             # List all models (explicit)
+      mix llm_db.models                  # List all models
+      mix llm_db.models "anthropic:*"     # List all Anthropic models
+      mix llm_db.models "openai:gpt-4o"   # List specific model
+      mix llm_db.models "*:*"             # List all models (explicit)
 
   ## Model Specs
 
@@ -35,16 +35,16 @@ defmodule Mix.Tasks.LlmDb.Models do
   ## Examples
 
       # List all Anthropic models
-      mix llmdb.models "anthropic:*"
+      mix llm_db.models "anthropic:*"
 
       # List all OpenAI GPT-4 models
-      mix llmdb.models "openai:gpt-4*"
+      mix llm_db.models "openai:gpt-4*"
 
       # List specific model by alias
-      mix llmdb.models "anthropic:claude-3.5-haiku"
+      mix llm_db.models "anthropic:claude-3.5-haiku"
 
       # List all models
-      mix llmdb.models
+      mix llm_db.models
   """
 
   use Mix.Task

--- a/lib/mix/tasks/llm_db.pull.ex
+++ b/lib/mix/tasks/llm_db.pull.ex
@@ -130,7 +130,10 @@ defmodule Mix.Tasks.LlmDb.Pull do
     Mix.Task.run("app.config")
 
     override? = Application.get_env(:llm_db, :dotenv_override, true)
-    LLMDB.Dotenv.load!(override: override?)
+
+    # Keep task ownership explicit without making the task itself a static
+    # caller of the deprecated compatibility facade.
+    apply(LLMDB.Dotenv, :load!, [[override: override?]])
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule LLMDB.MixProject do
           "guides/model-spec-formats.md",
           "guides/model-struct-evolution-proposal.md",
           "guides/pricing-and-billing.md",
+          "guides/runtime-and-maintainer-boundaries.md",
           "guides/schema-system.md",
           "guides/sources-and-engine.md",
           "guides/runtime-filters.md",
@@ -51,23 +52,32 @@ defmodule LLMDB.MixProject do
           "Stable Runtime API": [
             LLMDB,
             LLMDB.History,
+            LLMDB.LoadError,
             LLMDB.Model,
             LLMDB.Provider,
             LLMDB.Spec
           ],
-          "Supported Artifacts and Extensions": [
+          "Supported Build Extensions": [
             LLMDB.Snapshot,
             LLMDB.Source
           ],
-          "Maintainer Tooling": [
+          "Supported Mix Tasks": [
+            ~r/^Mix\.Tasks\.LlmDb\./
+          ],
+          "Compatibility Facades": [
+            LLMDB.Application,
+            LLMDB.Dotenv,
+            LLMDB.Store
+          ],
+          "Maintainer Internals": [
             LLMDB.Engine,
             LLMDB.Snapshot.Builder,
-            LLMDB.Snapshot.ReleaseStore,
+            ~r/^LLMDB\.(Enrich|History\.|Validate)(\.|$)/,
             ~r/^LLMDB\.Sources\./
           ],
-          "Internal Implementation": [
-            ~r/^LLMDB\.(Application|Config|Enrich|Generated|Loader|Merge|Normalize|Packaged|Pricing|Query|Runtime|Store|Validate)(\.|$)/,
-            ~r/^LLMDB\.History\./
+          "Internal Runtime Implementation": [
+            LLMDB.Snapshot.ReleaseStore,
+            ~r/^LLMDB\.(Catalog|Config|Generated|Loader|Merge|Normalize|Packaged|Pricing|Query|Runtime)(\.|$)/
           ]
         ]
       ]

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule LLMDB.MixProject do
           "Maintainer Internals": [
             LLMDB.Engine,
             LLMDB.Snapshot.Builder,
-            ~r/^LLMDB\.(Enrich|History\.|Validate)(\.|$)/,
+            ~r/^LLMDB\.(Enrich|History|Validate)(\.|$)/,
             ~r/^LLMDB\.Sources\./
           ],
           "Internal Runtime Implementation": [

--- a/test/llm_db/dotenv_test.exs
+++ b/test/llm_db/dotenv_test.exs
@@ -27,7 +27,7 @@ defmodule LLMDB.DotenvTest do
       System.put_env("LLMDB_DOTENV_EXISTING", "from_shell")
       System.delete_env("LLMDB_DOTENV_LOADED")
 
-      LLMDB.Dotenv.load!(path: env_path)
+      load_dotenv(path: env_path)
 
       assert System.get_env("LLMDB_DOTENV_EXISTING") == "from_shell"
       assert System.get_env("LLMDB_DOTENV_LOADED") == "from_dotenv"
@@ -48,7 +48,7 @@ defmodule LLMDB.DotenvTest do
       System.put_env("LLMDB_DOTENV_EXISTING", "from_shell")
       System.delete_env("LLMDB_DOTENV_LOADED")
 
-      LLMDB.Dotenv.load!(path: env_path, override: true)
+      load_dotenv(path: env_path, override: true)
 
       assert System.get_env("LLMDB_DOTENV_EXISTING") == "from_dotenv"
       assert System.get_env("LLMDB_DOTENV_LOADED") == "from_dotenv"
@@ -64,12 +64,14 @@ defmodule LLMDB.DotenvTest do
       Application.put_env(:llm_db, :load_dotenv, true)
 
       assert_raise RuntimeError, ~r/There was error with file/, fn ->
-        LLMDB.Dotenv.load!(path: env_path)
+        load_dotenv(path: env_path)
       end
     after
       File.rm(env_path)
     end
   end
+
+  defp load_dotenv(opts), do: apply(LLMDB.Dotenv, :load!, [opts])
 
   defp write_temp_env(contents) do
     path = Path.join(System.tmp_dir!(), "llm_db-dotenv-#{System.unique_integer([:positive])}.env")

--- a/test/llm_db/tooling_boundary_test.exs
+++ b/test/llm_db/tooling_boundary_test.exs
@@ -1,0 +1,65 @@
+defmodule LLMDB.ToolingBoundaryTest do
+  use ExUnit.Case, async: true
+
+  @project_root Path.expand("../..", __DIR__)
+  @boundary_guide Path.join(@project_root, "guides/runtime-and-maintainer-boundaries.md")
+
+  @supported_tasks %{
+    "llm_db.build" => Mix.Tasks.LlmDb.Build,
+    "llm_db.history.backfill" => Mix.Tasks.LlmDb.History.Backfill,
+    "llm_db.history.check" => Mix.Tasks.LlmDb.History.Check,
+    "llm_db.history.migrate_git" => Mix.Tasks.LlmDb.History.MigrateGit,
+    "llm_db.history.rebuild" => Mix.Tasks.LlmDb.History.Rebuild,
+    "llm_db.history.sync" => Mix.Tasks.LlmDb.History.Sync,
+    "llm_db.install" => Mix.Tasks.LlmDb.Install,
+    "llm_db.models" => Mix.Tasks.LlmDb.Models,
+    "llm_db.pull" => Mix.Tasks.LlmDb.Pull,
+    "llm_db.snapshot.build" => Mix.Tasks.LlmDb.Snapshot.Build,
+    "llm_db.snapshot.fetch" => Mix.Tasks.LlmDb.Snapshot.Fetch,
+    "llm_db.snapshot.publish" => Mix.Tasks.LlmDb.Snapshot.Publish,
+    "llm_db.version" => Mix.Tasks.LlmDb.Version
+  }
+
+  test "every supported Mix task name remains registered and callable" do
+    Enum.each(@supported_tasks, fn {task_name, module} ->
+      assert Code.ensure_loaded?(module)
+      assert Mix.Task.get(task_name) == module
+      assert function_exported?(module, :run, 1)
+    end)
+  end
+
+  test "dotenv compatibility calls identify their task replacement" do
+    deprecations = LLMDB.Dotenv.__info__(:deprecated)
+
+    assert {{:load!, 0}, message} = List.keyfind(deprecations, {:load!, 0}, 0)
+    assert message =~ "mix llm_db.pull"
+    assert {{:load!, 1}, ^message} = List.keyfind(deprecations, {:load!, 1}, 0)
+  end
+
+  test "the boundary guide inventories every shipped module and direct dependency" do
+    guide = File.read!(@boundary_guide)
+
+    modules =
+      @project_root
+      |> Path.join("lib/**/*.ex")
+      |> Path.wildcard()
+      |> Enum.flat_map(fn path ->
+        ~r/^\s*defmodule\s+([A-Za-z0-9_.]+)/m
+        |> Regex.scan(File.read!(path), capture: :all_but_first)
+        |> List.flatten()
+      end)
+      |> Enum.uniq()
+
+    dependencies =
+      Mix.Project.config()
+      |> Keyword.fetch!(:deps)
+      |> Enum.map(fn
+        {name, _requirement} -> name
+        {name, _requirement, _opts} -> name
+      end)
+      |> Enum.map(&Atom.to_string/1)
+
+    assert Enum.reject(modules, &String.contains?(guide, &1)) == []
+    assert Enum.reject(dependencies, &String.contains?(guide, "`#{&1}`")) == []
+  end
+end


### PR DESCRIPTION
Closes #257

## Summary

- Classify every shipped module and direct dependency by runtime, supported tooling, compatibility, or internal ownership.
- Group ExDoc around the supported runtime and Mix-task boundaries.
- Compiler-deprecate the Dotenv compatibility facade with mix llm_db.pull as its replacement.
- Document direct maintainer internals, dependency ownership, and the next-major extraction sequence.
- Preserve and registry-test all 13 supported Mix task names.
- Correct the documented llm_db.models task name.

## Compatibility

No task, module, or dependency is removed or made optional. Dotenvy, Req, and TOML remain available through the documented compatibility window.

## Validation

- Full mix test suite passed.
- mix quality passed.
- mix docs completed without warnings.
- Inventory drift test covers every source module and direct dependency.

## Stack

Depends on #244. Merge after the lazy initialization PR.