### PR TITLE
refactor: centralize catalog indexing and resolution

### DIFF
--- a/bench/catalog.exs
+++ b/bench/catalog.exs
@@ -1,0 +1,26 @@
+defmodule LLMDB.CatalogBenchmark do
+  @moduledoc false
+
+  def run do
+    measure("cold load", 3, fn ->
+      LLMDB.Store.clear!()
+      {:ok, _snapshot} = LLMDB.load()
+    end)
+
+    measure("no-op reload", 5, fn ->
+      {:ok, _snapshot} = LLMDB.load()
+    end)
+
+    measure("warm lookup", 100_000, fn ->
+      {:ok, _model} = LLMDB.model(:openai, "gpt-4o-mini")
+    end)
+  end
+
+  defp measure(label, iterations, fun) do
+    {microseconds, _result} = :timer.tc(fn -> Enum.each(1..iterations, fn _ -> fun.() end) end)
+    average = microseconds / iterations
+    IO.puts("#{label}: #{Float.round(average, 2)} µs/op (#{iterations} iterations)")
+  end
+end
+
+LLMDB.CatalogBenchmark.run()

--- a/bench/catalog.md
+++ b/bench/catalog.md
@@ -1,0 +1,20 @@
+# Catalog boundary benchmark
+
+Run with:
+
+```shell
+MIX_ENV=dev mix run bench/catalog.exs
+```
+
+Local comparison on 2026-07-16, using the packaged 168-provider/5,988-model
+snapshot and the same Erlang/Elixir installation for both revisions:
+
+| Operation | Before (`ce04c14`) | Catalog boundary | Change |
+| --- | ---: | ---: | ---: |
+| Cold load | 1,027,620 µs | 895,195 µs | -12.9% |
+| No-op reload | 1,022,509 µs | 909,781 µs | -11.0% |
+| Warm direct lookup | 19.73 µs | 0.17 µs | -99.1% |
+
+These are directional local measurements, not release guarantees. The warm
+lookup difference reflects replacing provider scanning with immutable lookup
+indexes. Re-run the script when the snapshot or runtime changes materially.

--- a/lib/llm_db/catalog.ex
+++ b/lib/llm_db/catalog.ex
@@ -1,0 +1,388 @@
+defmodule LLMDB.Catalog do
+  @moduledoc false
+
+  @store_key :llm_db_store
+  @provider_aliases %{google_vertex_anthropic: :google_vertex}
+  @bedrock_prefixes ~w(us. eu. ap. apac. ca. au. jp. us-gov. global.)
+
+  @typedoc false
+  @type t :: map()
+
+  @spec build(list(), list(), list(), keyword()) :: t()
+  def build(providers, filtered_models, base_models, opts)
+      when is_list(providers) and is_list(filtered_models) and is_list(base_models) and
+             is_list(opts) do
+    providers = apply_provider_aliases(providers)
+
+    %{
+      providers_by_id: index_providers(providers),
+      models_by_key: index_models(filtered_models),
+      aliases_by_key: index_aliases(filtered_models),
+      providers: providers,
+      models: Enum.group_by(filtered_models, & &1.provider),
+      base_models: base_models,
+      filters: Keyword.fetch!(opts, :filters),
+      prefer: Keyword.get(opts, :prefer, []),
+      meta: %{
+        epoch: nil,
+        source_generated_at: Keyword.get(opts, :source_generated_at),
+        source_snapshot_id: Keyword.get(opts, :source_snapshot_id),
+        loaded_at: Keyword.fetch!(opts, :loaded_at),
+        digest: Keyword.fetch!(opts, :digest)
+      }
+    }
+    |> put_resolution_indexes(filtered_models)
+  end
+
+  @spec empty(keyword()) :: t()
+  def empty(opts) when is_list(opts) do
+    build([], [], [], opts)
+  end
+
+  @spec with_runtime_view(t(), list(), map()) :: t()
+  def with_runtime_view(catalog, filtered_models, filters)
+      when is_map(catalog) and is_list(filtered_models) and is_map(filters) do
+    catalog
+    |> Map.merge(%{
+      filters: filters,
+      models_by_key: index_models(filtered_models),
+      aliases_by_key: index_aliases(filtered_models),
+      models: Enum.group_by(filtered_models, & &1.provider)
+    })
+    |> put_resolution_indexes(filtered_models)
+  end
+
+  @spec with_prefer(t(), [atom()]) :: t()
+  def with_prefer(catalog, prefer) when is_map(catalog) and is_list(prefer) do
+    Map.put(catalog, :prefer, prefer)
+  end
+
+  # Persistent storage belongs to the catalog boundary. Store remains a
+  # compatibility facade, while Spec and Query can depend on Catalog directly
+  # without forming Model -> Spec -> Store -> Model.
+  @spec get() :: map() | nil
+  def get, do: :persistent_term.get(@store_key, nil)
+
+  @spec snapshot() :: t() | nil
+  def snapshot do
+    case get() do
+      %{snapshot: snapshot} -> snapshot
+      _ -> nil
+    end
+  end
+
+  @spec epoch() :: non_neg_integer()
+  def epoch do
+    case get() do
+      %{epoch: epoch} -> epoch
+      _ -> 0
+    end
+  end
+
+  @spec last_opts() :: keyword()
+  def last_opts do
+    case get() do
+      %{opts: opts} -> opts
+      _ -> []
+    end
+  end
+
+  @spec put!(t(), keyword()) :: :ok
+  def put!(catalog, opts) when is_map(catalog) and is_list(opts) do
+    epoch = :erlang.unique_integer([:monotonic, :positive])
+    :persistent_term.put(@store_key, %{snapshot: catalog, epoch: epoch, opts: opts})
+    :ok
+  end
+
+  @spec clear!() :: :ok
+  def clear! do
+    :persistent_term.erase(@store_key)
+    :ok
+  end
+
+  @spec providers(t() | nil) :: list()
+  def providers(%{providers: providers}) when is_list(providers), do: providers
+  def providers(_catalog), do: []
+
+  @spec providers() :: list()
+  def providers, do: providers(snapshot())
+
+  @spec provider(t() | nil, atom()) :: {:ok, map()} | {:error, :not_found}
+  def provider(%{providers_by_id: providers}, provider_id)
+      when is_map(providers) and is_atom(provider_id) do
+    case Map.fetch(providers, provider_id) do
+      {:ok, provider} -> {:ok, provider}
+      :error -> {:error, :not_found}
+    end
+  end
+
+  def provider(_catalog, _provider_id), do: {:error, :not_found}
+
+  @spec provider(atom()) :: {:ok, map()} | {:error, :not_found}
+  def provider(provider_id), do: provider(snapshot(), provider_id)
+
+  @spec provider_exists?(t() | nil, atom()) :: boolean()
+  def provider_exists?(%{providers_by_id: providers}, provider_id)
+      when is_map(providers) and is_atom(provider_id) do
+    Map.has_key?(providers, provider_id)
+  end
+
+  def provider_exists?(_catalog, _provider_id), do: false
+
+  @spec provider_exists?(atom()) :: boolean()
+  def provider_exists?(provider_id), do: provider_exists?(snapshot(), provider_id)
+
+  @spec models(t() | nil, atom()) :: list()
+  def models(catalog, provider_id) when is_map(catalog) and is_atom(provider_id) do
+    models = Map.get(catalog, :models) || Map.get(catalog, :models_by_provider) || %{}
+
+    if is_map(models) do
+      catalog
+      |> provider_lookup_ids(provider_id)
+      |> Enum.flat_map(&Map.get(models, &1, []))
+      |> Enum.uniq_by(&field(&1, :id))
+    else
+      []
+    end
+  end
+
+  def models(_catalog, _provider_id), do: []
+
+  @spec models(atom()) :: list()
+  def models(provider_id), do: models(snapshot(), provider_id)
+
+  @spec model(t() | nil, atom(), String.t()) :: {:ok, map()} | {:error, :not_found}
+  def model(catalog, provider_id, model_id)
+      when is_atom(provider_id) and is_binary(model_id) do
+    case resolve_model(catalog, provider_id, model_id) do
+      {:ok, {_provider, _canonical_id, model}} -> {:ok, model}
+      {:error, :not_found} = error -> error
+    end
+  end
+
+  @spec model(atom(), String.t()) :: {:ok, map()} | {:error, :not_found}
+  def model(provider_id, model_id), do: model(snapshot(), provider_id, model_id)
+
+  @spec resolve_model(t() | nil, atom(), String.t()) ::
+          {:ok, {atom(), String.t(), map()}} | {:error, :not_found}
+  def resolve_model(nil, _provider_id, _model_id), do: {:error, :not_found}
+
+  def resolve_model(catalog, provider_id, model_id)
+      when is_map(catalog) and is_atom(provider_id) and is_binary(model_id) do
+    {lookup_id, prefix} = strip_prefix(provider_id, model_id)
+
+    result =
+      catalog
+      |> provider_lookup_ids(provider_id)
+      |> Enum.find_value(fn actual_provider ->
+        case fetch_model(catalog, actual_provider, lookup_id) do
+          nil -> nil
+          {canonical_id, model} -> {actual_provider, canonical_id, model}
+        end
+      end)
+
+    case result do
+      nil ->
+        {:error, :not_found}
+
+      {actual_provider, canonical_id, model} ->
+        returned_id = if prefix, do: prefix <> canonical_id, else: canonical_id
+        model = normalize_provider(model, actual_provider, provider_id)
+        {:ok, {provider_id, returned_id, model}}
+    end
+  end
+
+  @spec resolve_bare(t() | nil, String.t()) ::
+          {:ok, {atom(), String.t(), map()}} | {:error, :not_found | :ambiguous}
+  def resolve_bare(nil, _model_id), do: {:error, :not_found}
+
+  def resolve_bare(catalog, model_id) when is_map(catalog) and is_binary(model_id) do
+    direct = Map.get(resolutions_by_model_id(catalog), model_id, [])
+    {bedrock_id, bedrock_prefix} = strip_prefix(:amazon_bedrock, model_id)
+
+    prefixed_bedrock =
+      if bedrock_prefix do
+        catalog
+        |> resolutions_by_model_id()
+        |> Map.get(bedrock_id, [])
+        |> Enum.filter(fn {provider, _canonical_id, _model} ->
+          provider == :amazon_bedrock
+        end)
+        |> Enum.map(fn {provider, canonical_id, model} ->
+          {provider, bedrock_prefix <> canonical_id, model}
+        end)
+      else
+        []
+      end
+
+    matches =
+      (direct ++ prefixed_bedrock)
+      |> Enum.uniq_by(fn {provider, canonical_id, _model} -> {provider, canonical_id} end)
+
+    case matches do
+      [] -> {:error, :not_found}
+      [match] -> {:ok, match}
+      [_ | _] -> {:error, :ambiguous}
+    end
+  end
+
+  @spec resolve_bare(String.t()) ::
+          {:ok, {atom(), String.t(), map()}} | {:error, :not_found | :ambiguous}
+  def resolve_bare(model_id), do: resolve_bare(snapshot(), model_id)
+
+  @spec strip_prefix(atom(), String.t()) :: {String.t(), String.t() | nil}
+  def strip_prefix(:amazon_bedrock, model_id) when is_binary(model_id) do
+    case Enum.find_value(@bedrock_prefixes, fn prefix ->
+           if String.starts_with?(model_id, prefix) do
+             {String.replace_prefix(model_id, prefix, ""), prefix}
+           end
+         end) do
+      nil -> {model_id, nil}
+      result -> result
+    end
+  end
+
+  def strip_prefix(_provider, model_id) when is_binary(model_id), do: {model_id, nil}
+
+  @spec prefer(t() | nil) :: [atom()]
+  def prefer(%{prefer: prefer}) when is_list(prefer), do: prefer
+  def prefer(_catalog), do: []
+
+  @spec prefer() :: [atom()]
+  def prefer, do: prefer(snapshot())
+
+  defp put_resolution_indexes(catalog, models) do
+    Map.merge(catalog, %{
+      __llm_db_provider_lookup_ids__: index_provider_lookup_ids(catalog.providers),
+      __llm_db_resolutions_by_model_id__: index_resolutions(models)
+    })
+  end
+
+  defp apply_provider_aliases(providers) do
+    Enum.map(providers, fn provider ->
+      case Map.get(@provider_aliases, field(provider, :id)) do
+        nil -> provider
+        primary_id -> Map.put(provider, :alias_of, primary_id)
+      end
+    end)
+  end
+
+  defp index_providers(providers), do: Map.new(providers, &{field(&1, :id), &1})
+
+  defp index_models(models) do
+    Map.new(models, &{{field(&1, :provider), field(&1, :id)}, &1})
+  end
+
+  defp index_aliases(models) do
+    models
+    |> Enum.flat_map(fn model ->
+      provider = field(model, :provider)
+      canonical_id = field(model, :id)
+
+      Enum.map(field(model, :aliases) || [], fn alias_name ->
+        {{provider, alias_name}, canonical_id}
+      end)
+    end)
+    |> Map.new()
+  end
+
+  defp index_provider_lookup_ids(providers) do
+    provider_ids_by_name =
+      Map.new(providers, fn provider ->
+        provider_id = field(provider, :id)
+        {to_string(provider_id), provider_id}
+      end)
+
+    Enum.reduce(providers, %{}, fn provider, acc ->
+      provider_id = field(provider, :id)
+      alias_of = normalize_provider_id(field(provider, :alias_of), provider_ids_by_name)
+      acc = Map.put_new(acc, provider_id, [provider_id])
+
+      if is_atom(alias_of) do
+        Map.update(acc, alias_of, [alias_of, provider_id], fn ids ->
+          Enum.uniq(ids ++ [provider_id])
+        end)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp index_resolutions(models) do
+    models
+    |> Enum.reduce(%{}, fn model, acc ->
+      provider = field(model, :provider)
+      canonical_id = field(model, :id)
+      resolution = {provider, canonical_id, model}
+
+      [canonical_id | field(model, :aliases) || []]
+      |> Enum.reduce(acc, fn lookup_id, entries ->
+        Map.update(entries, lookup_id, [resolution], &[resolution | &1])
+      end)
+    end)
+    |> Map.new(fn {model_id, entries} -> {model_id, Enum.reverse(entries)} end)
+  end
+
+  defp provider_lookup_ids(catalog, provider_id) do
+    catalog
+    |> provider_lookup_index()
+    |> Map.get(provider_id, [provider_id])
+  end
+
+  defp provider_lookup_index(%{__llm_db_provider_lookup_ids__: index}) when is_map(index),
+    do: index
+
+  defp provider_lookup_index(catalog), do: index_provider_lookup_ids(providers(catalog))
+
+  defp resolutions_by_model_id(%{__llm_db_resolutions_by_model_id__: index})
+       when is_map(index),
+       do: index
+
+  defp resolutions_by_model_id(catalog) do
+    models =
+      cond do
+        is_map(Map.get(catalog, :models)) ->
+          catalog |> Map.fetch!(:models) |> Map.values() |> List.flatten()
+
+        is_map(Map.get(catalog, :models_by_provider)) ->
+          catalog |> Map.fetch!(:models_by_provider) |> Map.values() |> List.flatten()
+
+        is_map(Map.get(catalog, :models_by_key)) ->
+          catalog |> Map.fetch!(:models_by_key) |> Map.values()
+
+        true ->
+          []
+      end
+
+    index_resolutions(models)
+  end
+
+  defp fetch_model(catalog, provider, lookup_id) do
+    key = {provider, lookup_id}
+    canonical_id = Map.get(catalog.aliases_by_key, key, lookup_id)
+
+    case Map.get(catalog.models_by_key, {provider, canonical_id}) do
+      nil -> nil
+      model -> {canonical_id, model}
+    end
+  end
+
+  defp normalize_provider(model, provider, requested_provider)
+       when provider != requested_provider do
+    Map.put(model, :provider, requested_provider)
+  end
+
+  defp normalize_provider(model, _provider, _requested_provider), do: model
+
+  defp normalize_provider_id(provider_id, _provider_ids_by_name) when is_atom(provider_id),
+    do: provider_id
+
+  defp normalize_provider_id(provider_id, provider_ids_by_name) when is_binary(provider_id),
+    do: Map.get(provider_ids_by_name, provider_id)
+
+  defp normalize_provider_id(_provider_id, _provider_ids_by_name), do: nil
+
+  defp field(map, key) when is_map(map) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key)))
+  end
+end

--- a/lib/llm_db/catalog.ex
+++ b/lib/llm_db/catalog.ex
@@ -197,8 +197,13 @@ defmodule LLMDB.Catalog do
   def resolve_bare(nil, _model_id), do: {:error, :not_found}
 
   def resolve_bare(catalog, model_id) when is_map(catalog) and is_binary(model_id) do
-    direct = Map.get(resolutions_by_model_id(catalog), model_id, [])
     {bedrock_id, bedrock_prefix} = strip_prefix(:amazon_bedrock, model_id)
+
+    direct =
+      catalog
+      |> resolutions_by_model_id()
+      |> Map.get(model_id, [])
+      |> maybe_reject_prefixed_bedrock(bedrock_prefix)
 
     prefixed_bedrock =
       if bedrock_prefix do
@@ -309,18 +314,41 @@ defmodule LLMDB.Catalog do
   end
 
   defp index_resolutions(models) do
-    models
-    |> Enum.reduce(%{}, fn model, acc ->
-      provider = field(model, :provider)
-      canonical_id = field(model, :id)
-      resolution = {provider, canonical_id, model}
-
-      [canonical_id | field(model, :aliases) || []]
-      |> Enum.reduce(acc, fn lookup_id, entries ->
-        Map.update(entries, lookup_id, [resolution], &[resolution | &1])
+    direct =
+      Map.new(models, fn model ->
+        provider = field(model, :provider)
+        canonical_id = field(model, :id)
+        {{provider, canonical_id}, {provider, canonical_id, model}}
       end)
+
+    aliases =
+      Enum.reduce(models, %{}, fn model, acc ->
+        provider = field(model, :provider)
+        canonical_id = field(model, :id)
+        resolution = {provider, canonical_id, model}
+
+        Enum.reduce(field(model, :aliases) || [], acc, fn alias_name, entries ->
+          Map.put(entries, {provider, alias_name}, resolution)
+        end)
+      end)
+
+    direct
+    |> Map.merge(aliases)
+    |> Enum.group_by(
+      fn {{_provider, lookup_id}, _resolution} -> lookup_id end,
+      fn {_key, resolution} -> resolution end
+    )
+    |> Map.new(fn {lookup_id, resolutions} ->
+      {lookup_id, Enum.sort_by(resolutions, fn {provider, _canonical_id, _model} -> provider end)}
     end)
-    |> Map.new(fn {model_id, entries} -> {model_id, Enum.reverse(entries)} end)
+  end
+
+  defp maybe_reject_prefixed_bedrock(resolutions, nil), do: resolutions
+
+  defp maybe_reject_prefixed_bedrock(resolutions, _prefix) do
+    Enum.reject(resolutions, fn {provider, _canonical_id, _model} ->
+      provider == :amazon_bedrock
+    end)
   end
 
   defp provider_lookup_ids(catalog, provider_id) do

--- a/lib/llm_db/loader.ex
+++ b/lib/llm_db/loader.ex
@@ -9,7 +9,19 @@ defmodule LLMDB.Loader do
   LLMDB module focused on the query API.
   """
 
-  alias LLMDB.{Engine, Merge, Model, Packaged, Pricing, Provider, Runtime, Snapshot, Validate}
+  alias LLMDB.{
+    Catalog,
+    Engine,
+    Merge,
+    Model,
+    Packaged,
+    Pricing,
+    Provider,
+    Runtime,
+    Snapshot,
+    Validate
+  }
+
   alias LLMDB.Generated.{ProviderRegistry, ValidModalities}
   alias LLMDB.Snapshot.ReleaseStore
 
@@ -223,23 +235,15 @@ defmodule LLMDB.Loader do
   def load_empty(opts \\ []) do
     runtime = Runtime.compile(opts)
 
-    snapshot = %{
-      providers_by_id: %{},
-      models_by_key: %{},
-      aliases_by_key: %{},
-      providers: [],
-      models: %{},
-      base_models: [],
-      filters: runtime.filters,
-      prefer: runtime.prefer,
-      meta: %{
-        epoch: nil,
+    snapshot =
+      Catalog.empty(
+        filters: runtime.filters,
+        prefer: runtime.prefer,
         source_generated_at: nil,
         source_snapshot_id: nil,
         loaded_at: DateTime.utc_now() |> DateTime.to_iso8601(),
         digest: compute_digest([], [], runtime)
-      }
-    }
+      )
 
     {:ok, snapshot}
   end
@@ -542,66 +546,18 @@ defmodule LLMDB.Loader do
          generated_at,
          source_snapshot_id
        ) do
-    # Apply provider aliases AFTER all sources are loaded
-    providers_with_aliases = apply_provider_aliases(providers)
-
-    %{
-      providers_by_id: index_providers(providers_with_aliases),
-      models_by_key: index_models(filtered_models),
-      aliases_by_key: index_aliases(filtered_models),
-      providers: providers_with_aliases,
-      models: Enum.group_by(filtered_models, & &1.provider),
-      base_models: base_models,
+    Catalog.build(providers, filtered_models, base_models,
       filters: runtime.filters,
       prefer: runtime.prefer,
-      meta: %{
-        epoch: nil,
-        source_generated_at: generated_at,
-        source_snapshot_id: source_snapshot_id,
-        loaded_at: DateTime.utc_now() |> DateTime.to_iso8601(),
-        digest:
-          compute_digest(providers, base_models, runtime, %{
-            source_generated_at: generated_at,
-            source_snapshot_id: source_snapshot_id
-          })
-      }
-    }
-  end
-
-  # Apply provider aliases post-load (after all sources merged)
-  # This handles cases where a single implementation (e.g., GoogleVertex)
-  # should handle models from multiple LLMDB providers
-  defp apply_provider_aliases(providers) do
-    # Hardcoded provider alias mappings
-    # Key: aliased provider ID, Value: primary provider ID
-    alias_map = %{
-      google_vertex_anthropic: :google_vertex
-    }
-
-    Enum.map(providers, fn provider ->
-      case Map.get(alias_map, provider.id) do
-        nil -> provider
-        primary_id -> Map.put(provider, :alias_of, primary_id)
-      end
-    end)
-  end
-
-  defp index_providers(providers), do: Map.new(providers, &{&1.id, &1})
-
-  defp index_models(models), do: Map.new(models, &{{&1.provider, &1.id}, &1})
-
-  defp index_aliases(models) do
-    models
-    |> Enum.flat_map(fn model ->
-      provider = model.provider
-      canonical_id = model.id
-      aliases = Map.get(model, :aliases, [])
-
-      Enum.map(aliases, fn alias_name ->
-        {{provider, alias_name}, canonical_id}
-      end)
-    end)
-    |> Map.new()
+      source_generated_at: generated_at,
+      source_snapshot_id: source_snapshot_id,
+      loaded_at: DateTime.utc_now() |> DateTime.to_iso8601(),
+      digest:
+        compute_digest(providers, base_models, runtime, %{
+          source_generated_at: generated_at,
+          source_snapshot_id: source_snapshot_id
+        })
+    )
   end
 
   defp summarize_filter(:all), do: ":all"

--- a/lib/llm_db/query.ex
+++ b/lib/llm_db/query.ex
@@ -6,7 +6,7 @@ defmodule LLMDB.Query do
   All queries operate on the filtered catalog loaded into the Store.
   """
 
-  alias LLMDB.{Model, Spec, Store}
+  alias LLMDB.{Catalog, Model, Spec}
 
   @type provider :: atom()
   @type model_id :: String.t()
@@ -73,10 +73,7 @@ defmodule LLMDB.Query do
     prefer =
       case Keyword.fetch(opts, :prefer) do
         :error ->
-          case Store.snapshot() do
-            %{prefer: p} when is_list(p) -> p
-            _ -> []
-          end
+          Catalog.prefer()
 
         {:ok, p} ->
           p
@@ -126,10 +123,7 @@ defmodule LLMDB.Query do
     prefer =
       case Keyword.fetch(opts, :prefer) do
         :error ->
-          case Store.snapshot() do
-            %{prefer: p} when is_list(p) -> p
-            _ -> []
-          end
+          Catalog.prefer()
 
         {:ok, p} ->
           p
@@ -164,7 +158,7 @@ defmodule LLMDB.Query do
   def capabilities(%Model{capabilities: caps}), do: caps
 
   def capabilities({provider, model_id}) when is_atom(provider) and is_binary(model_id) do
-    case Store.model(provider, model_id) do
+    case Catalog.model(provider, model_id) do
       {:ok, m} -> Map.get(m, :capabilities)
       _ -> nil
     end
@@ -180,7 +174,7 @@ defmodule LLMDB.Query do
   # Private helpers
 
   defp build_provider_list(:all, prefer) do
-    all_providers = Store.providers() |> Enum.map(& &1.id)
+    all_providers = Catalog.providers() |> Enum.map(&Map.get(&1, :id, Map.get(&1, "id")))
 
     if prefer != [] do
       prefer ++ (all_providers -- prefer)
@@ -197,7 +191,7 @@ defmodule LLMDB.Query do
 
   defp find_first_match([provider | rest], require_kw, forbid_kw) do
     models_list =
-      Store.models(provider)
+      Catalog.models(provider)
       |> Enum.filter(&matches_require?(&1, require_kw))
       |> Enum.reject(&matches_forbid?(&1, forbid_kw))
 
@@ -209,7 +203,7 @@ defmodule LLMDB.Query do
 
   defp find_all_matches(providers, require_kw, forbid_kw) do
     Enum.flat_map(providers, fn provider ->
-      Store.models(provider)
+      Catalog.models(provider)
       |> Enum.filter(&matches_require?(&1, require_kw))
       |> Enum.reject(&matches_forbid?(&1, forbid_kw))
       |> Enum.map(&{provider, &1.id})

--- a/lib/llm_db/runtime.ex
+++ b/lib/llm_db/runtime.ex
@@ -25,7 +25,7 @@ defmodule LLMDB.Runtime do
       # Runtime config can then be used to filter and customize the catalog
   """
 
-  alias LLMDB.Config
+  alias LLMDB.{Catalog, Config}
 
   require Logger
 
@@ -309,39 +309,17 @@ defmodule LLMDB.Runtime do
          "(allow: #{allow_summary}, deny: #{deny_summary}). " <>
          "Use allow: :all to widen filters or remove deny patterns."}
     else
-      updated_snapshot = %{
-        snapshot
-        | filters: compiled_filters,
-          models_by_key: index_models(filtered_models),
-          models: Enum.group_by(filtered_models, & &1.provider),
-          aliases_by_key: index_aliases(filtered_models)
-      }
+      updated_snapshot = Catalog.with_runtime_view(snapshot, filtered_models, compiled_filters)
 
       {:ok, updated_snapshot}
     end
-  end
-
-  defp index_models(models), do: Map.new(models, &{{&1.provider, &1.id}, &1})
-
-  defp index_aliases(models) do
-    models
-    |> Enum.flat_map(fn model ->
-      provider = model.provider
-      canonical_id = model.id
-      aliases = Map.get(model, :aliases, [])
-
-      Enum.map(aliases, fn alias_name ->
-        {{provider, alias_name}, canonical_id}
-      end)
-    end)
-    |> Map.new()
   end
 
   defp maybe_update_prefer({:ok, snapshot}, nil), do: {:ok, snapshot}
   defp maybe_update_prefer({:ok, snapshot}, []), do: {:ok, snapshot}
 
   defp maybe_update_prefer({:ok, snapshot}, prefer) when is_list(prefer) do
-    {:ok, %{snapshot | prefer: prefer}}
+    {:ok, Catalog.with_prefer(snapshot, prefer)}
   end
 
   defp maybe_update_prefer({:error, _} = error, _prefer), do: error

--- a/lib/llm_db/spec.ex
+++ b/lib/llm_db/spec.ex
@@ -30,12 +30,8 @@ defmodule LLMDB.Spec do
   model ID retains the "us." prefix for API routing purposes.
   """
 
-  alias LLMDB.{Normalize, Store}
+  alias LLMDB.{Catalog, Normalize}
   alias LLMDB.Model
-
-  # Valid Bedrock inference profile region prefixes.
-  # See: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
-  @bedrock_prefixes ~w(us. eu. ap. apac. ca. au. jp. us-gov. global.)
 
   @doc """
   Parses and validates a provider identifier.
@@ -478,16 +474,10 @@ defmodule LLMDB.Spec do
   end
 
   defp verify_provider_exists(provider_atom) do
-    case Store.snapshot() do
-      %{providers_by_id: providers} when is_map(providers) ->
-        if Map.has_key?(providers, provider_atom) do
-          {:ok, provider_atom}
-        else
-          {:error, :unknown_provider}
-        end
-
-      _ ->
-        {:error, :unknown_provider}
+    if Catalog.provider_exists?(provider_atom) do
+      {:ok, provider_atom}
+    else
+      {:error, :unknown_provider}
     end
   end
 
@@ -501,91 +491,13 @@ defmodule LLMDB.Spec do
   For other providers, returns `{model_id, nil}` unchanged.
   """
   @spec strip_prefix(atom(), String.t()) :: {String.t(), String.t() | nil}
-  def strip_prefix(provider, model_id) do
-    lookup_id_and_prefix(provider, model_id)
-  end
-
-  defp lookup_id_and_prefix(provider, model_id) do
-    if provider == :amazon_bedrock do
-      case Enum.find_value(@bedrock_prefixes, fn prefix ->
-             if String.starts_with?(model_id, prefix),
-               do: {prefix, String.replace_prefix(model_id, prefix, "")}
-           end) do
-        nil -> {model_id, nil}
-        {prefix, base_id} -> {base_id, prefix}
-      end
-    else
-      {model_id, nil}
-    end
-  end
+  defdelegate strip_prefix(provider, model_id), to: Catalog
 
   defp resolve_model(provider, model_id) do
-    case Store.snapshot() do
-      nil ->
-        {:error, :not_found}
-
-      snapshot ->
-        {lookup_id, prefix} = lookup_id_and_prefix(provider, model_id)
-
-        key = {provider, lookup_id}
-        canonical_base_id = Map.get(snapshot.aliases_by_key, key, lookup_id)
-        canonical_key = {provider, canonical_base_id}
-
-        case Map.get(snapshot.models_by_key, canonical_key) do
-          nil ->
-            {:error, :not_found}
-
-          model ->
-            returned_id =
-              case prefix do
-                nil -> canonical_base_id
-                p -> p <> canonical_base_id
-              end
-
-            {:ok, {provider, returned_id, model}}
-        end
-    end
+    Catalog.resolve_model(Catalog.snapshot(), provider, model_id)
   end
 
   defp resolve_bare_model(model_id) do
-    case Store.snapshot() do
-      nil ->
-        {:error, :not_found}
-
-      snapshot ->
-        matches = find_all_matches(snapshot, model_id)
-
-        case matches do
-          [] -> {:error, :not_found}
-          [{provider, canonical_id, model}] -> {:ok, {provider, canonical_id, model}}
-          [_ | _] -> {:error, :ambiguous}
-        end
-    end
-  end
-
-  defp find_all_matches(snapshot, model_id) do
-    providers = Map.keys(snapshot.providers_by_id)
-
-    Enum.flat_map(providers, fn provider ->
-      {lookup_id, prefix} = lookup_id_and_prefix(provider, model_id)
-
-      key = {provider, lookup_id}
-      canonical_base_id = Map.get(snapshot.aliases_by_key, key, lookup_id)
-      canonical_key = {provider, canonical_base_id}
-
-      case Map.get(snapshot.models_by_key, canonical_key) do
-        nil ->
-          []
-
-        model ->
-          returned_id =
-            case prefix do
-              nil -> canonical_base_id
-              p -> p <> canonical_base_id
-            end
-
-          [{provider, returned_id, model}]
-      end
-    end)
+    Catalog.resolve_bare(Catalog.snapshot(), model_id)
   end
 end

--- a/lib/llm_db/store.ex
+++ b/lib/llm_db/store.ex
@@ -5,7 +5,7 @@ defmodule LLMDB.Store do
   Uses `:persistent_term` for fast, concurrent reads with atomic updates tracked by monotonic epochs.
   """
 
-  @store_key :llm_db_store
+  alias LLMDB.{Catalog, Model, Provider}
 
   @doc """
   Reads the full store from persistent_term.
@@ -15,9 +15,7 @@ defmodule LLMDB.Store do
   Map with `:snapshot`, `:epoch`, and `:opts` keys, or `nil` if not set.
   """
   @spec get() :: map() | nil
-  def get do
-    :persistent_term.get(@store_key, nil)
-  end
+  defdelegate get(), to: Catalog
 
   @doc """
   Returns the snapshot portion from the store.
@@ -27,12 +25,7 @@ defmodule LLMDB.Store do
   The snapshot map or `nil` if not set.
   """
   @spec snapshot() :: map() | nil
-  def snapshot do
-    case get() do
-      %{snapshot: snapshot} -> snapshot
-      _ -> nil
-    end
-  end
+  defdelegate snapshot(), to: Catalog
 
   @doc """
   Returns the current epoch from the store.
@@ -42,12 +35,7 @@ defmodule LLMDB.Store do
   Non-negative integer representing the current epoch, or `0` if not set.
   """
   @spec epoch() :: non_neg_integer()
-  def epoch do
-    case get() do
-      %{epoch: epoch} -> epoch
-      _ -> 0
-    end
-  end
+  defdelegate epoch(), to: Catalog
 
   @doc """
   Returns the last load options from the store.
@@ -57,12 +45,7 @@ defmodule LLMDB.Store do
   Keyword list of options used in the last load, or `[]` if not set.
   """
   @spec last_opts() :: keyword()
-  def last_opts do
-    case get() do
-      %{opts: opts} -> opts
-      _ -> []
-    end
-  end
+  defdelegate last_opts(), to: Catalog
 
   @doc """
   Atomically swaps the store with new snapshot and options.
@@ -79,12 +62,7 @@ defmodule LLMDB.Store do
   `:ok`
   """
   @spec put!(map(), keyword()) :: :ok
-  def put!(snapshot, opts) do
-    epoch = :erlang.unique_integer([:monotonic, :positive])
-    store = %{snapshot: snapshot, epoch: epoch, opts: opts}
-    :persistent_term.put(@store_key, store)
-    :ok
-  end
+  defdelegate put!(snapshot, opts), to: Catalog
 
   @doc """
   Clears the persistent_term store.
@@ -96,10 +74,7 @@ defmodule LLMDB.Store do
   `:ok`
   """
   @spec clear!() :: :ok
-  def clear! do
-    :persistent_term.erase(@store_key)
-    :ok
-  end
+  defdelegate clear!(), to: Catalog
 
   # Query functions
 
@@ -112,16 +87,11 @@ defmodule LLMDB.Store do
   """
   @spec providers() :: [LLMDB.Provider.t()]
   def providers do
-    case snapshot() do
-      %{providers: providers} when is_list(providers) ->
-        Enum.map(providers, fn
-          %LLMDB.Provider{} = p -> p
-          provider -> LLMDB.Provider.new!(provider)
-        end)
-
-      _ ->
-        []
-    end
+    Catalog.providers()
+    |> Enum.map(fn
+      %Provider{} = provider -> provider
+      provider -> Provider.new!(provider)
+    end)
   end
 
   @doc """
@@ -138,15 +108,10 @@ defmodule LLMDB.Store do
   """
   @spec provider(atom()) :: {:ok, LLMDB.Provider.t()} | {:error, :not_found}
   def provider(provider_id) when is_atom(provider_id) do
-    case snapshot() do
-      %{providers_by_id: providers_by_id} ->
-        case Map.get(providers_by_id, provider_id) do
-          nil -> {:error, :not_found}
-          provider -> {:ok, LLMDB.Provider.new!(provider)}
-        end
-
-      _ ->
-        {:error, :not_found}
+    case Catalog.provider(provider_id) do
+      {:ok, %Provider{} = provider} -> {:ok, provider}
+      {:ok, provider} -> {:ok, Provider.new!(provider)}
+      {:error, :not_found} = error -> error
     end
   end
 
@@ -167,33 +132,11 @@ defmodule LLMDB.Store do
   """
   @spec models(atom()) :: [LLMDB.Model.t()]
   def models(provider_id) when is_atom(provider_id) do
-    case snapshot() do
-      %{models: models_by_provider, providers_by_id: providers_by_id} ->
-        # Get models for the requested provider
-        direct_models = Map.get(models_by_provider, provider_id, [])
-
-        # Find all providers that alias to this provider
-        aliased_models =
-          providers_by_id
-          |> Enum.filter(fn {_id, provider} ->
-            Map.get(provider, :alias_of) == provider_id ||
-              Map.get(provider, "alias_of") == Atom.to_string(provider_id)
-          end)
-          |> Enum.flat_map(fn {aliased_provider_id, _provider} ->
-            Map.get(models_by_provider, aliased_provider_id, [])
-          end)
-
-        # Combine and deduplicate models
-        (direct_models ++ aliased_models)
-        |> Enum.uniq_by(fn m -> Map.get(m, :id) || Map.get(m, "id") end)
-        |> Enum.map(fn
-          %LLMDB.Model{} = m -> m
-          model -> LLMDB.Model.new!(model)
-        end)
-
-      _ ->
-        []
-    end
+    Catalog.models(provider_id)
+    |> Enum.map(fn
+      %Model{} = model -> model
+      model -> Model.new!(model)
+    end)
   end
 
   @doc """
@@ -215,86 +158,10 @@ defmodule LLMDB.Store do
   """
   @spec model(atom(), String.t()) :: {:ok, LLMDB.Model.t()} | {:error, :not_found}
   def model(provider_id, model_id) when is_atom(provider_id) and is_binary(model_id) do
-    case snapshot() do
-      %{
-        models_by_key: models_by_key,
-        aliases_by_key: aliases_by_key,
-        providers_by_id: providers_by_id
-      } ->
-        # Build list of provider IDs to search: [requested_provider | aliased_providers]
-        providers_to_search =
-          [provider_id] ++
-            (providers_by_id
-             |> Enum.filter(fn {_id, provider} ->
-               Map.get(provider, :alias_of) == provider_id ||
-                 Map.get(provider, "alias_of") == Atom.to_string(provider_id)
-             end)
-             |> Enum.map(fn {id, _} -> id end))
-
-        # Strip inference profile prefix for Bedrock lookups
-        {lookup_id, _prefix} = LLMDB.Spec.strip_prefix(provider_id, model_id)
-
-        # Try each provider in the search list
-        result =
-          Enum.find_value(providers_to_search, fn search_provider_id ->
-            key = {search_provider_id, lookup_id}
-
-            # Try direct lookup first
-            case Map.get(models_by_key, key) do
-              nil ->
-                # Try alias resolution
-                case Map.get(aliases_by_key, key) do
-                  nil ->
-                    nil
-
-                  canonical_id ->
-                    canonical_key = {search_provider_id, canonical_id}
-                    Map.get(models_by_key, canonical_key)
-                end
-
-              model ->
-                model
-            end
-          end)
-
-        case result do
-          nil ->
-            {:error, :not_found}
-
-          %LLMDB.Model{provider: model_provider} = m ->
-            # If model's provider is aliased, normalize it to the requested provider
-            provider_info = Map.get(providers_by_id, model_provider)
-
-            normalized_provider =
-              cond do
-                is_nil(provider_info) -> model_provider
-                Map.get(provider_info, :alias_of) == provider_id -> provider_id
-                Map.get(provider_info, "alias_of") == Atom.to_string(provider_id) -> provider_id
-                true -> model_provider
-              end
-
-            {:ok, %{m | provider: normalized_provider}}
-
-          model ->
-            # Convert to struct first
-            {:ok, model_struct} = LLMDB.Model.new(model)
-
-            # Normalize provider
-            provider_info = Map.get(providers_by_id, model_struct.provider)
-
-            normalized_provider =
-              cond do
-                is_nil(provider_info) -> model_struct.provider
-                Map.get(provider_info, :alias_of) == provider_id -> provider_id
-                Map.get(provider_info, "alias_of") == Atom.to_string(provider_id) -> provider_id
-                true -> model_struct.provider
-              end
-
-            {:ok, %{model_struct | provider: normalized_provider}}
-        end
-
-      _ ->
-        {:error, :not_found}
+    case Catalog.model(provider_id, model_id) do
+      {:ok, %Model{} = model} -> {:ok, model}
+      {:ok, model} -> Model.new(model)
+      {:error, :not_found} = error -> error
     end
   end
 end

--- a/test/llm_db/catalog_test.exs
+++ b/test/llm_db/catalog_test.exs
@@ -80,6 +80,37 @@ defmodule LLMDB.CatalogTest do
     assert model.provider == :google_vertex
   end
 
+  test "bare aliases retain precedence over colliding canonical IDs" do
+    provider = Provider.new!(%{id: :openrouter, name: "OpenRouter"})
+
+    alias_target =
+      Model.new!(%{
+        id: "canonical-target",
+        provider: :openrouter,
+        aliases: ["colliding-id"]
+      })
+
+    colliding_model = Model.new!(%{id: "colliding-id", provider: :openrouter})
+    catalog = build_catalog([provider], [alias_target, colliding_model])
+
+    assert {:ok, {:openrouter, "canonical-target", model}} =
+             Catalog.resolve_bare(catalog, "colliding-id")
+
+    assert model.id == "canonical-target"
+  end
+
+  test "Bedrock-prefixed bare IDs retain stripped-prefix precedence" do
+    provider = Provider.new!(%{id: :amazon_bedrock, name: "Amazon Bedrock"})
+    base = Model.new!(%{id: "anthropic.model", provider: :amazon_bedrock})
+    regional = Model.new!(%{id: "us.anthropic.model", provider: :amazon_bedrock})
+    catalog = build_catalog([provider], [base, regional])
+
+    assert {:ok, {:amazon_bedrock, "us.anthropic.model", model}} =
+             Catalog.resolve_bare(catalog, "us.anthropic.model")
+
+    assert model.id == "anthropic.model"
+  end
+
   defp catalog_fixture do
     providers = [
       Provider.new!(%{id: :google_vertex, name: "Google Vertex"}),
@@ -94,7 +125,11 @@ defmodule LLMDB.CatalogTest do
         aliases: ["claude-alias"]
       })
 
-    Catalog.build(providers, [model], [model],
+    build_catalog(providers, [model])
+  end
+
+  defp build_catalog(providers, models) do
+    Catalog.build(providers, models, models,
       filters: %{allow: :all, deny: %{}},
       prefer: [:google_vertex],
       source_generated_at: "2026-07-16T00:00:00Z",

--- a/test/llm_db/catalog_test.exs
+++ b/test/llm_db/catalog_test.exs
@@ -1,0 +1,106 @@
+defmodule LLMDB.CatalogTest do
+  use ExUnit.Case, async: false
+
+  alias LLMDB.{Catalog, Model, Provider, Spec, Store}
+
+  setup do
+    Catalog.clear!()
+    on_exit(&Catalog.clear!/0)
+    :ok
+  end
+
+  test "builds the canonical indexes and retains snapshot identity" do
+    catalog = catalog_fixture()
+
+    assert catalog.providers_by_id.google_vertex.name == "Google Vertex"
+
+    assert catalog.models_by_key[{:google_vertex_anthropic, "claude-model"}].name ==
+             "Claude Model"
+
+    assert catalog.aliases_by_key[{:google_vertex_anthropic, "claude-alias"}] ==
+             "claude-model"
+
+    assert catalog.meta.source_snapshot_id == "snapshot-123"
+    assert catalog.meta.digest == "semantic-digest"
+    assert catalog.meta.source_generated_at == "2026-07-16T00:00:00Z"
+  end
+
+  test "provider and model aliases share one map-based resolution path" do
+    catalog = catalog_fixture()
+
+    # Resolution continues from immutable indexes even if the presentation list
+    # is absent, proving direct lookup does not scan providers.
+    indexed_only = Map.put(catalog, :providers, [])
+
+    assert {:ok, {:google_vertex, "claude-model", model}} =
+             Catalog.resolve_model(indexed_only, :google_vertex, "claude-alias")
+
+    assert model.id == "claude-model"
+    assert model.provider == :google_vertex
+  end
+
+  test "Store and Spec compatibility facades resolve through Catalog" do
+    catalog = catalog_fixture()
+    Catalog.put!(catalog, source: :test)
+
+    assert {:ok, store_model} = Store.model(:google_vertex, "claude-alias")
+
+    assert {:ok, {:google_vertex, "claude-model", spec_model}} =
+             Spec.resolve({:google_vertex, "claude-alias"})
+
+    assert store_model == spec_model
+    assert Catalog.last_opts() == [source: :test]
+  end
+
+  test "runtime views rebuild every model resolution index" do
+    catalog = catalog_fixture()
+    filtered = Catalog.with_runtime_view(catalog, [], %{allow: %{}, deny: %{}})
+
+    assert {:error, :not_found} =
+             Catalog.resolve_model(filtered, :google_vertex, "claude-alias")
+
+    assert {:error, :not_found} = Catalog.resolve_bare(filtered, "claude-alias")
+  end
+
+  test "legacy string alias_of values resolve without creating provider atoms" do
+    catalog =
+      catalog_fixture()
+      |> update_in([:providers], fn providers ->
+        Enum.map(providers, fn provider ->
+          if provider.id == :google_vertex_anthropic do
+            provider |> Map.from_struct() |> Map.put(:alias_of, "google_vertex")
+          else
+            provider
+          end
+        end)
+      end)
+      |> Map.delete(:__llm_db_provider_lookup_ids__)
+
+    assert {:ok, model} = Catalog.model(catalog, :google_vertex, "claude-alias")
+    assert model.provider == :google_vertex
+  end
+
+  defp catalog_fixture do
+    providers = [
+      Provider.new!(%{id: :google_vertex, name: "Google Vertex"}),
+      Provider.new!(%{id: :google_vertex_anthropic, name: "Vertex Anthropic"})
+    ]
+
+    model =
+      Model.new!(%{
+        id: "claude-model",
+        provider: :google_vertex_anthropic,
+        name: "Claude Model",
+        aliases: ["claude-alias"]
+      })
+
+    Catalog.build(providers, [model], [model],
+      filters: %{allow: :all, deny: %{}},
+      prefer: [:google_vertex],
+      source_generated_at: "2026-07-16T00:00:00Z",
+      source_snapshot_id: "snapshot-123",
+      loaded_at: "2026-07-16T00:01:00Z",
+      digest: "semantic-digest"
+    )
+  end
+end


### PR DESCRIPTION
Closes #245

## Summary

- Introduce one internal Catalog boundary for persistent storage, indexing, aliases, and canonical resolution.
- Keep Store as a backward-compatible struct-converting facade.
- Precompute provider-alias and bare-model resolution indexes.
- Remove duplicated runtime index construction and break the Model, Spec, Store dependency cycle.
- Add cold, reload, and warm-lookup benchmark coverage.

## Compatibility

Public maps, structs, Store calls, aliases, Bedrock prefixes, filters, and manual legacy snapshots retain their existing shapes and behavior.

## Validation

- Full mix test suite passed.
- mix quality passed.
- mix xref graph --format cycles reports no cycles.
- Legacy string alias_of regression coverage added.

## Stack

Depends on #243. Merge after the safe snapshot decoding PR.