### PR TITLE
refactor: share pricing validation schema

### DIFF
--- a/guides/runtime-and-maintainer-boundaries.md
+++ b/guides/runtime-and-maintainer-boundaries.md
@@ -21,7 +21,7 @@ Runtime implementation modules are internal even though they remain shipped:
 | Modules | Ownership |
 | --- | --- |
 | LLMDB.Catalog, LLMDB.Loader, LLMDB.Packaged, LLMDB.Query, LLMDB.Runtime | Lazy loading, indexing, storage, and query execution |
-| LLMDB.Config, LLMDB.Merge, LLMDB.Normalize, LLMDB.Pricing | Shared runtime normalization, filtering, and pricing support |
+| LLMDB.Config, LLMDB.Merge, LLMDB.Normalize, LLMDB.Pricing, LLMDB.Schema.Pricing | Shared runtime normalization, filtering, and pricing support |
 | LLMDB.Generated.ProviderRegistry, LLMDB.Generated.ValidModalities | Generated bounded decode registries |
 | `LLMDB.Snapshot.ReleaseStore` | Shared remote snapshot/history transport used by configured runtime readers and maintainer tasks |
 

--- a/lib/llm_db/model.ex
+++ b/lib/llm_db/model.ex
@@ -78,49 +78,7 @@ defmodule LLMDB.Model do
                  output_video: Zoi.number() |> Zoi.nullish()
                })
 
-  @pricing_component_schema Zoi.object(%{
-                              id: Zoi.string(),
-                              kind:
-                                Zoi.enum([
-                                  "token",
-                                  "tool",
-                                  "image",
-                                  "storage",
-                                  "request",
-                                  "other"
-                                ])
-                                |> Zoi.nullish(),
-                              unit:
-                                Zoi.enum([
-                                  "token",
-                                  "call",
-                                  "query",
-                                  "session",
-                                  "gb_day",
-                                  "image",
-                                  "source",
-                                  "other"
-                                ])
-                                |> Zoi.nullish(),
-                              per: Zoi.integer() |> Zoi.min(1) |> Zoi.nullish(),
-                              rate: Zoi.number() |> Zoi.nullish(),
-                              meter: Zoi.string() |> Zoi.nullish(),
-                              tool: Zoi.union([Zoi.atom(), Zoi.string()]) |> Zoi.nullish(),
-                              size_class: Zoi.string() |> Zoi.nullish(),
-                              multiplier: Zoi.number() |> Zoi.nullish(),
-                              derives_from: Zoi.string() |> Zoi.nullish(),
-                              applies_to: Zoi.array(Zoi.string()) |> Zoi.nullish(),
-                              applies_when: Zoi.map() |> Zoi.nullish(),
-                              excludes_when: Zoi.map() |> Zoi.nullish(),
-                              mode: Zoi.string() |> Zoi.nullish(),
-                              charge_scope: Zoi.string() |> Zoi.nullish(),
-                              source: Zoi.string() |> Zoi.nullish(),
-                              notes: Zoi.string() |> Zoi.nullish()
-                            })
-
-  @pricing_schema Zoi.object(%{
-                    currency: Zoi.string() |> Zoi.nullish(),
-                    components: Zoi.array(@pricing_component_schema) |> Zoi.default([]),
+  @pricing_schema LLMDB.Schema.Pricing.schema(%{
                     merge: Zoi.enum(["replace", "merge_by_id"]) |> Zoi.default("merge_by_id")
                   })
 

--- a/lib/llm_db/provider.ex
+++ b/lib/llm_db/provider.ex
@@ -44,50 +44,7 @@ defmodule LLMDB.Provider do
                          doc: Zoi.string() |> Zoi.nullish()
                        })
 
-  @pricing_component_schema Zoi.object(%{
-                              id: Zoi.string(),
-                              kind:
-                                Zoi.enum([
-                                  "token",
-                                  "tool",
-                                  "image",
-                                  "storage",
-                                  "request",
-                                  "other"
-                                ])
-                                |> Zoi.nullish(),
-                              unit:
-                                Zoi.enum([
-                                  "token",
-                                  "call",
-                                  "query",
-                                  "session",
-                                  "gb_day",
-                                  "image",
-                                  "source",
-                                  "other"
-                                ])
-                                |> Zoi.nullish(),
-                              per: Zoi.integer() |> Zoi.min(1) |> Zoi.nullish(),
-                              rate: Zoi.number() |> Zoi.nullish(),
-                              meter: Zoi.string() |> Zoi.nullish(),
-                              tool: Zoi.union([Zoi.atom(), Zoi.string()]) |> Zoi.nullish(),
-                              size_class: Zoi.string() |> Zoi.nullish(),
-                              multiplier: Zoi.number() |> Zoi.nullish(),
-                              derives_from: Zoi.string() |> Zoi.nullish(),
-                              applies_to: Zoi.array(Zoi.string()) |> Zoi.nullish(),
-                              applies_when: Zoi.map() |> Zoi.nullish(),
-                              excludes_when: Zoi.map() |> Zoi.nullish(),
-                              mode: Zoi.string() |> Zoi.nullish(),
-                              charge_scope: Zoi.string() |> Zoi.nullish(),
-                              source: Zoi.string() |> Zoi.nullish(),
-                              notes: Zoi.string() |> Zoi.nullish()
-                            })
-
-  @pricing_defaults_schema Zoi.object(%{
-                             currency: Zoi.string() |> Zoi.nullish(),
-                             components: Zoi.array(@pricing_component_schema) |> Zoi.default([])
-                           })
+  @pricing_defaults_schema LLMDB.Schema.Pricing.schema()
 
   @runtime_auth_header_schema Zoi.object(%{
                                 name: Zoi.string(),

--- a/lib/llm_db/schema/pricing.ex
+++ b/lib/llm_db/schema/pricing.ex
@@ -1,0 +1,55 @@
+defmodule LLMDB.Schema.Pricing do
+  @moduledoc false
+
+  @component Zoi.object(%{
+               id: Zoi.string(),
+               kind:
+                 Zoi.enum([
+                   "token",
+                   "tool",
+                   "image",
+                   "storage",
+                   "request",
+                   "other"
+                 ])
+                 |> Zoi.nullish(),
+               unit:
+                 Zoi.enum([
+                   "token",
+                   "call",
+                   "query",
+                   "session",
+                   "gb_day",
+                   "image",
+                   "source",
+                   "other"
+                 ])
+                 |> Zoi.nullish(),
+               per: Zoi.integer() |> Zoi.min(1) |> Zoi.nullish(),
+               rate: Zoi.number() |> Zoi.nullish(),
+               meter: Zoi.string() |> Zoi.nullish(),
+               tool: Zoi.union([Zoi.atom(), Zoi.string()]) |> Zoi.nullish(),
+               size_class: Zoi.string() |> Zoi.nullish(),
+               multiplier: Zoi.number() |> Zoi.nullish(),
+               derives_from: Zoi.string() |> Zoi.nullish(),
+               applies_to: Zoi.array(Zoi.string()) |> Zoi.nullish(),
+               applies_when: Zoi.map() |> Zoi.nullish(),
+               excludes_when: Zoi.map() |> Zoi.nullish(),
+               mode: Zoi.string() |> Zoi.nullish(),
+               charge_scope: Zoi.string() |> Zoi.nullish(),
+               source: Zoi.string() |> Zoi.nullish(),
+               notes: Zoi.string() |> Zoi.nullish()
+             })
+
+  @base_fields %{
+    currency: Zoi.string() |> Zoi.nullish(),
+    components: Zoi.array(@component) |> Zoi.default([])
+  }
+
+  @doc false
+  def schema(extra_fields \\ %{}) when is_map(extra_fields) do
+    @base_fields
+    |> Map.merge(extra_fields)
+    |> Zoi.object()
+  end
+end

--- a/test/llm_db/schema/pricing_test.exs
+++ b/test/llm_db/schema/pricing_test.exs
@@ -1,0 +1,63 @@
+defmodule LLMDB.Schema.PricingTest do
+  use ExUnit.Case, async: true
+
+  alias LLMDB.{Model, Provider}
+
+  @pricing %{
+    currency: "USD",
+    components: [
+      %{
+        id: "token.input.long_context",
+        kind: "token",
+        unit: "token",
+        per: 1_000_000,
+        rate: 10.0,
+        meter: "input_tokens",
+        tool: :web_search,
+        size_class: "long",
+        multiplier: 2.0,
+        derives_from: "token.input",
+        applies_to: ["token.*"],
+        applies_when: %{input_tokens: %{gt: 272_000}},
+        excludes_when: %{api: "batch"},
+        mode: "standard",
+        charge_scope: "full_request",
+        source: "provider_docs",
+        notes: "Long-context tier"
+      }
+    ]
+  }
+
+  test "model and provider parents parse shared pricing fields identically" do
+    model = Model.new!(%{id: "model", provider: :provider, pricing: @pricing})
+    provider = Provider.new!(%{id: :provider, pricing_defaults: @pricing})
+
+    assert Map.drop(model.pricing, [:merge]) == provider.pricing_defaults
+
+    assert model.pricing.merge == "merge_by_id"
+  end
+
+  test "model-specific merge behavior remains available" do
+    model =
+      Model.new!(%{
+        id: "model",
+        provider: :provider,
+        pricing: Map.put(@pricing, :merge, "replace")
+      })
+
+    assert model.pricing.merge == "replace"
+  end
+
+  test "both parents reject the same invalid component payloads" do
+    invalid = put_in(@pricing, [:components, Access.at(0), :per], 0)
+
+    assert {:error, model_error} =
+             Model.new(%{id: "model", provider: :provider, pricing: invalid})
+
+    assert {:error, provider_error} =
+             Provider.new(%{id: :provider, pricing_defaults: invalid})
+
+    assert inspect(model_error) =~ "per"
+    assert inspect(provider_error) =~ "per"
+  end
+end


### PR DESCRIPTION
## Summary

- extract the duplicated pricing envelope and component validation into `LLMDB.Schema.Pricing`
- preserve the model-only merge strategy and provider/model parsed output shapes
- add parity coverage for valid, defaulted, overridden, and invalid pricing payloads
- classify the new internal schema in the runtime boundary inventory

## Validation

- `mix test test/llm_db/schema/pricing_test.exs test/llm_db/schema/model_test.exs test/llm_db/schema/provider_test.exs`
- `mix test test/llm_db/tooling_boundary_test.exs test/llm_db/schema/pricing_test.exs`
- `mix quality`

Closes #250