### PR TITLE
refactor: move provider runtime policy into data

### DIFF
--- a/lib/llm_db/engine.ex
+++ b/lib/llm_db/engine.ex
@@ -91,6 +91,7 @@ defmodule LLMDB.Engine do
          {:ok, merged_validated} <- validate_merged(merged),
          {:ok, snapshot} <- finalize(merged_validated),
          :ok <- validate_runtime_contract(snapshot),
+         snapshot <- publish_runtime_contract(snapshot),
          :ok <- ensure_viable(snapshot) do
       {:ok, snapshot}
     end
@@ -231,7 +232,7 @@ defmodule LLMDB.Engine do
       merged.models
       |> Enrich.enrich_models()
 
-    {providers, models} = RuntimeContract.enrich(merged.providers, models)
+    {providers, models} = RuntimeContract.enrich_for_validation(merged.providers, models)
     nested_providers = build_nested_providers(providers, models)
 
     snapshot = %{
@@ -269,6 +270,15 @@ defmodule LLMDB.Engine do
       |> Enum.flat_map(fn provider -> Map.values(provider.models) end)
 
     Validate.validate_runtime_contract(provider_list, model_list)
+  end
+
+  defp publish_runtime_contract(%{providers: providers} = snapshot) do
+    published =
+      Map.new(providers, fn {provider_id, provider} ->
+        {provider_id, RuntimeContract.publish_provider(provider)}
+      end)
+
+    %{snapshot | providers: published}
   end
 
   @doc """

--- a/lib/llm_db/enrich/runtime_contract.ex
+++ b/lib/llm_db/enrich/runtime_contract.ex
@@ -4,6 +4,8 @@ defmodule LLMDB.Enrich.RuntimeContract do
   alias LLMDB.ExecutionContract
 
   defdelegate enrich(providers, models), to: ExecutionContract
+  defdelegate enrich_for_validation(providers, models), to: ExecutionContract
   defdelegate enrich_provider(provider), to: ExecutionContract
   defdelegate enrich_model(model, provider), to: ExecutionContract
+  defdelegate publish_provider(provider), to: ExecutionContract
 end

--- a/lib/llm_db/execution_contract.ex
+++ b/lib/llm_db/execution_contract.ex
@@ -68,6 +68,15 @@ defmodule LLMDB.ExecutionContract do
 
   @spec enrich([Provider.t()], [Model.t()]) :: {[Provider.t()], [Model.t()]}
   def enrich(providers, models) when is_list(providers) and is_list(models) do
+    {enriched_providers, enriched_models} = enrich_for_validation(providers, models)
+    published_providers = Enum.map(enriched_providers, &publish_provider/1)
+
+    {published_providers, enriched_models}
+  end
+
+  @doc false
+  @spec enrich_for_validation([Provider.t()], [Model.t()]) :: {[Provider.t()], [Model.t()]}
+  def enrich_for_validation(providers, models) when is_list(providers) and is_list(models) do
     enriched_providers = Enum.map(providers, &enrich_provider/1)
     provider_lookup = Map.new(enriched_providers, &{&1.id, &1})
 
@@ -76,10 +85,16 @@ defmodule LLMDB.ExecutionContract do
         enrich_model(model, Map.get(provider_lookup, model.provider))
       end)
 
-    published_providers = Enum.map(enriched_providers, &strip_execution_policy/1)
-
-    {published_providers, enriched_models}
+    {enriched_providers, enriched_models}
   end
+
+  @doc false
+  @spec publish_provider(Provider.t()) :: Provider.t()
+  def publish_provider(%Provider{runtime: runtime} = provider) when is_map(runtime) do
+    %{provider | runtime: Map.delete(runtime, :execution)}
+  end
+
+  def publish_provider(provider), do: provider
 
   @spec enrich_provider(Provider.t()) :: Provider.t()
   def enrich_provider(%Provider{} = provider) do
@@ -178,12 +193,6 @@ defmodule LLMDB.ExecutionContract do
     |> Map.put(:env, env)
     |> Map.put_new(:headers, [])
   end
-
-  defp strip_execution_policy(%Provider{runtime: runtime} = provider) when is_map(runtime) do
-    %{provider | runtime: Map.delete(runtime, :execution)}
-  end
-
-  defp strip_execution_policy(provider), do: provider
 
   defp derive_execution(
          %Model{} = model,

--- a/lib/llm_db/execution_contract.ex
+++ b/lib/llm_db/execution_contract.ex
@@ -15,144 +15,11 @@ defmodule LLMDB.ExecutionContract do
 
   alias LLMDB.{Merge, Model, Provider}
 
-  @provider_runtime_defaults %{
-    openai: %{
-      base_url: "https://api.openai.com/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://platform.openai.com/docs"
-    },
-    anthropic: %{
-      base_url: "https://api.anthropic.com",
-      auth: %{type: "x_api_key", header_name: "x-api-key"},
-      doc_url: "https://docs.anthropic.com"
-    },
-    google: %{
-      base_url: "https://generativelanguage.googleapis.com/v1beta",
-      auth: %{type: "header", header_name: "x-goog-api-key"},
-      doc_url: "https://ai.google.dev/docs"
-    },
-    openrouter: %{
-      base_url: "https://openrouter.ai/api/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://openrouter.ai/docs"
-    },
-    groq: %{
-      base_url: "https://api.groq.com/openai/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://groq.com/docs"
-    },
-    xai: %{
-      base_url: "https://api.x.ai/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.x.ai"
-    },
-    zenmux: %{
-      base_url: "https://zenmux.ai/api/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.zenmux.ai"
-    },
-    elevenlabs: %{
-      base_url: "https://api.elevenlabs.io",
-      auth: %{type: "header", header_name: "xi-api-key"},
-      doc_url: "https://elevenlabs.io/docs/api-reference/introduction"
-    },
-    cohere: %{
-      base_url: "https://api.cohere.com",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.cohere.com/docs/models"
-    },
-    mistral: %{
-      base_url: "https://api.mistral.ai/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.mistral.ai/getting-started/models/"
-    },
-    togetherai: %{
-      base_url: "https://api.together.xyz/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.together.ai/docs/serverless-models"
-    },
-    github_models: %{
-      base_url: "https://models.github.ai/inference",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.github.com/en/github-models"
-    },
-    perplexity: %{
-      base_url: "https://api.perplexity.ai",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.perplexity.ai"
-    },
-    cloudflare_workers_ai: %{
-      base_url: "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1",
-      auth: %{type: "bearer", env: ["CLOUDFLARE_API_KEY"]},
-      config_schema: [
-        %{
-          name: "account_id",
-          type: "string",
-          required: true,
-          doc: "Cloudflare account ID used in the Workers AI base URL template."
-        }
-      ],
-      doc_url: "https://developers.cloudflare.com/workers-ai/models/"
-    },
-    fireworks_ai: %{
-      base_url: "https://api.fireworks.ai/inference/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://fireworks.ai/docs/"
-    },
-    minimax: %{
-      base_url: "https://api.minimax.io/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://platform.minimax.io/docs/guides/quickstart"
-    },
-    friendli: %{
-      base_url: "https://api.friendli.ai/serverless/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://friendli.ai/docs/guides/serverless_endpoints/introduction"
-    },
-    ollama_cloud: %{
-      base_url: "https://ollama.com/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.ollama.com/cloud"
-    },
-    deepseek: %{
-      base_url: "https://api.deepseek.com",
-      auth: %{type: "bearer"},
-      doc_url: "https://api-docs.deepseek.com"
-    },
-    alibaba: %{
-      base_url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://www.alibabacloud.com/help/en/model-studio/models"
-    },
-    venice: %{
-      base_url: "https://api.venice.ai/api/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.venice.ai"
-    },
-    cerebras: %{
-      base_url: "https://api.cerebras.ai/v1",
-      auth: %{type: "bearer"},
-      doc_url: "https://cerebras.ai/docs"
-    },
-    zai: %{
-      base_url: "https://api.z.ai/api/paas/v4",
-      auth: %{type: "bearer"},
-      doc_url: "https://docs.z.ai/guides/overview/pricing"
-    }
-  }
-
-  @openai_compatible_providers Map.keys(@provider_runtime_defaults)
-                               |> Enum.filter(
-                                 &(&1 not in [:anthropic, :google, :cohere, :elevenlabs])
-                               )
-                               |> MapSet.new()
-
   @google_generation_methods MapSet.new([
                                "generateAnswer",
                                "generateContent",
                                "batchGenerateContent"
                              ])
-  @google_embedding_methods MapSet.new(["embedContent", "asyncBatchEmbedContent"])
   @cohere_embedding_methods MapSet.new(["embed", "embedText", "embedTexts"])
   @cohere_rerank_methods MapSet.new(["rerank"])
 
@@ -209,7 +76,9 @@ defmodule LLMDB.ExecutionContract do
         enrich_model(model, Map.get(provider_lookup, model.provider))
       end)
 
-    {enriched_providers, enriched_models}
+    published_providers = Enum.map(enriched_providers, &strip_execution_policy/1)
+
+    {published_providers, enriched_models}
   end
 
   @spec enrich_provider(Provider.t()) :: Provider.t()
@@ -271,26 +140,12 @@ defmodule LLMDB.ExecutionContract do
   @spec executable?(map() | nil) :: boolean()
   def executable?(execution), do: executable_execution?(execution)
 
-  defp resolved_runtime(%Provider{id: provider_id} = provider) do
-    defaults = Map.get(@provider_runtime_defaults, provider_id)
-    existing = provider.runtime
-
-    cond do
-      is_map(existing) and runtime_complete?(existing) ->
+  defp resolved_runtime(%Provider{} = provider) do
+    case provider.runtime do
+      existing when is_map(existing) ->
         normalize_runtime(existing, provider)
 
-      is_map(defaults) ->
-        defaults
-        |> normalize_runtime(provider)
-        |> merge_runtime(existing, provider)
-        |> maybe_runtime(existing)
-
-      is_map(existing) ->
-        existing
-        |> normalize_runtime(provider)
-        |> maybe_runtime(existing)
-
-      true ->
+      _other ->
         nil
     end
   end
@@ -307,7 +162,8 @@ defmodule LLMDB.ExecutionContract do
       default_headers: Map.get(runtime, :default_headers, %{}),
       default_query: Map.get(runtime, :default_query, %{}),
       config_schema: Map.get(runtime, :config_schema) || provider.config_schema,
-      doc_url: Map.get(runtime, :doc_url) || provider.doc
+      doc_url: Map.get(runtime, :doc_url) || provider.doc,
+      execution: Map.get(runtime, :execution)
     }
   end
 
@@ -323,153 +179,73 @@ defmodule LLMDB.ExecutionContract do
     |> Map.put_new(:headers, [])
   end
 
-  defp merge_runtime(defaults, existing, provider) when is_map(existing) do
-    auth = defaults.auth |> Map.merge(Map.get(existing, :auth, %{})) |> normalize_auth(provider)
-
-    %{
-      base_url: Map.get(existing, :base_url) || defaults.base_url || provider.base_url,
-      auth: auth,
-      default_headers:
-        Map.merge(defaults.default_headers || %{}, Map.get(existing, :default_headers, %{})),
-      default_query:
-        Map.merge(defaults.default_query || %{}, Map.get(existing, :default_query, %{})),
-      config_schema:
-        Map.get(existing, :config_schema) || defaults.config_schema || provider.config_schema,
-      doc_url: Map.get(existing, :doc_url) || defaults.doc_url || provider.doc
-    }
+  defp strip_execution_policy(%Provider{runtime: runtime} = provider) when is_map(runtime) do
+    %{provider | runtime: Map.delete(runtime, :execution)}
   end
 
-  defp merge_runtime(defaults, _existing, _provider), do: defaults
-
-  defp maybe_runtime(runtime, existing) do
-    cond do
-      runtime_complete?(runtime) ->
-        runtime
-
-      is_map(existing) ->
-        runtime
-
-      true ->
-        nil
-    end
-  end
-
-  defp runtime_complete?(%{base_url: base_url, auth: auth})
-       when is_binary(base_url) and is_map(auth) do
-    valid_auth?(auth)
-  end
-
-  defp runtime_complete?(_runtime), do: false
-
-  defp valid_auth?(%{type: type, env: env}) when type in ["bearer", "x_api_key"],
-    do: is_list(env) and env != []
-
-  defp valid_auth?(%{type: "header", env: env, header_name: header_name}),
-    do: is_binary(header_name) and is_list(env) and env != []
-
-  defp valid_auth?(%{type: "query", env: env, query_name: query_name}),
-    do: is_binary(query_name) and is_list(env) and env != []
-
-  defp valid_auth?(%{type: "multi_header", headers: headers}),
-    do: is_list(headers) and headers != []
-
-  defp valid_auth?(_auth), do: false
+  defp strip_execution_policy(provider), do: provider
 
   defp derive_execution(
          %Model{} = model,
-         %Provider{id: provider_id, catalog_only: false}
+         %Provider{catalog_only: false} = provider
        ) do
     []
-    |> maybe_put_entry(:text, text_entry(model, provider_id))
-    |> maybe_put_entry(:object, object_entry(model, provider_id))
-    |> maybe_put_entry(:embed, embed_entry(model, provider_id))
-    |> maybe_put_entry(:image, image_entry(model, provider_id))
-    |> maybe_put_entry(:transcription, transcription_entry(model, provider_id))
-    |> maybe_put_entry(:speech, speech_entry(model, provider_id))
-    |> maybe_put_entry(:realtime, realtime_entry(model, provider_id))
+    |> maybe_put_entry(:text, text_entry(model, provider))
+    |> maybe_put_entry(:object, object_entry(model, provider))
+    |> maybe_put_entry(:embed, media_entry(model, provider, :embed, &embedding_model?/1))
+    |> maybe_put_entry(:image, media_entry(model, provider, :image, &image_generation_model?/1))
+    |> maybe_put_entry(
+      :transcription,
+      media_entry(model, provider, :transcription, &dedicated_transcription_model?/1)
+    )
+    |> maybe_put_entry(:speech, media_entry(model, provider, :speech, &dedicated_speech_model?/1))
+    |> maybe_put_entry(:realtime, realtime_entry(model, provider))
     |> Map.new()
     |> nil_if_empty()
   end
 
   defp derive_execution(_model, _provider), do: nil
 
-  defp text_entry(model, provider_id) do
-    if text_object_capable?(model, provider_id) do
-      execution_entry(model, provider_id, text_object_family(model, provider_id))
+  defp text_entry(model, provider) do
+    if text_object_capable?(model, provider) do
+      execution_entry(model, provider, text_object_family(model, provider, :text))
     end
   end
 
-  defp object_entry(model, provider_id) do
-    if object_capable?(model, provider_id) do
-      execution_entry(model, provider_id, text_object_family(model, provider_id))
+  defp object_entry(model, provider) do
+    if object_capable?(model, provider) do
+      execution_entry(model, provider, text_object_family(model, provider, :object))
     end
   end
 
-  defp embed_entry(model, provider_id) do
-    cond do
-      provider_id == :google and google_embedding_model?(model) ->
-        nil
+  defp media_entry(model, provider, operation, classifier) do
+    family = provider_family(provider, operation)
 
-      provider_id == :cohere and cohere_embedding_or_rerank_model?(model) ->
-        nil
-
-      provider_id in @openai_compatible_providers and embedding_model?(model) ->
-        execution_entry(model, provider_id, "openai_embeddings")
-
-      true ->
-        nil
+    if is_binary(family) and classifier.(model) do
+      execution_entry(model, provider, family)
     end
   end
 
-  defp image_entry(model, provider_id) do
-    if provider_id in @openai_compatible_providers and image_generation_model?(model) do
-      execution_entry(model, provider_id, "openai_images")
-    end
-  end
+  defp realtime_entry(model, provider) do
+    family = provider_family(provider, :realtime)
 
-  defp transcription_entry(model, provider_id) do
-    cond do
-      provider_id == :elevenlabs and elevenlabs_transcription_model?(model) ->
-        execution_entry(model, provider_id, "elevenlabs_transcription")
-
-      provider_id in @openai_compatible_providers and dedicated_transcription_model?(model) ->
-        execution_entry(model, provider_id, "openai_transcription")
-
-      true ->
-        nil
-    end
-  end
-
-  defp speech_entry(model, provider_id) do
-    cond do
-      provider_id == :elevenlabs and elevenlabs_speech_model?(model) ->
-        execution_entry(model, provider_id, "elevenlabs_speech")
-
-      provider_id == :openai and openai_speech_model?(model) ->
-        execution_entry(model, provider_id, "openai_speech")
-
-      true ->
-        nil
-    end
-  end
-
-  defp realtime_entry(model, provider_id) do
-    if provider_id == :openai and realtime_model?(model) do
-      execution_entry(model, provider_id, "openai_realtime")
+    if is_binary(family) and realtime_model?(model) do
+      execution_entry(model, provider, family)
       |> Map.put(:transport, "websocket")
     end
   end
 
-  defp text_object_capable?(model, provider_id) do
-    family = text_object_family(model, provider_id)
+  defp text_object_capable?(model, provider) do
+    family = text_object_family(model, provider, :text)
     is_binary(family)
   end
 
-  defp object_capable?(model, :anthropic) do
-    text_object_capable?(model, :anthropic) and json_schema_capable?(model)
-  end
+  defp object_capable?(model, provider) do
+    family = text_object_family(model, provider, :object)
 
-  defp object_capable?(model, provider_id), do: text_object_capable?(model, provider_id)
+    is_binary(family) and
+      (family != "anthropic_messages" or json_schema_capable?(model))
+  end
 
   defp json_schema_capable?(%Model{capabilities: capabilities}) when is_map(capabilities) do
     case Map.get(capabilities, :json) do
@@ -482,34 +258,40 @@ defmodule LLMDB.ExecutionContract do
 
   defp json_schema_capable?(_model), do: false
 
-  defp text_object_family(model, provider_id) do
+  defp text_object_family(model, provider, operation) do
+    configured_family = provider_family(provider, operation)
+
     cond do
-      google_text_object_model?(model, provider_id) ->
-        "google_generate_content"
-
-      provider_id == :anthropic and chat_generation_model?(model) ->
-        "anthropic_messages"
-
-      provider_id == :cohere and cohere_chat_model?(model) ->
-        "cohere_chat"
-
       protocol = text_object_protocol(model) ->
         protocol_family(protocol)
 
-      provider_id in @openai_compatible_providers and chat_generation_model?(model) ->
-        "openai_chat_compatible"
+      configured_family == "google_generate_content" and google_text_object_model?(model) ->
+        configured_family
+
+      configured_family == "cohere_chat" and cohere_chat_model?(model) ->
+        configured_family
+
+      configured_family in ["google_generate_content", "cohere_chat"] ->
+        nil
+
+      is_binary(configured_family) and chat_generation_model?(model) ->
+        configured_family
 
       true ->
         nil
     end
   end
 
-  defp google_text_object_model?(model, :google) do
+  defp google_text_object_model?(model) do
     methods = supported_generation_methods(model)
     MapSet.disjoint?(@google_generation_methods, methods) == false
   end
 
-  defp google_text_object_model?(_model, _provider_id), do: false
+  defp provider_family(%Provider{runtime: %{execution: execution}}, operation)
+       when is_map(execution),
+       do: Map.get(execution, operation)
+
+  defp provider_family(_provider, _operation), do: nil
 
   defp cohere_chat_model?(model) do
     chat_generation_model?(model) and not cohere_embedding_or_rerank_model?(model)
@@ -535,11 +317,6 @@ defmodule LLMDB.ExecutionContract do
     Merge.merge(existing, derived, :higher)
   end
 
-  defp google_embedding_model?(model) do
-    methods = supported_generation_methods(model)
-    MapSet.disjoint?(@google_embedding_methods, methods) == false or embedding_model?(model)
-  end
-
   defp text_object_protocol(model) do
     protocol =
       case wire_protocol(model) do
@@ -557,10 +334,10 @@ defmodule LLMDB.ExecutionContract do
   defp protocol_family("anthropic_messages"), do: "anthropic_messages"
   defp protocol_family(_protocol), do: nil
 
-  defp execution_entry(model, provider_id, family) when is_binary(family) do
+  defp execution_entry(model, provider, family) when is_binary(family) do
     wire_protocol = Map.get(@family_wire_protocol, family)
     provider_model_id = provider_model_id_override(model)
-    base_url = model_base_url_override(model, provider_id)
+    base_url = model_base_url_override(model, provider)
 
     %{
       supported: true,
@@ -580,17 +357,14 @@ defmodule LLMDB.ExecutionContract do
 
   defp provider_model_id_override(_model), do: nil
 
-  defp model_base_url_override(%Model{base_url: base_url}, provider_id)
+  defp model_base_url_override(%Model{base_url: base_url}, %Provider{} = provider)
        when is_binary(base_url) do
-    provider_base_url =
-      @provider_runtime_defaults
-      |> Map.get(provider_id, %{})
-      |> Map.get(:base_url)
+    provider_base_url = get_in(provider, [Access.key(:runtime), Access.key(:base_url)])
 
     if base_url != provider_base_url, do: base_url
   end
 
-  defp model_base_url_override(_model, _provider_id), do: nil
+  defp model_base_url_override(_model, _provider), do: nil
 
   defp merge_execution(nil, existing), do: existing
   defp merge_execution(derived, nil), do: derived
@@ -791,13 +565,6 @@ defmodule LLMDB.ExecutionContract do
 
     wire_protocol(model) in ["realtime", "openai_realtime"] or
       String.contains?(normalized_id, "realtime")
-  end
-
-  defp openai_speech_model?(model), do: dedicated_speech_model?(model)
-  defp elevenlabs_speech_model?(model), do: dedicated_speech_model?(model)
-
-  defp elevenlabs_transcription_model?(model) do
-    dedicated_transcription_model?(model) and not elevenlabs_speech_model?(model)
   end
 
   defp exclusive_media_model?(model) do

--- a/lib/llm_db/provider.ex
+++ b/lib/llm_db/provider.ex
@@ -62,13 +62,24 @@ defmodule LLMDB.Provider do
                          headers: Zoi.array(@runtime_auth_header_schema) |> Zoi.default([])
                        })
 
+  @runtime_execution_schema Zoi.object(%{
+                              text: Zoi.string() |> Zoi.nullish(),
+                              object: Zoi.string() |> Zoi.nullish(),
+                              embed: Zoi.string() |> Zoi.nullish(),
+                              image: Zoi.string() |> Zoi.nullish(),
+                              transcription: Zoi.string() |> Zoi.nullish(),
+                              speech: Zoi.string() |> Zoi.nullish(),
+                              realtime: Zoi.string() |> Zoi.nullish()
+                            })
+
   @runtime_schema Zoi.object(%{
                     base_url: Zoi.string() |> Zoi.nullish(),
                     auth: @runtime_auth_schema |> Zoi.nullish(),
                     default_headers: Zoi.map() |> Zoi.default(%{}),
                     default_query: Zoi.map() |> Zoi.default(%{}),
                     config_schema: Zoi.array(@config_field_schema) |> Zoi.nullish(),
-                    doc_url: Zoi.string() |> Zoi.nullish()
+                    doc_url: Zoi.string() |> Zoi.nullish(),
+                    execution: @runtime_execution_schema |> Zoi.nullish()
                   })
 
   @schema Zoi.struct(

--- a/priv/llm_db/local/alibaba/provider.toml
+++ b/priv/llm_db/local/alibaba/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://www.alibabacloud.com/help/en/model-studio/models"
 
 [runtime.auth]
 type = "bearer"
+env = ["DASHSCOPE_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/alibaba/provider.toml
+++ b/priv/llm_db/local/alibaba/provider.toml
@@ -1,0 +1,15 @@
+id = "alibaba"
+
+[runtime]
+base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+doc_url = "https://www.alibabacloud.com/help/en/model-studio/models"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/anthropic/provider.toml
+++ b/priv/llm_db/local/anthropic/provider.toml
@@ -56,6 +56,7 @@ doc_url = "https://docs.anthropic.com"
 
 [runtime.auth]
 type = "x_api_key"
+env = ["ANTHROPIC_API_KEY"]
 header_name = "x-api-key"
 
 [runtime.execution]

--- a/priv/llm_db/local/anthropic/provider.toml
+++ b/priv/llm_db/local/anthropic/provider.toml
@@ -49,3 +49,15 @@ tool = "web_search"
 unit = "call"
 per = 1000
 rate = 10.0
+
+[runtime]
+base_url = "https://api.anthropic.com"
+doc_url = "https://docs.anthropic.com"
+
+[runtime.auth]
+type = "x_api_key"
+header_name = "x-api-key"
+
+[runtime.execution]
+text = "anthropic_messages"
+object = "anthropic_messages"

--- a/priv/llm_db/local/cerebras/provider.toml
+++ b/priv/llm_db/local/cerebras/provider.toml
@@ -9,3 +9,17 @@ env = ["CEREBRAS_API_KEY"]
 exclude_models = [
   "qwen-3-235b-a22b-thinking-2507"
 ]
+
+[runtime]
+base_url = "https://api.cerebras.ai/v1"
+doc_url = "https://cerebras.ai/docs"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/cerebras/provider.toml
+++ b/priv/llm_db/local/cerebras/provider.toml
@@ -16,6 +16,7 @@ doc_url = "https://cerebras.ai/docs"
 
 [runtime.auth]
 type = "bearer"
+env = ["CEREBRAS_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/cloudflare_workers_ai/provider.toml
+++ b/priv/llm_db/local/cloudflare_workers_ai/provider.toml
@@ -1,0 +1,22 @@
+id = "cloudflare_workers_ai"
+
+[runtime]
+base_url = "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1"
+doc_url = "https://developers.cloudflare.com/workers-ai/models/"
+
+[[runtime.config_schema]]
+name = "account_id"
+type = "string"
+required = true
+doc = "Cloudflare account ID used in the Workers AI base URL template."
+
+[runtime.auth]
+type = "bearer"
+env = ["CLOUDFLARE_API_KEY"]
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/cohere/provider.toml
+++ b/priv/llm_db/local/cohere/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://docs.cohere.com/docs/models"
 
 [runtime.auth]
 type = "bearer"
+env = ["COHERE_API_KEY"]
 
 [runtime.execution]
 text = "cohere_chat"

--- a/priv/llm_db/local/cohere/provider.toml
+++ b/priv/llm_db/local/cohere/provider.toml
@@ -1,0 +1,12 @@
+id = "cohere"
+
+[runtime]
+base_url = "https://api.cohere.com"
+doc_url = "https://docs.cohere.com/docs/models"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "cohere_chat"
+object = "cohere_chat"

--- a/priv/llm_db/local/deepseek/provider.toml
+++ b/priv/llm_db/local/deepseek/provider.toml
@@ -1,0 +1,15 @@
+id = "deepseek"
+
+[runtime]
+base_url = "https://api.deepseek.com"
+doc_url = "https://api-docs.deepseek.com"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/deepseek/provider.toml
+++ b/priv/llm_db/local/deepseek/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://api-docs.deepseek.com"
 
 [runtime.auth]
 type = "bearer"
+env = ["DEEPSEEK_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/elevenlabs/provider.toml
+++ b/priv/llm_db/local/elevenlabs/provider.toml
@@ -12,6 +12,7 @@ doc_url = "https://elevenlabs.io/docs/api-reference/introduction"
 
 [runtime.auth]
 type = "header"
+env = ["ELEVENLABS_API_KEY"]
 header_name = "xi-api-key"
 
 [runtime.execution]

--- a/priv/llm_db/local/elevenlabs/provider.toml
+++ b/priv/llm_db/local/elevenlabs/provider.toml
@@ -5,3 +5,15 @@ base_url = "https://api.elevenlabs.io"
 doc = "https://elevenlabs.io/docs/api-reference/introduction"
 
 env = ["ELEVENLABS_API_KEY"]
+
+[runtime]
+base_url = "https://api.elevenlabs.io"
+doc_url = "https://elevenlabs.io/docs/api-reference/introduction"
+
+[runtime.auth]
+type = "header"
+header_name = "xi-api-key"
+
+[runtime.execution]
+transcription = "elevenlabs_transcription"
+speech = "elevenlabs_speech"

--- a/priv/llm_db/local/fireworks_ai/provider.toml
+++ b/priv/llm_db/local/fireworks_ai/provider.toml
@@ -1,0 +1,15 @@
+id = "fireworks_ai"
+
+[runtime]
+base_url = "https://api.fireworks.ai/inference/v1"
+doc_url = "https://fireworks.ai/docs/"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/fireworks_ai/provider.toml
+++ b/priv/llm_db/local/fireworks_ai/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://fireworks.ai/docs/"
 
 [runtime.auth]
 type = "bearer"
+env = ["FIREWORKS_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/friendli/provider.toml
+++ b/priv/llm_db/local/friendli/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://friendli.ai/docs/guides/serverless_endpoints/introduction"
 
 [runtime.auth]
 type = "bearer"
+env = ["FRIENDLI_TOKEN"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/friendli/provider.toml
+++ b/priv/llm_db/local/friendli/provider.toml
@@ -1,0 +1,15 @@
+id = "friendli"
+
+[runtime]
+base_url = "https://api.friendli.ai/serverless/v1"
+doc_url = "https://friendli.ai/docs/guides/serverless_endpoints/introduction"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/github_models/provider.toml
+++ b/priv/llm_db/local/github_models/provider.toml
@@ -1,0 +1,15 @@
+id = "github_models"
+
+[runtime]
+base_url = "https://models.github.ai/inference"
+doc_url = "https://docs.github.com/en/github-models"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/github_models/provider.toml
+++ b/priv/llm_db/local/github_models/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://docs.github.com/en/github-models"
 
 [runtime.auth]
 type = "bearer"
+env = ["GITHUB_TOKEN"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/google/provider.toml
+++ b/priv/llm_db/local/google/provider.toml
@@ -53,6 +53,7 @@ doc_url = "https://ai.google.dev/docs"
 
 [runtime.auth]
 type = "header"
+env = ["GOOGLE_API_KEY", "GEMINI_API_KEY"]
 header_name = "x-goog-api-key"
 
 [runtime.execution]

--- a/priv/llm_db/local/google/provider.toml
+++ b/priv/llm_db/local/google/provider.toml
@@ -46,3 +46,15 @@ tool = "web_search"
 unit = "call"
 per = 1000
 rate = 35.0
+
+[runtime]
+base_url = "https://generativelanguage.googleapis.com/v1beta"
+doc_url = "https://ai.google.dev/docs"
+
+[runtime.auth]
+type = "header"
+header_name = "x-goog-api-key"
+
+[runtime.execution]
+text = "google_generate_content"
+object = "google_generate_content"

--- a/priv/llm_db/local/groq/provider.toml
+++ b/priv/llm_db/local/groq/provider.toml
@@ -35,3 +35,17 @@ exclude_models = [
   "qwen-2.5-coder-32b",
   "qwen-qwq-32b"
 ]
+
+[runtime]
+base_url = "https://api.groq.com/openai/v1"
+doc_url = "https://groq.com/docs"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/groq/provider.toml
+++ b/priv/llm_db/local/groq/provider.toml
@@ -42,6 +42,7 @@ doc_url = "https://groq.com/docs"
 
 [runtime.auth]
 type = "bearer"
+env = ["GROQ_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/minimax/provider.toml
+++ b/priv/llm_db/local/minimax/provider.toml
@@ -5,3 +5,17 @@ base_url = "https://api.minimax.io/v1"
 doc = "https://platform.minimax.io/docs/guides/quickstart"
 
 env = ["MINIMAX_API_KEY"]
+
+[runtime]
+base_url = "https://api.minimax.io/v1"
+doc_url = "https://platform.minimax.io/docs/guides/quickstart"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/minimax/provider.toml
+++ b/priv/llm_db/local/minimax/provider.toml
@@ -12,6 +12,7 @@ doc_url = "https://platform.minimax.io/docs/guides/quickstart"
 
 [runtime.auth]
 type = "bearer"
+env = ["MINIMAX_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/mistral/provider.toml
+++ b/priv/llm_db/local/mistral/provider.toml
@@ -1,0 +1,15 @@
+id = "mistral"
+
+[runtime]
+base_url = "https://api.mistral.ai/v1"
+doc_url = "https://docs.mistral.ai/getting-started/models/"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/mistral/provider.toml
+++ b/priv/llm_db/local/mistral/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://docs.mistral.ai/getting-started/models/"
 
 [runtime.auth]
 type = "bearer"
+env = ["MISTRAL_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/ollama_cloud/provider.toml
+++ b/priv/llm_db/local/ollama_cloud/provider.toml
@@ -1,0 +1,15 @@
+id = "ollama_cloud"
+
+[runtime]
+base_url = "https://ollama.com/v1"
+doc_url = "https://docs.ollama.com/cloud"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/ollama_cloud/provider.toml
+++ b/priv/llm_db/local/ollama_cloud/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://docs.ollama.com/cloud"
 
 [runtime.auth]
 type = "bearer"
+env = ["OLLAMA_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/openai/provider.toml
+++ b/priv/llm_db/local/openai/provider.toml
@@ -96,3 +96,19 @@ unit = "session"
 per = 1
 rate = 1.92
 notes = "64 GB hosted shell/code interpreter container, 20-minute session"
+
+[runtime]
+base_url = "https://api.openai.com/v1"
+doc_url = "https://platform.openai.com/docs"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"
+speech = "openai_speech"
+realtime = "openai_realtime"

--- a/priv/llm_db/local/openai/provider.toml
+++ b/priv/llm_db/local/openai/provider.toml
@@ -103,6 +103,7 @@ doc_url = "https://platform.openai.com/docs"
 
 [runtime.auth]
 type = "bearer"
+env = ["OPENAI_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/openrouter/provider.toml
+++ b/priv/llm_db/local/openrouter/provider.toml
@@ -85,6 +85,7 @@ doc_url = "https://openrouter.ai/docs"
 
 [runtime.auth]
 type = "bearer"
+env = ["OPENROUTER_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/openrouter/provider.toml
+++ b/priv/llm_db/local/openrouter/provider.toml
@@ -78,3 +78,17 @@ exclude_models = [
   "xiaomi/mimo-v2-omni",
   "xiaomi/mimo-v2-pro"
 ]
+
+[runtime]
+base_url = "https://openrouter.ai/api/v1"
+doc_url = "https://openrouter.ai/docs"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/perplexity/provider.toml
+++ b/priv/llm_db/local/perplexity/provider.toml
@@ -1,0 +1,15 @@
+id = "perplexity"
+
+[runtime]
+base_url = "https://api.perplexity.ai"
+doc_url = "https://docs.perplexity.ai"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/perplexity/provider.toml
+++ b/priv/llm_db/local/perplexity/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://docs.perplexity.ai"
 
 [runtime.auth]
 type = "bearer"
+env = ["PERPLEXITY_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/togetherai/provider.toml
+++ b/priv/llm_db/local/togetherai/provider.toml
@@ -1,0 +1,15 @@
+id = "togetherai"
+
+[runtime]
+base_url = "https://api.together.xyz/v1"
+doc_url = "https://docs.together.ai/docs/serverless-models"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/togetherai/provider.toml
+++ b/priv/llm_db/local/togetherai/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://docs.together.ai/docs/serverless-models"
 
 [runtime.auth]
 type = "bearer"
+env = ["TOGETHER_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/venice/provider.toml
+++ b/priv/llm_db/local/venice/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://docs.venice.ai"
 
 [runtime.auth]
 type = "bearer"
+env = ["VENICE_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/venice/provider.toml
+++ b/priv/llm_db/local/venice/provider.toml
@@ -1,0 +1,15 @@
+id = "venice"
+
+[runtime]
+base_url = "https://api.venice.ai/api/v1"
+doc_url = "https://docs.venice.ai"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/xai/provider.toml
+++ b/priv/llm_db/local/xai/provider.toml
@@ -82,6 +82,7 @@ doc_url = "https://docs.x.ai"
 
 [runtime.auth]
 type = "bearer"
+env = ["XAI_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/xai/provider.toml
+++ b/priv/llm_db/local/xai/provider.toml
@@ -75,3 +75,17 @@ tool = "file_search"
 unit = "call"
 per = 1000
 rate = 2.5
+
+[runtime]
+base_url = "https://api.x.ai/v1"
+doc_url = "https://docs.x.ai"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/zai/provider.toml
+++ b/priv/llm_db/local/zai/provider.toml
@@ -1,0 +1,15 @@
+id = "zai"
+
+[runtime]
+base_url = "https://api.z.ai/api/paas/v4"
+doc_url = "https://docs.z.ai/guides/overview/pricing"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/priv/llm_db/local/zai/provider.toml
+++ b/priv/llm_db/local/zai/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://docs.z.ai/guides/overview/pricing"
 
 [runtime.auth]
 type = "bearer"
+env = ["ZHIPU_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/zenmux/provider.toml
+++ b/priv/llm_db/local/zenmux/provider.toml
@@ -6,6 +6,7 @@ doc_url = "https://docs.zenmux.ai"
 
 [runtime.auth]
 type = "bearer"
+env = ["ZENMUX_API_KEY"]
 
 [runtime.execution]
 text = "openai_chat_compatible"

--- a/priv/llm_db/local/zenmux/provider.toml
+++ b/priv/llm_db/local/zenmux/provider.toml
@@ -1,0 +1,15 @@
+id = "zenmux"
+
+[runtime]
+base_url = "https://zenmux.ai/api/v1"
+doc_url = "https://docs.zenmux.ai"
+
+[runtime.auth]
+type = "bearer"
+
+[runtime.execution]
+text = "openai_chat_compatible"
+object = "openai_chat_compatible"
+embed = "openai_embeddings"
+image = "openai_images"
+transcription = "openai_transcription"

--- a/test/llm_db/engine/validate_test.exs
+++ b/test/llm_db/engine/validate_test.exs
@@ -667,7 +667,11 @@ defmodule LLMDB.Engine.ValidateTest do
           id: :openai,
           runtime: %{
             base_url: "https://api.openai.com/v1",
-            auth: %{type: "bearer", env: ["OPENAI_API_KEY"]}
+            auth: %{type: "bearer", env: ["OPENAI_API_KEY"]},
+            execution: %{
+              text: "openai_chat_compatible",
+              object: "openai_chat_compatible"
+            }
           }
         })
       ]
@@ -701,7 +705,8 @@ defmodule LLMDB.Engine.ValidateTest do
           id: :anthropic,
           runtime: %{
             base_url: "https://api.anthropic.com",
-            auth: %{type: "x_api_key", env: ["ANTHROPIC_API_KEY"], header_name: "x-api-key"}
+            auth: %{type: "x_api_key", env: ["ANTHROPIC_API_KEY"], header_name: "x-api-key"},
+            execution: %{text: "anthropic_messages", object: "anthropic_messages"}
           }
         })
       ]

--- a/test/llm_db/enrich/runtime_contract_test.exs
+++ b/test/llm_db/enrich/runtime_contract_test.exs
@@ -2,18 +2,12 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
   use ExUnit.Case, async: true
 
   alias LLMDB.Enrich.RuntimeContract
+  alias LLMDB.Sources.Local
   alias LLMDB.{Model, Provider}
 
   describe "enrich_provider/1" do
     test "adds typed runtime defaults for executable providers" do
-      provider =
-        Provider.new!(%{
-          id: :openai,
-          env: ["OPENAI_API_KEY"],
-          doc: "https://platform.openai.com/docs"
-        })
-
-      enriched = RuntimeContract.enrich_provider(provider)
+      enriched = local_provider(:openai)
 
       assert enriched.catalog_only == false
       assert enriched.runtime.base_url == "https://api.openai.com/v1"
@@ -23,13 +17,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "adds config schema for providers with required runtime placeholders" do
-      provider =
-        Provider.new!(%{
-          id: :cloudflare_workers_ai,
-          env: ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_KEY"]
-        })
-
-      enriched = RuntimeContract.enrich_provider(provider)
+      enriched = local_provider(:cloudflare_workers_ai)
 
       assert enriched.catalog_only == false
 
@@ -42,13 +30,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "adds native MiniMax runtime defaults" do
-      provider =
-        Provider.new!(%{
-          id: :minimax,
-          env: ["MINIMAX_API_KEY"]
-        })
-
-      enriched = RuntimeContract.enrich_provider(provider)
+      enriched = local_provider(:minimax)
 
       assert enriched.catalog_only == false
       assert enriched.runtime.base_url == "https://api.minimax.io/v1"
@@ -81,9 +63,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
 
   describe "enrich_model/2" do
     test "derives responses-family execution from explicit wire protocol" do
-      provider =
-        Provider.new!(%{id: :openai, env: ["OPENAI_API_KEY"]})
-        |> RuntimeContract.enrich_provider()
+      provider = local_provider(:openai)
 
       model =
         Model.new!(%{
@@ -101,9 +81,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "does not derive object execution for Anthropic models without JSON schema support" do
-      provider =
-        Provider.new!(%{id: :anthropic, env: ["ANTHROPIC_API_KEY"]})
-        |> RuntimeContract.enrich_provider()
+      provider = local_provider(:anthropic)
 
       model =
         Model.new!(%{
@@ -121,9 +99,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "derives object execution for Anthropic models with JSON schema support" do
-      provider =
-        Provider.new!(%{id: :anthropic, env: ["ANTHROPIC_API_KEY"]})
-        |> RuntimeContract.enrich_provider()
+      provider = local_provider(:anthropic)
 
       model =
         Model.new!(%{
@@ -141,9 +117,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "derives speech execution for dedicated tts models without adding text operations" do
-      provider =
-        Provider.new!(%{id: :openai, env: ["OPENAI_API_KEY"]})
-        |> RuntimeContract.enrich_provider()
+      provider = local_provider(:openai)
 
       model = Model.new!(%{id: "gpt-4o-mini-tts", provider: :openai})
       enriched = RuntimeContract.enrich_model(model, provider)
@@ -156,9 +130,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "keeps multimodal chat models on the text lane instead of misclassifying them as transcription" do
-      provider =
-        Provider.new!(%{id: :alibaba, env: ["DASHSCOPE_API_KEY"]})
-        |> RuntimeContract.enrich_provider()
+      provider = local_provider(:alibaba)
 
       model =
         Model.new!(%{
@@ -177,9 +149,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "marks models without a safe execution contract catalog only" do
-      provider =
-        Provider.new!(%{id: :google, env: ["GOOGLE_API_KEY"]})
-        |> RuntimeContract.enrich_provider()
+      provider = local_provider(:google)
 
       model =
         Model.new!(%{
@@ -195,9 +165,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "derives rerank capability metadata from explicit rerank source hints" do
-      provider =
-        Provider.new!(%{id: :cohere, env: ["COHERE_API_KEY"]})
-        |> RuntimeContract.enrich_provider()
+      provider = local_provider(:cohere)
 
       model =
         Model.new!(%{
@@ -216,9 +184,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "derives embed execution for openrouter model with :embeddings plural in output modalities" do
-      provider =
-        Provider.new!(%{id: :openrouter, env: ["OPENROUTER_API_KEY"]})
-        |> RuntimeContract.enrich_provider()
+      provider = local_provider(:openrouter)
 
       model =
         Model.new!(%{
@@ -237,9 +203,7 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
     end
 
     test "derives embed execution for openrouter model with :embedding singular in output modalities" do
-      provider =
-        Provider.new!(%{id: :openrouter, env: ["OPENROUTER_API_KEY"]})
-        |> RuntimeContract.enrich_provider()
+      provider = local_provider(:openrouter)
 
       model =
         Model.new!(%{
@@ -275,5 +239,16 @@ defmodule LLMDB.Enrich.RuntimeContractTest do
       assert enriched.capabilities.chat == false
       assert enriched.capabilities.rerank == true
     end
+  end
+
+  defp local_provider(id) do
+    {:ok, providers} = Local.load(%{dir: "priv/llm_db/local"})
+
+    providers
+    |> Map.fetch!(Atom.to_string(id))
+    |> Map.delete(:models)
+    |> Map.put(:id, id)
+    |> Provider.new!()
+    |> RuntimeContract.enrich_provider()
   end
 end

--- a/test/llm_db/execution_contract_test.exs
+++ b/test/llm_db/execution_contract_test.exs
@@ -68,8 +68,41 @@ defmodule LLMDB.ExecutionContractTest do
     assert :ok = Validate.validate_runtime_contract([provider], [enriched])
   end
 
+  test "enrich/2 consumes provider execution policy without publishing it" do
+    provider = executable_provider()
+
+    model =
+      Model.new!(%{
+        id: "chat-model",
+        provider: :openai,
+        modalities: %{input: [:text], output: [:text]}
+      })
+
+    assert {[published_provider], [published_model]} =
+             ExecutionContract.enrich([provider], [model])
+
+    refute Map.has_key?(published_provider.runtime, :execution)
+    assert published_model.execution.text.family == "openai_chat_compatible"
+  end
+
   defp executable_provider do
-    Provider.new!(%{id: :openai, env: ["OPENAI_API_KEY"]})
+    Provider.new!(%{
+      id: :openai,
+      env: ["OPENAI_API_KEY"],
+      runtime: %{
+        base_url: "https://api.openai.com/v1",
+        auth: %{type: "bearer"},
+        execution: %{
+          text: "openai_chat_compatible",
+          object: "openai_chat_compatible",
+          embed: "openai_embeddings",
+          image: "openai_images",
+          transcription: "openai_transcription",
+          speech: "openai_speech",
+          realtime: "openai_realtime"
+        }
+      }
+    })
     |> ExecutionContract.enrich_provider()
   end
 end

--- a/test/llm_db/execution_contract_test.exs
+++ b/test/llm_db/execution_contract_test.exs
@@ -85,6 +85,35 @@ defmodule LLMDB.ExecutionContractTest do
     assert published_model.execution.text.family == "openai_chat_compatible"
   end
 
+  test "validation sees provider policy before the publication boundary strips it" do
+    provider = executable_provider()
+
+    model =
+      Model.new!(%{
+        id: "chat-model",
+        provider: :openai,
+        modalities: %{input: [:text], output: [:text]}
+      })
+
+    assert {[validation_provider], [enriched_model]} =
+             ExecutionContract.enrich_for_validation([provider], [model])
+
+    assert validation_provider.runtime.execution.object == "openai_chat_compatible"
+
+    incomplete_model = %{
+      enriched_model
+      | execution: Map.delete(enriched_model.execution, :object)
+    }
+
+    assert {:error, {:invalid_runtime_contract, errors}} =
+             Validate.validate_runtime_contract([validation_provider], [incomplete_model])
+
+    assert Enum.any?(errors, &(&1.error == :missing_execution_entry and &1.operation == :object))
+
+    published_provider = ExecutionContract.publish_provider(validation_provider)
+    refute Map.has_key?(published_provider.runtime, :execution)
+  end
+
   defp executable_provider do
     Provider.new!(%{
       id: :openai,

--- a/test/llm_db/provider_runtime_data_test.exs
+++ b/test/llm_db/provider_runtime_data_test.exs
@@ -1,0 +1,58 @@
+defmodule LLMDB.ProviderRuntimeDataTest do
+  use ExUnit.Case, async: true
+
+  alias LLMDB.Provider
+  alias LLMDB.Sources.Local
+
+  @openai_compatible [
+    :openai,
+    :openrouter,
+    :groq,
+    :xai,
+    :zenmux,
+    :mistral,
+    :togetherai,
+    :github_models,
+    :perplexity,
+    :cloudflare_workers_ai,
+    :fireworks_ai,
+    :minimax,
+    :friendli,
+    :ollama_cloud,
+    :deepseek,
+    :alibaba,
+    :venice,
+    :cerebras,
+    :zai
+  ]
+
+  test "provider TOML owns every executable provider runtime policy" do
+    {:ok, providers} = Local.load(%{dir: "priv/llm_db/local"})
+
+    Enum.each(@openai_compatible, fn id ->
+      runtime = provider_runtime(providers, id)
+
+      assert is_binary(runtime.base_url), "missing runtime base URL for #{id}"
+      assert runtime.auth.type == "bearer"
+      assert runtime.execution.text == "openai_chat_compatible"
+      assert runtime.execution.object == "openai_chat_compatible"
+    end)
+
+    assert provider_runtime(providers, :anthropic).execution.text == "anthropic_messages"
+    assert provider_runtime(providers, :google).execution.text == "google_generate_content"
+    assert provider_runtime(providers, :cohere).execution.text == "cohere_chat"
+
+    elevenlabs = provider_runtime(providers, :elevenlabs)
+    assert elevenlabs.execution.speech == "elevenlabs_speech"
+    assert elevenlabs.execution.transcription == "elevenlabs_transcription"
+  end
+
+  defp provider_runtime(providers, id) do
+    providers
+    |> Map.fetch!(Atom.to_string(id))
+    |> Map.delete(:models)
+    |> Map.put(:id, id)
+    |> Provider.new!()
+    |> Map.fetch!(:runtime)
+  end
+end

--- a/test/llm_db/provider_runtime_data_test.exs
+++ b/test/llm_db/provider_runtime_data_test.exs
@@ -34,15 +34,26 @@ defmodule LLMDB.ProviderRuntimeDataTest do
 
       assert is_binary(runtime.base_url), "missing runtime base URL for #{id}"
       assert runtime.auth.type == "bearer"
+
+      assert is_list(runtime.auth.env) and runtime.auth.env != [],
+             "missing runtime auth env for #{id}"
+
       assert runtime.execution.text == "openai_chat_compatible"
       assert runtime.execution.object == "openai_chat_compatible"
     end)
 
-    assert provider_runtime(providers, :anthropic).execution.text == "anthropic_messages"
-    assert provider_runtime(providers, :google).execution.text == "google_generate_content"
-    assert provider_runtime(providers, :cohere).execution.text == "cohere_chat"
+    for {id, family} <- [
+          anthropic: "anthropic_messages",
+          google: "google_generate_content",
+          cohere: "cohere_chat"
+        ] do
+      runtime = provider_runtime(providers, id)
+      assert runtime.execution.text == family
+      assert is_list(runtime.auth.env) and runtime.auth.env != []
+    end
 
     elevenlabs = provider_runtime(providers, :elevenlabs)
+    assert elevenlabs.auth.env == ["ELEVENLABS_API_KEY"]
     assert elevenlabs.execution.speech == "elevenlabs_speech"
     assert elevenlabs.execution.transcription == "elevenlabs_transcription"
   end

--- a/test/llm_db/schema/provider_test.exs
+++ b/test/llm_db/schema/provider_test.exs
@@ -65,6 +65,24 @@ defmodule LLMDB.Schema.ProviderTest do
       assert result.runtime.default_query["project"] == "demo"
       assert hd(result.runtime.config_schema).name == "project"
       assert result.runtime.doc_url == "https://platform.openai.com/docs/api-reference"
+      assert Map.get(result.runtime, :execution) == nil
+    end
+
+    test "parses additive runtime execution policy" do
+      input = %{
+        id: :openai,
+        runtime: %{
+          execution: %{
+            text: "openai_chat_compatible",
+            object: "openai_responses_compatible"
+          }
+        }
+      }
+
+      assert {:ok, result} = Provider.new(input)
+      assert result.runtime.execution.text == "openai_chat_compatible"
+      assert result.runtime.execution.object == "openai_responses_compatible"
+      assert Map.get(result.runtime.execution, :embed) == nil
     end
 
     test "normalizes auth type atoms through Provider.new/1" do


### PR DESCRIPTION
Closes #249

## Summary
- move executable-provider URLs, auth, and operation-family policy into provider TOML overlays
- make execution inference consume provider data instead of branching on provider IDs
- keep the runtime execution policy build-internal so the published snapshot remains semantically unchanged
- add schema, provider-data, inference, override, and publication-boundary coverage

## Verification
- `mix test` (844 passed)
- `mix quality`
- `mix llm_db.build --check --install`