### PR TITLE
refactor: share remote source transport

### DIFF
--- a/guides/runtime-and-maintainer-boundaries.md
+++ b/guides/runtime-and-maintainer-boundaries.md
@@ -70,7 +70,7 @@ No module or task is removed in this minor release.
 | `LLMDB.History.Backfill`, `LLMDB.History.Migrator`, `LLMDB.History.Rebuilder`, `LLMDB.History.Bundle` | Corresponding `mix llm_db.history.*` task | Documentation-deprecated maintainer orchestration |
 | `LLMDB.Snapshot.ReleaseStore` mutation/publishing calls | `mix llm_db.snapshot.publish` or `mix llm_db.history.rebuild --publish` | Internal shared transport; runtime fetch behavior remains supported through configuration |
 | `LLMDB.Enrich`, `LLMDB.Validate`, `LLMDB.Enrich.AzureWireProtocol`, `LLMDB.Enrich.RuntimeContract` | `mix llm_db.build` | Internal ETL stages |
-| LLMDB.Sources.Anthropic, LLMDB.Sources.Google, LLMDB.Sources.Llmfit, LLMDB.Sources.Local, LLMDB.Sources.ModelsDev, LLMDB.Sources.OpenAI, LLMDB.Sources.OpenRouter, LLMDB.Sources.XAI, LLMDB.Sources.Zenmux | `LLMDB.Source` for extensions; `mix llm_db.pull`/`build` for workflows | Internal bundled adapters |
+| LLMDB.Sources.Anthropic, LLMDB.Sources.Google, LLMDB.Sources.Llmfit, LLMDB.Sources.Local, LLMDB.Sources.ModelsDev, LLMDB.Sources.OpenAI, LLMDB.Sources.OpenRouter, LLMDB.Sources.Remote, LLMDB.Sources.XAI, LLMDB.Sources.Zenmux | `LLMDB.Source` for extensions; `mix llm_db.pull`/`build` for workflows | Internal bundled adapters and shared remote transport |
 
 Documentation-only deprecation avoids warnings inside the still-supported task
 wrappers during the extraction window. It does not grant these modules a new

--- a/lib/llm_db/sources/anthropic.ex
+++ b/lib/llm_db/sources/anthropic.ex
@@ -34,6 +34,8 @@ defmodule LLMDB.Sources.Anthropic do
 
   @behaviour LLMDB.Source
 
+  alias LLMDB.Sources.Remote
+
   @default_url "https://api.anthropic.com/v1/models"
   @default_cache_dir "priv/llm_db/remote"
   @default_version "2023-06-01"
@@ -53,9 +55,6 @@ defmodule LLMDB.Sources.Anthropic do
 
   defp do_pull(opts, api_key) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
-    manifest_path = manifest_path(url, cache_dir)
     req_opts = Map.get(opts, :req_opts, [])
 
     headers = build_headers(api_key, opts)
@@ -67,10 +66,10 @@ defmodule LLMDB.Sources.Anthropic do
 
     case all_models do
       {:ok, models} ->
-        response = %{"data" => models}
-        bin = Jason.encode!(response, pretty: true)
-        write_cache(cache_path, manifest_path, bin, url, [])
-        {:ok, cache_path}
+        Remote.store(url, %{"data" => models},
+          cache_dir: get_cache_dir(),
+          cache_key: "anthropic"
+        )
 
       {:error, reason} ->
         {:error, reason}
@@ -80,21 +79,10 @@ defmodule LLMDB.Sources.Anthropic do
   @impl true
   def load(opts) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
 
-    case File.read(cache_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, decoded} -> {:ok, transform(decoded)}
-          {:error, err} -> {:error, {:json_error, err}}
-        end
-
-      {:error, :enoent} ->
-        {:error, :no_cache}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Remote.load(url, cache_dir: get_cache_dir(), cache_key: "anthropic") do
+      {:ok, decoded} -> {:ok, transform(decoded)}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -374,8 +362,8 @@ defmodule LLMDB.Sources.Anthropic do
 
     req_opts = Keyword.put(req_opts, :params, params)
 
-    case Req.get(url, req_opts) do
-      {:ok, %Req.Response{status: 200, body: body}} ->
+    case Remote.request_json(url, req_opts) do
+      {:ok, body} when is_map(body) ->
         data = Map.get(body, "data", [])
         has_more = Map.get(body, "has_more", false)
         new_acc = acc ++ data
@@ -386,8 +374,8 @@ defmodule LLMDB.Sources.Anthropic do
           {:ok, new_acc}
         end
 
-      {:ok, %Req.Response{status: status}} when status >= 400 ->
-        {:error, {:http_status, status}}
+      {:ok, _body} ->
+        {:error, :invalid_shape}
 
       {:error, reason} ->
         {:error, reason}
@@ -400,16 +388,6 @@ defmodule LLMDB.Sources.Anthropic do
 
   defp get_cache_dir do
     Application.get_env(:llm_db, :anthropic_cache_dir, @default_cache_dir)
-  end
-
-  defp cache_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "anthropic-#{hash}.json")
-  end
-
-  defp manifest_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "anthropic-#{hash}.manifest.json")
   end
 
   defp build_headers(api_key, opts) do
@@ -427,19 +405,5 @@ defmodule LLMDB.Sources.Anthropic do
       beta when is_binary(beta) ->
         [{"anthropic-beta", beta} | headers]
     end
-  end
-
-  defp write_cache(cache_path, manifest_path, content, url, _headers) do
-    File.mkdir_p!(Path.dirname(cache_path))
-    File.write!(cache_path, content)
-
-    manifest = %{
-      source_url: url,
-      sha256: :crypto.hash(:sha256, content) |> Base.encode16(case: :lower),
-      size_bytes: byte_size(content),
-      downloaded_at: DateTime.utc_now() |> DateTime.to_iso8601()
-    }
-
-    File.write!(manifest_path, Jason.encode!(manifest, pretty: true))
   end
 end

--- a/lib/llm_db/sources/google.ex
+++ b/lib/llm_db/sources/google.ex
@@ -32,6 +32,8 @@ defmodule LLMDB.Sources.Google do
 
   @behaviour LLMDB.Source
 
+  alias LLMDB.Sources.Remote
+
   @default_url "https://generativelanguage.googleapis.com/v1beta/models"
   @default_cache_dir "priv/llm_db/remote"
 
@@ -48,9 +50,6 @@ defmodule LLMDB.Sources.Google do
 
   defp do_pull(opts, api_key) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
-    manifest_path = manifest_path(url, cache_dir)
     req_opts = Map.get(opts, :req_opts, [])
 
     headers = build_headers(api_key)
@@ -62,10 +61,10 @@ defmodule LLMDB.Sources.Google do
 
     case all_models do
       {:ok, models} ->
-        response = %{"models" => models}
-        bin = Jason.encode!(response, pretty: true)
-        write_cache(cache_path, manifest_path, bin, url, [])
-        {:ok, cache_path}
+        Remote.store(url, %{"models" => models},
+          cache_dir: get_cache_dir(),
+          cache_key: "google"
+        )
 
       {:error, reason} ->
         {:error, reason}
@@ -75,21 +74,10 @@ defmodule LLMDB.Sources.Google do
   @impl true
   def load(opts) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
 
-    case File.read(cache_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, decoded} -> {:ok, transform(decoded)}
-          {:error, err} -> {:error, {:json_error, err}}
-        end
-
-      {:error, :enoent} ->
-        {:error, :no_cache}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Remote.load(url, cache_dir: get_cache_dir(), cache_key: "google") do
+      {:ok, decoded} -> {:ok, transform(decoded)}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -232,8 +220,8 @@ defmodule LLMDB.Sources.Google do
     params = [pageSize: page_size]
     req_opts = Keyword.put(req_opts, :params, params)
 
-    case Req.get(url, req_opts) do
-      {:ok, %Req.Response{status: 200, body: body}} ->
+    case Remote.request_json(url, req_opts) do
+      {:ok, body} when is_map(body) ->
         models = Map.get(body, "models", [])
         next_page_token = Map.get(body, "nextPageToken")
         new_acc = acc ++ models
@@ -247,8 +235,8 @@ defmodule LLMDB.Sources.Google do
           {:ok, new_acc}
         end
 
-      {:ok, %Req.Response{status: status}} when status >= 400 ->
-        {:error, {:http_status, status}}
+      {:ok, _body} ->
+        {:error, :invalid_shape}
 
       {:error, reason} ->
         {:error, reason}
@@ -268,31 +256,7 @@ defmodule LLMDB.Sources.Google do
     Application.get_env(:llm_db, :google_cache_dir, @default_cache_dir)
   end
 
-  defp cache_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "google-#{hash}.json")
-  end
-
-  defp manifest_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "google-#{hash}.manifest.json")
-  end
-
   defp build_headers(api_key) do
     [{"x-goog-api-key", api_key}]
-  end
-
-  defp write_cache(cache_path, manifest_path, content, url, _headers) do
-    File.mkdir_p!(Path.dirname(cache_path))
-    File.write!(cache_path, content)
-
-    manifest = %{
-      source_url: url,
-      sha256: :crypto.hash(:sha256, content) |> Base.encode16(case: :lower),
-      size_bytes: byte_size(content),
-      downloaded_at: DateTime.utc_now() |> DateTime.to_iso8601()
-    }
-
-    File.write!(manifest_path, Jason.encode!(manifest, pretty: true))
   end
 end

--- a/lib/llm_db/sources/llmfit.ex
+++ b/lib/llm_db/sources/llmfit.ex
@@ -13,7 +13,7 @@ defmodule LLMDB.Sources.Llmfit do
 
   @behaviour LLMDB.Source
 
-  require Logger
+  alias LLMDB.Sources.Remote
 
   @default_url "https://raw.githubusercontent.com/AlexsJones/llmfit/main/llmfit-core/data/hf_models.json"
   @default_cache_dir "priv/llm_db/upstream"
@@ -33,55 +33,12 @@ defmodule LLMDB.Sources.Llmfit do
   @impl true
   def pull(opts) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
-    manifest_path = manifest_path(url, cache_dir)
-    req_opts = Map.get(opts, :req_opts, [])
 
-    cond_headers = build_cond_headers(manifest_path)
-    headers = cond_headers ++ Keyword.get(req_opts, :headers, [])
-    req_opts = Keyword.put(req_opts, :headers, headers)
-    req_opts = Keyword.put(req_opts, :decode_body, false)
-
-    case Req.get(url, req_opts) do
-      {:ok, %Req.Response{status: 304}} ->
-        :noop
-
-      {:ok, %Req.Response{status: 200, body: body, headers: resp_headers}} ->
-        bin =
-          cond do
-            is_binary(body) and String.starts_with?(body, ["{", "["]) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            is_binary(body) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            is_map(body) or is_list(body) ->
-              Jason.encode!(body, pretty: true)
-
-            true ->
-              Jason.encode!(body, pretty: true)
-          end
-
-        write_cache(cache_path, manifest_path, bin, url, resp_headers)
-        {:ok, cache_path}
-
-      {:ok, %Req.Response{status: status}} when status >= 400 ->
-        {:error, {:http_status, status}}
-
-      {:ok, %Req.Response{status: status}} ->
-        Logger.warning("Unexpected status #{status}")
-        {:error, {:http_status, status}}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    Remote.pull(url,
+      cache_dir: get_cache_dir(),
+      cache_key: "llmfit",
+      req_opts: Map.get(opts, :req_opts, [])
+    )
   end
 
   @impl true
@@ -93,22 +50,11 @@ defmodule LLMDB.Sources.Llmfit do
   @spec load_raw(map()) :: {:ok, [map()]} | {:error, term()}
   def load_raw(opts \\ %{}) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    path = cache_path(url, cache_dir)
 
-    case File.read(path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, decoded} when is_list(decoded) -> {:ok, decoded}
-          {:ok, _other} -> {:error, :invalid_shape}
-          {:error, err} -> {:error, {:json_error, err}}
-        end
-
-      {:error, :enoent} ->
-        {:error, :no_cache}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Remote.load(url, cache_dir: get_cache_dir(), cache_key: "llmfit") do
+      {:ok, decoded} when is_list(decoded) -> {:ok, decoded}
+      {:ok, _other} -> {:error, :invalid_shape}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -126,71 +72,6 @@ defmodule LLMDB.Sources.Llmfit do
 
   defp get_cache_dir do
     Application.get_env(:llm_db, :llmfit_cache_dir, @default_cache_dir)
-  end
-
-  defp cache_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "llmfit-#{hash}.json")
-  end
-
-  defp manifest_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "llmfit-#{hash}.manifest.json")
-  end
-
-  defp write_cache(cache_path, manifest_path, content, url, headers) do
-    File.mkdir_p!(Path.dirname(cache_path))
-    File.write!(cache_path, content)
-
-    manifest = %{
-      source_url: url,
-      etag: get_header(headers, "etag"),
-      last_modified: get_header(headers, "last-modified"),
-      sha256: :crypto.hash(:sha256, content) |> Base.encode16(case: :lower),
-      size_bytes: byte_size(content),
-      downloaded_at: DateTime.utc_now() |> DateTime.to_iso8601()
-    }
-
-    File.write!(manifest_path, Jason.encode!(manifest, pretty: true))
-  end
-
-  defp build_cond_headers(manifest_path) do
-    case File.read(manifest_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, manifest} ->
-            headers = []
-
-            headers =
-              case Map.get(manifest, "etag") do
-                etag when is_binary(etag) -> [{"if-none-match", etag} | headers]
-                _ -> headers
-              end
-
-            headers =
-              case Map.get(manifest, "last_modified") do
-                last_mod when is_binary(last_mod) -> [{"if-modified-since", last_mod} | headers]
-                _ -> headers
-              end
-
-            headers
-
-          _ ->
-            []
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp get_header(headers, name) do
-    case Enum.find(headers, fn {k, _} -> String.downcase(k) == name end) do
-      {_, [v | _]} when is_list(v) -> v
-      {_, v} when is_binary(v) -> v
-      {_, v} when is_list(v) -> List.first(v)
-      _ -> nil
-    end
   end
 
   defp index_rows(rows) do

--- a/lib/llm_db/sources/models_dev.ex
+++ b/lib/llm_db/sources/models_dev.ex
@@ -30,7 +30,7 @@ defmodule LLMDB.Sources.ModelsDev do
 
   @behaviour LLMDB.Source
 
-  require Logger
+  alias LLMDB.Sources.Remote
 
   @default_url "https://models.dev/api.json"
   @default_cache_dir "priv/llm_db/remote"
@@ -38,78 +38,21 @@ defmodule LLMDB.Sources.ModelsDev do
   @impl true
   def pull(opts) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
-    manifest_path = manifest_path(url, cache_dir)
-    req_opts = Map.get(opts, :req_opts, [])
 
-    # Build conditional headers from manifest
-    cond_headers = build_cond_headers(manifest_path)
-    headers = cond_headers ++ Keyword.get(req_opts, :headers, [])
-    req_opts = Keyword.put(req_opts, :headers, headers)
-
-    # Disable automatic JSON decoding for more control
-    req_opts = Keyword.put(req_opts, :decode_body, false)
-
-    case Req.get(url, req_opts) do
-      {:ok, %Req.Response{status: 304}} ->
-        :noop
-
-      {:ok, %Req.Response{status: 200, body: body, headers: resp_headers}} ->
-        bin =
-          cond do
-            is_binary(body) and String.starts_with?(body, ["{", "["]) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            is_binary(body) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            is_map(body) or is_list(body) ->
-              Jason.encode!(body, pretty: true)
-
-            true ->
-              Jason.encode!(body, pretty: true)
-          end
-
-        write_cache(cache_path, manifest_path, bin, url, resp_headers)
-        {:ok, cache_path}
-
-      {:ok, %Req.Response{status: status}} when status >= 400 ->
-        {:error, {:http_status, status}}
-
-      {:ok, %Req.Response{status: status}} ->
-        Logger.warning("Unexpected status #{status}")
-        {:error, {:http_status, status}}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    Remote.pull(url,
+      cache_dir: get_cache_dir(),
+      cache_key: "models-dev",
+      req_opts: Map.get(opts, :req_opts, [])
+    )
   end
 
   @impl true
   def load(opts) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
 
-    case File.read(cache_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, decoded} -> {:ok, transform(decoded)}
-          {:error, err} -> {:error, {:json_error, err}}
-        end
-
-      {:error, :enoent} ->
-        {:error, :no_cache}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Remote.load(url, cache_dir: get_cache_dir(), cache_key: "models-dev") do
+      {:ok, decoded} -> {:ok, transform(decoded)}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -170,71 +113,6 @@ defmodule LLMDB.Sources.ModelsDev do
 
   defp get_cache_dir do
     Application.get_env(:llm_db, :models_dev_cache_dir, @default_cache_dir)
-  end
-
-  defp cache_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "models-dev-#{hash}.json")
-  end
-
-  defp manifest_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "models-dev-#{hash}.manifest.json")
-  end
-
-  defp write_cache(cache_path, manifest_path, content, url, headers) do
-    File.mkdir_p!(Path.dirname(cache_path))
-    File.write!(cache_path, content)
-
-    manifest = %{
-      source_url: url,
-      etag: get_header(headers, "etag"),
-      last_modified: get_header(headers, "last-modified"),
-      sha256: :crypto.hash(:sha256, content) |> Base.encode16(case: :lower),
-      size_bytes: byte_size(content),
-      downloaded_at: DateTime.utc_now() |> DateTime.to_iso8601()
-    }
-
-    File.write!(manifest_path, Jason.encode!(manifest, pretty: true))
-  end
-
-  defp build_cond_headers(manifest_path) do
-    case File.read(manifest_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, manifest} ->
-            headers = []
-
-            headers =
-              case Map.get(manifest, "etag") do
-                etag when is_binary(etag) -> [{"if-none-match", etag} | headers]
-                _ -> headers
-              end
-
-            headers =
-              case Map.get(manifest, "last_modified") do
-                last_mod when is_binary(last_mod) -> [{"if-modified-since", last_mod} | headers]
-                _ -> headers
-              end
-
-            headers
-
-          _ ->
-            []
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp get_header(headers, name) do
-    case Enum.find(headers, fn {k, _} -> String.downcase(k) == name end) do
-      {_, [v | _]} when is_list(v) -> v
-      {_, v} when is_binary(v) -> v
-      {_, v} when is_list(v) -> List.first(v)
-      _ -> nil
-    end
   end
 
   # Fields we explicitly map to canonical Zoi fields (should not go to extra)

--- a/lib/llm_db/sources/openai.ex
+++ b/lib/llm_db/sources/openai.ex
@@ -33,7 +33,7 @@ defmodule LLMDB.Sources.OpenAI do
 
   @behaviour LLMDB.Source
 
-  require Logger
+  alias LLMDB.Sources.Remote
 
   @default_url "https://api.openai.com/v1/models"
   @default_cache_dir "priv/llm_db/remote"
@@ -51,72 +51,22 @@ defmodule LLMDB.Sources.OpenAI do
 
   defp do_pull(opts, api_key) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
-    manifest_path = manifest_path(url, cache_dir)
-    req_opts = Map.get(opts, :req_opts, [])
 
-    headers = build_headers(api_key, opts)
-    headers = headers ++ Keyword.get(req_opts, :headers, [])
-    req_opts = Keyword.put(req_opts, :headers, headers)
-
-    cond_headers = build_cond_headers(manifest_path)
-    headers = cond_headers ++ Keyword.get(req_opts, :headers, [])
-    req_opts = Keyword.put(req_opts, :headers, headers)
-
-    case Req.get(url, req_opts) do
-      {:ok, %Req.Response{status: 304}} ->
-        :noop
-
-      {:ok, %Req.Response{status: 200, body: body, headers: resp_headers}} ->
-        bin =
-          cond do
-            is_map(body) or is_list(body) ->
-              Jason.encode!(body, pretty: true)
-
-            is_binary(body) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            true ->
-              Jason.encode!(body, pretty: true)
-          end
-
-        write_cache(cache_path, manifest_path, bin, url, resp_headers)
-        {:ok, cache_path}
-
-      {:ok, %Req.Response{status: status}} when status >= 400 ->
-        {:error, {:http_status, status}}
-
-      {:ok, %Req.Response{status: status}} ->
-        Logger.warning("Unexpected status #{status}")
-        {:error, {:http_status, status}}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    Remote.pull(url,
+      cache_dir: get_cache_dir(),
+      cache_key: "openai",
+      headers: build_headers(api_key, opts),
+      req_opts: Map.get(opts, :req_opts, [])
+    )
   end
 
   @impl true
   def load(opts) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
 
-    case File.read(cache_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, decoded} -> {:ok, transform(decoded)}
-          {:error, err} -> {:error, {:json_error, err}}
-        end
-
-      {:error, :enoent} ->
-        {:error, :no_cache}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Remote.load(url, cache_dir: get_cache_dir(), cache_key: "openai") do
+      {:ok, decoded} -> {:ok, transform(decoded)}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -194,16 +144,6 @@ defmodule LLMDB.Sources.OpenAI do
     Application.get_env(:llm_db, :openai_cache_dir, @default_cache_dir)
   end
 
-  defp cache_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "openai-#{hash}.json")
-  end
-
-  defp manifest_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "openai-#{hash}.manifest.json")
-  end
-
   defp build_headers(api_key, opts) do
     headers = [{"authorization", "Bearer #{api_key}"}]
 
@@ -216,61 +156,6 @@ defmodule LLMDB.Sources.OpenAI do
     case Map.get(opts, :project) do
       nil -> headers
       project -> [{"openai-project", project} | headers]
-    end
-  end
-
-  defp write_cache(cache_path, manifest_path, content, url, headers) do
-    File.mkdir_p!(Path.dirname(cache_path))
-    File.write!(cache_path, content)
-
-    manifest = %{
-      source_url: url,
-      etag: get_header(headers, "etag"),
-      last_modified: get_header(headers, "last-modified"),
-      sha256: :crypto.hash(:sha256, content) |> Base.encode16(case: :lower),
-      size_bytes: byte_size(content),
-      downloaded_at: DateTime.utc_now() |> DateTime.to_iso8601()
-    }
-
-    File.write!(manifest_path, Jason.encode!(manifest, pretty: true))
-  end
-
-  defp build_cond_headers(manifest_path) do
-    case File.read(manifest_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, manifest} ->
-            headers = []
-
-            headers =
-              case Map.get(manifest, "etag") do
-                etag when is_binary(etag) -> [{"if-none-match", etag} | headers]
-                _ -> headers
-              end
-
-            headers =
-              case Map.get(manifest, "last_modified") do
-                last_mod when is_binary(last_mod) -> [{"if-modified-since", last_mod} | headers]
-                _ -> headers
-              end
-
-            headers
-
-          _ ->
-            []
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp get_header(headers, name) do
-    case Enum.find(headers, fn {k, _} -> String.downcase(k) == name end) do
-      {_, [v | _]} when is_list(v) -> v
-      {_, v} when is_binary(v) -> v
-      {_, v} when is_list(v) -> List.first(v)
-      _ -> nil
     end
   end
 end

--- a/lib/llm_db/sources/openrouter.ex
+++ b/lib/llm_db/sources/openrouter.ex
@@ -31,7 +31,7 @@ defmodule LLMDB.Sources.OpenRouter do
 
   @behaviour LLMDB.Source
 
-  require Logger
+  alias LLMDB.Sources.Remote
 
   @default_url "https://openrouter.ai/api/v1/models?output_modalities=all"
   @default_cache_dir "priv/llm_db/upstream"
@@ -39,86 +39,28 @@ defmodule LLMDB.Sources.OpenRouter do
   @impl true
   def pull(opts) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
-    manifest_path = manifest_path(url, cache_dir)
-    req_opts = Map.get(opts, :req_opts, [])
 
-    # Build conditional headers from manifest
-    cond_headers = build_cond_headers(manifest_path)
-
-    # Add authorization header if API key provided
     auth_headers =
       case Map.get(opts, :api_key) do
         nil -> []
         key -> [{"authorization", "Bearer #{key}"}]
       end
 
-    headers = cond_headers ++ auth_headers ++ Keyword.get(req_opts, :headers, [])
-    req_opts = Keyword.put(req_opts, :headers, headers)
-
-    # Disable automatic JSON decoding for more control
-    req_opts = Keyword.put(req_opts, :decode_body, false)
-
-    case Req.get(url, req_opts) do
-      {:ok, %Req.Response{status: 304}} ->
-        :noop
-
-      {:ok, %Req.Response{status: 200, body: body, headers: resp_headers}} ->
-        bin =
-          cond do
-            is_binary(body) and String.starts_with?(body, ["{", "["]) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            is_binary(body) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            is_map(body) or is_list(body) ->
-              Jason.encode!(body, pretty: true)
-
-            true ->
-              Jason.encode!(body, pretty: true)
-          end
-
-        write_cache(cache_path, manifest_path, bin, url, resp_headers)
-        {:ok, cache_path}
-
-      {:ok, %Req.Response{status: status}} when status >= 400 ->
-        {:error, {:http_status, status}}
-
-      {:ok, %Req.Response{status: status}} ->
-        Logger.warning("Unexpected status #{status}")
-        {:error, {:http_status, status}}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    Remote.pull(url,
+      cache_dir: get_cache_dir(),
+      cache_key: "openrouter",
+      headers: auth_headers,
+      req_opts: Map.get(opts, :req_opts, [])
+    )
   end
 
   @impl true
   def load(opts) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
 
-    case File.read(cache_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, decoded} -> {:ok, transform(decoded)}
-          {:error, err} -> {:error, {:json_error, err}}
-        end
-
-      {:error, :enoent} ->
-        {:error, :no_cache}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Remote.load(url, cache_dir: get_cache_dir(), cache_key: "openrouter") do
+      {:ok, decoded} -> {:ok, transform(decoded)}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -228,71 +170,6 @@ defmodule LLMDB.Sources.OpenRouter do
 
   defp get_cache_dir do
     Application.get_env(:llm_db, :openrouter_cache_dir, @default_cache_dir)
-  end
-
-  defp cache_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "openrouter-#{hash}.json")
-  end
-
-  defp manifest_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "openrouter-#{hash}.manifest.json")
-  end
-
-  defp write_cache(cache_path, manifest_path, content, url, headers) do
-    File.mkdir_p!(Path.dirname(cache_path))
-    File.write!(cache_path, content)
-
-    manifest = %{
-      source_url: url,
-      etag: get_header(headers, "etag"),
-      last_modified: get_header(headers, "last-modified"),
-      sha256: :crypto.hash(:sha256, content) |> Base.encode16(case: :lower),
-      size_bytes: byte_size(content),
-      downloaded_at: DateTime.utc_now() |> DateTime.to_iso8601()
-    }
-
-    File.write!(manifest_path, Jason.encode!(manifest, pretty: true))
-  end
-
-  defp build_cond_headers(manifest_path) do
-    case File.read(manifest_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, manifest} ->
-            headers = []
-
-            headers =
-              case Map.get(manifest, "etag") do
-                etag when is_binary(etag) -> [{"if-none-match", etag} | headers]
-                _ -> headers
-              end
-
-            headers =
-              case Map.get(manifest, "last_modified") do
-                last_mod when is_binary(last_mod) -> [{"if-modified-since", last_mod} | headers]
-                _ -> headers
-              end
-
-            headers
-
-          _ ->
-            []
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp get_header(headers, name) do
-    case Enum.find(headers, fn {k, _} -> String.downcase(k) == name end) do
-      {_, [v | _]} when is_list(v) -> v
-      {_, v} when is_binary(v) -> v
-      {_, v} when is_list(v) -> List.first(v)
-      _ -> nil
-    end
   end
 
   # Fields we explicitly map to canonical Zoi fields

--- a/lib/llm_db/sources/remote.ex
+++ b/lib/llm_db/sources/remote.ex
@@ -120,6 +120,8 @@ defmodule LLMDB.Sources.Remote do
     end
   end
 
+  defp fallback_to_cache({:error, {:http_status, _status}} = error, _cache_path), do: error
+
   defp fallback_to_cache({:error, _reason} = error, cache_path) do
     case File.read(cache_path) do
       {:ok, content} -> if match?({:ok, _}, decode(content)), do: {:ok, cache_path}, else: error

--- a/lib/llm_db/sources/remote.ex
+++ b/lib/llm_db/sources/remote.ex
@@ -1,0 +1,198 @@
+defmodule LLMDB.Sources.Remote do
+  @moduledoc false
+
+  @type pull_result :: :noop | {:ok, String.t()} | {:error, term()}
+
+  @spec pull(String.t(), keyword()) :: pull_result()
+  def pull(url, opts) when is_binary(url) and is_list(opts) do
+    {cache_path, manifest_path} = paths(url, opts)
+    req_opts = request_options(manifest_path, opts)
+    request = Keyword.get(opts, :request, &Req.get/2)
+
+    url
+    |> request.(req_opts)
+    |> handle_response(url, cache_path, manifest_path)
+    |> fallback_to_cache(cache_path)
+  end
+
+  @spec load(String.t(), keyword()) :: {:ok, term()} | {:error, term()}
+  def load(url, opts) when is_binary(url) and is_list(opts) do
+    {cache_path, _manifest_path} = paths(url, opts)
+
+    case File.read(cache_path) do
+      {:ok, content} -> decode(content)
+      {:error, :enoent} -> {:error, :no_cache}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec store(String.t(), term(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def store(url, body, opts) when is_binary(url) and is_list(opts) do
+    {cache_path, manifest_path} = paths(url, opts)
+    headers = Keyword.get(opts, :response_headers, [])
+    include_validators? = Keyword.get(opts, :include_validators, false)
+    store_at(url, body, cache_path, manifest_path, headers, include_validators?)
+  end
+
+  @spec cache_path(String.t(), keyword()) :: String.t()
+  def cache_path(url, opts) when is_binary(url) and is_list(opts) do
+    {path, _manifest_path} = paths(url, opts)
+    path
+  end
+
+  @spec request_json(String.t(), keyword()) :: {:ok, term()} | {:error, term()}
+  def request_json(url, req_opts) when is_binary(url) and is_list(req_opts) do
+    request = Keyword.get(req_opts, :request, &Req.get/2)
+    req_opts = req_opts |> Keyword.delete(:request) |> Keyword.put(:decode_body, false)
+
+    case request.(url, req_opts) do
+      {:ok, %Req.Response{status: 200, body: body}} -> decode_body(body)
+      {:ok, %Req.Response{status: status}} -> {:error, {:http_status, status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp paths(url, opts) do
+    cache_dir = Keyword.fetch!(opts, :cache_dir)
+    cache_key = Keyword.fetch!(opts, :cache_key)
+    hash = url |> sha256() |> binary_part(0, 8)
+    basename = "#{cache_key}-#{hash}"
+
+    {
+      Path.join(cache_dir, "#{basename}.json"),
+      Path.join(cache_dir, "#{basename}.manifest.json")
+    }
+  end
+
+  defp request_options(manifest_path, opts) do
+    req_opts = Keyword.get(opts, :req_opts, [])
+
+    headers =
+      conditional_headers(manifest_path) ++
+        Keyword.get(opts, :headers, []) ++ Keyword.get(req_opts, :headers, [])
+
+    req_opts
+    |> Keyword.put(:headers, headers)
+    |> Keyword.put(:decode_body, false)
+  end
+
+  defp handle_response({:ok, %Req.Response{status: 304}}, _url, _cache_path, _manifest_path),
+    do: :noop
+
+  defp handle_response(
+         {:ok, %Req.Response{status: 200, body: body, headers: headers}},
+         url,
+         cache_path,
+         manifest_path
+       ) do
+    store_at(url, body, cache_path, manifest_path, headers, true)
+  end
+
+  defp handle_response({:ok, %Req.Response{status: status}}, _url, _cache_path, _manifest_path),
+    do: {:error, {:http_status, status}}
+
+  defp handle_response({:error, reason}, _url, _cache_path, _manifest_path),
+    do: {:error, reason}
+
+  defp store_at(url, body, cache_path, manifest_path, headers, include_validators?) do
+    with {:ok, decoded} <- decode_body(body),
+         {:ok, content} <- Jason.encode(decoded, pretty: true),
+         :ok <-
+           write_cache(
+             cache_path,
+             manifest_path,
+             content,
+             url,
+             headers,
+             include_validators?
+           ) do
+      {:ok, cache_path}
+    end
+  end
+
+  defp decode_body(body) when is_binary(body), do: decode(body)
+  defp decode_body(body), do: {:ok, body}
+
+  defp decode(content) do
+    case Jason.decode(content) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, reason} -> {:error, {:json_error, reason}}
+    end
+  end
+
+  defp fallback_to_cache({:error, _reason} = error, cache_path) do
+    case File.read(cache_path) do
+      {:ok, content} -> if match?({:ok, _}, decode(content)), do: {:ok, cache_path}, else: error
+      {:error, _reason} -> error
+    end
+  end
+
+  defp fallback_to_cache(result, _cache_path), do: result
+
+  defp write_cache(cache_path, manifest_path, content, url, headers, include_validators?) do
+    manifest =
+      %{
+        source_url: url,
+        sha256: sha256(content),
+        size_bytes: byte_size(content),
+        downloaded_at: DateTime.utc_now() |> DateTime.to_iso8601()
+      }
+      |> maybe_put_validators(headers, include_validators?)
+
+    with :ok <- File.mkdir_p(Path.dirname(cache_path)),
+         :ok <- atomic_write(cache_path, content),
+         {:ok, encoded_manifest} <- Jason.encode(manifest, pretty: true),
+         :ok <- atomic_write(manifest_path, encoded_manifest) do
+      :ok
+    end
+  end
+
+  defp maybe_put_validators(manifest, _headers, false), do: manifest
+
+  defp maybe_put_validators(manifest, headers, true) do
+    manifest
+    |> Map.put(:etag, header(headers, "etag"))
+    |> Map.put(:last_modified, header(headers, "last-modified"))
+  end
+
+  defp atomic_write(path, content) do
+    temporary_path = "#{path}.tmp-#{System.unique_integer([:positive])}"
+
+    with :ok <- File.write(temporary_path, content),
+         :ok <- File.rename(temporary_path, path) do
+      :ok
+    else
+      {:error, _reason} = error ->
+        File.rm(temporary_path)
+        error
+    end
+  end
+
+  defp conditional_headers(manifest_path) do
+    with {:ok, content} <- File.read(manifest_path),
+         {:ok, manifest} when is_map(manifest) <- Jason.decode(content) do
+      []
+      |> maybe_header("if-none-match", Map.get(manifest, "etag"))
+      |> maybe_header("if-modified-since", Map.get(manifest, "last_modified"))
+    else
+      _error -> []
+    end
+  end
+
+  defp maybe_header(headers, _name, value) when not is_binary(value), do: headers
+  defp maybe_header(headers, name, value), do: [{name, value} | headers]
+
+  defp header(headers, name) do
+    case Enum.find(headers, fn {key, _value} -> String.downcase(key) == name end) do
+      {_key, [value | _rest]} when is_binary(value) -> value
+      {_key, value} when is_binary(value) -> value
+      _other -> nil
+    end
+  end
+
+  defp sha256(value) do
+    value
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/llm_db/sources/xai.ex
+++ b/lib/llm_db/sources/xai.ex
@@ -42,7 +42,7 @@ defmodule LLMDB.Sources.XAI do
 
   @behaviour LLMDB.Source
 
-  require Logger
+  alias LLMDB.Sources.Remote
 
   @default_url "https://api.x.ai/v1/models"
   @default_cache_dir "priv/llm_db/remote"
@@ -65,72 +65,22 @@ defmodule LLMDB.Sources.XAI do
 
   defp do_pull(opts, api_key) do
     url = get_url(opts)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
-    manifest_path = manifest_path(url, cache_dir)
-    req_opts = Map.get(opts, :req_opts, [])
 
-    headers = build_headers(api_key)
-    headers = headers ++ Keyword.get(req_opts, :headers, [])
-    req_opts = Keyword.put(req_opts, :headers, headers)
-
-    cond_headers = build_cond_headers(manifest_path)
-    headers = cond_headers ++ Keyword.get(req_opts, :headers, [])
-    req_opts = Keyword.put(req_opts, :headers, headers)
-
-    case Req.get(url, req_opts) do
-      {:ok, %Req.Response{status: 304}} ->
-        :noop
-
-      {:ok, %Req.Response{status: 200, body: body, headers: resp_headers}} ->
-        bin =
-          cond do
-            is_map(body) or is_list(body) ->
-              Jason.encode!(body, pretty: true)
-
-            is_binary(body) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            true ->
-              Jason.encode!(body, pretty: true)
-          end
-
-        write_cache(cache_path, manifest_path, bin, url, resp_headers)
-        {:ok, cache_path}
-
-      {:ok, %Req.Response{status: status}} when status >= 400 ->
-        {:error, {:http_status, status}}
-
-      {:ok, %Req.Response{status: status}} ->
-        Logger.warning("Unexpected status #{status}")
-        {:error, {:http_status, status}}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    Remote.pull(url,
+      cache_dir: get_cache_dir(),
+      cache_key: "xai",
+      headers: build_headers(api_key),
+      req_opts: Map.get(opts, :req_opts, [])
+    )
   end
 
   @impl true
   def load(opts) do
     url = get_url(opts)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
 
-    case File.read(cache_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, decoded} -> {:ok, transform(decoded)}
-          {:error, err} -> {:error, {:json_error, err}}
-        end
-
-      {:error, :enoent} ->
-        {:error, :no_cache}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Remote.load(url, cache_dir: get_cache_dir(), cache_key: "xai") do
+      {:ok, decoded} -> {:ok, transform(decoded)}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -302,72 +252,7 @@ defmodule LLMDB.Sources.XAI do
     Application.get_env(:llm_db, :xai_cache_dir, @default_cache_dir)
   end
 
-  defp cache_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "xai-#{hash}.json")
-  end
-
-  defp manifest_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "xai-#{hash}.manifest.json")
-  end
-
   defp build_headers(api_key) do
     [{"authorization", "Bearer #{api_key}"}]
-  end
-
-  defp write_cache(cache_path, manifest_path, content, url, headers) do
-    File.mkdir_p!(Path.dirname(cache_path))
-    File.write!(cache_path, content)
-
-    manifest = %{
-      source_url: url,
-      etag: get_header(headers, "etag"),
-      last_modified: get_header(headers, "last-modified"),
-      sha256: :crypto.hash(:sha256, content) |> Base.encode16(case: :lower),
-      size_bytes: byte_size(content),
-      downloaded_at: DateTime.utc_now() |> DateTime.to_iso8601()
-    }
-
-    File.write!(manifest_path, Jason.encode!(manifest, pretty: true))
-  end
-
-  defp build_cond_headers(manifest_path) do
-    case File.read(manifest_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, manifest} ->
-            headers = []
-
-            headers =
-              case Map.get(manifest, "etag") do
-                etag when is_binary(etag) -> [{"if-none-match", etag} | headers]
-                _ -> headers
-              end
-
-            headers =
-              case Map.get(manifest, "last_modified") do
-                last_mod when is_binary(last_mod) -> [{"if-modified-since", last_mod} | headers]
-                _ -> headers
-              end
-
-            headers
-
-          _ ->
-            []
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp get_header(headers, name) do
-    case Enum.find(headers, fn {k, _} -> String.downcase(k) == name end) do
-      {_, [v | _]} when is_list(v) -> v
-      {_, v} when is_binary(v) -> v
-      {_, v} when is_list(v) -> List.first(v)
-      _ -> nil
-    end
   end
 end

--- a/lib/llm_db/sources/zenmux.ex
+++ b/lib/llm_db/sources/zenmux.ex
@@ -31,7 +31,7 @@ defmodule LLMDB.Sources.Zenmux do
 
   @behaviour LLMDB.Source
 
-  require Logger
+  alias LLMDB.Sources.Remote
 
   @default_url "https://zenmux.ai/api/v1/models"
   @default_cache_dir "priv/llm_db/remote"
@@ -49,81 +49,22 @@ defmodule LLMDB.Sources.Zenmux do
 
   defp do_pull(opts, api_key) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
-    manifest_path = manifest_path(url, cache_dir)
-    req_opts = Map.get(opts, :req_opts, [])
 
-    headers = build_headers(api_key)
-    headers = headers ++ Keyword.get(req_opts, :headers, [])
-    req_opts = Keyword.put(req_opts, :headers, headers)
-
-    # Disable automatic JSON decoding for more control
-    req_opts = Keyword.put(req_opts, :decode_body, false)
-
-    cond_headers = build_cond_headers(manifest_path)
-    headers = cond_headers ++ Keyword.get(req_opts, :headers, [])
-    req_opts = Keyword.put(req_opts, :headers, headers)
-
-    case Req.get(url, req_opts) do
-      {:ok, %Req.Response{status: 304}} ->
-        :noop
-
-      {:ok, %Req.Response{status: 200, body: body, headers: resp_headers}} ->
-        bin =
-          cond do
-            is_binary(body) and String.starts_with?(body, ["{", "["]) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            is_binary(body) ->
-              case Jason.decode(body) do
-                {:ok, decoded} -> Jason.encode!(decoded, pretty: true)
-                {:error, _} -> body
-              end
-
-            is_map(body) or is_list(body) ->
-              Jason.encode!(body, pretty: true)
-
-            true ->
-              Jason.encode!(body, pretty: true)
-          end
-
-        write_cache(cache_path, manifest_path, bin, url, resp_headers)
-        {:ok, cache_path}
-
-      {:ok, %Req.Response{status: status}} when status >= 400 ->
-        {:error, {:http_status, status}}
-
-      {:ok, %Req.Response{status: status}} ->
-        Logger.warning("Unexpected status #{status}")
-        {:error, {:http_status, status}}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    Remote.pull(url,
+      cache_dir: get_cache_dir(),
+      cache_key: "zenmux",
+      headers: build_headers(api_key),
+      req_opts: Map.get(opts, :req_opts, [])
+    )
   end
 
   @impl true
   def load(opts) do
     url = Map.get(opts, :url, @default_url)
-    cache_dir = get_cache_dir()
-    cache_path = cache_path(url, cache_dir)
 
-    case File.read(cache_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, decoded} -> {:ok, transform(decoded)}
-          {:error, err} -> {:error, {:json_error, err}}
-        end
-
-      {:error, :enoent} ->
-        {:error, :no_cache}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Remote.load(url, cache_dir: get_cache_dir(), cache_key: "zenmux") do
+      {:ok, decoded} -> {:ok, transform(decoded)}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -270,72 +211,7 @@ defmodule LLMDB.Sources.Zenmux do
     Application.get_env(:llm_db, :zenmux_cache_dir, @default_cache_dir)
   end
 
-  defp cache_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "zenmux-#{hash}.json")
-  end
-
-  defp manifest_path(url, cache_dir) do
-    hash = :crypto.hash(:sha256, url) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-    Path.join(cache_dir, "zenmux-#{hash}.manifest.json")
-  end
-
   defp build_headers(api_key) do
     [{"authorization", "Bearer #{api_key}"}]
-  end
-
-  defp write_cache(cache_path, manifest_path, content, url, headers) do
-    File.mkdir_p!(Path.dirname(cache_path))
-    File.write!(cache_path, content)
-
-    manifest = %{
-      source_url: url,
-      etag: get_header(headers, "etag"),
-      last_modified: get_header(headers, "last-modified"),
-      sha256: :crypto.hash(:sha256, content) |> Base.encode16(case: :lower),
-      size_bytes: byte_size(content),
-      downloaded_at: DateTime.utc_now() |> DateTime.to_iso8601()
-    }
-
-    File.write!(manifest_path, Jason.encode!(manifest, pretty: true))
-  end
-
-  defp build_cond_headers(manifest_path) do
-    case File.read(manifest_path) do
-      {:ok, bin} ->
-        case Jason.decode(bin) do
-          {:ok, manifest} ->
-            headers = []
-
-            headers =
-              case Map.get(manifest, "etag") do
-                etag when is_binary(etag) -> [{"if-none-match", etag} | headers]
-                _ -> headers
-              end
-
-            headers =
-              case Map.get(manifest, "last_modified") do
-                last_mod when is_binary(last_mod) -> [{"if-modified-since", last_mod} | headers]
-                _ -> headers
-              end
-
-            headers
-
-          _ ->
-            []
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp get_header(headers, name) do
-    case Enum.find(headers, fn {k, _} -> String.downcase(k) == name end) do
-      {_, [v | _]} when is_list(v) -> v
-      {_, v} when is_binary(v) -> v
-      {_, v} when is_list(v) -> List.first(v)
-      _ -> nil
-    end
   end
 end

--- a/test/llm_db/sources/remote_test.exs
+++ b/test/llm_db/sources/remote_test.exs
@@ -1,0 +1,131 @@
+defmodule LLMDB.Sources.RemoteTest do
+  use ExUnit.Case, async: false
+
+  alias LLMDB.Sources.Remote
+
+  @url "https://example.test/models.json"
+  @remote_opts [cache_dir: "tmp/test/remote", cache_key: "provider"]
+
+  setup do
+    File.rm_rf!(Keyword.fetch!(@remote_opts, :cache_dir))
+    on_exit(fn -> File.rm_rf!(Keyword.fetch!(@remote_opts, :cache_dir)) end)
+  end
+
+  test "writes compatible cache and provenance metadata for a 200 response" do
+    request = fn url, opts ->
+      send(self(), {:request, url, opts})
+
+      {:ok,
+       %Req.Response{
+         status: 200,
+         body: ~s({"models":[{"id":"model-1"}]}),
+         headers: %{"etag" => ["tag-1"], "last-modified" => ["Mon, 01 Jan 2024"]}
+       }}
+    end
+
+    assert {:ok, cache_path} = Remote.pull(@url, @remote_opts ++ [request: request])
+    assert_receive {:request, @url, request_opts}
+    assert request_opts[:decode_body] == false
+
+    assert {:ok, %{"models" => [%{"id" => "model-1"}]}} =
+             Remote.load(@url, @remote_opts)
+
+    content = File.read!(cache_path)
+    manifest = cache_path |> manifest_path() |> File.read!() |> Jason.decode!()
+
+    assert manifest["source_url"] == @url
+    assert manifest["etag"] == "tag-1"
+    assert manifest["last_modified"] == "Mon, 01 Jan 2024"
+    assert manifest["size_bytes"] == byte_size(content)
+    assert manifest["sha256"] == sha256(content)
+    assert is_binary(manifest["downloaded_at"])
+  end
+
+  test "returns noop for a 304 response" do
+    request = fn _url, _opts -> {:ok, %Req.Response{status: 304}} end
+    assert :noop = Remote.pull(@url, @remote_opts ++ [request: request])
+  end
+
+  test "returns transport errors when there is no usable cache" do
+    request = fn _url, _opts -> {:error, :timeout} end
+    assert {:error, :timeout} = Remote.pull(@url, @remote_opts ++ [request: request])
+  end
+
+  test "keeps a valid stale cache on timeout and invalid JSON" do
+    cache_path = seed_cache!()
+    original = File.read!(cache_path)
+
+    timeout = fn _url, _opts -> {:error, :timeout} end
+    assert {:ok, ^cache_path} = Remote.pull(@url, @remote_opts ++ [request: timeout])
+
+    invalid_json = fn _url, _opts ->
+      {:ok, %Req.Response{status: 200, body: "not-json", headers: %{}}}
+    end
+
+    assert {:ok, ^cache_path} = Remote.pull(@url, @remote_opts ++ [request: invalid_json])
+    assert File.read!(cache_path) == original
+  end
+
+  test "reports invalid JSON when there is no stale cache" do
+    request = fn _url, _opts ->
+      {:ok, %Req.Response{status: 200, body: "not-json", headers: %{}}}
+    end
+
+    assert {:error, {:json_error, %Jason.DecodeError{}}} =
+             Remote.pull(@url, @remote_opts ++ [request: request])
+  end
+
+  test "ignores a corrupt manifest and refreshes without conditional headers" do
+    cache_path = seed_cache!()
+    File.write!(manifest_path(cache_path), "not-json")
+
+    request = fn _url, opts ->
+      refute List.keymember?(opts[:headers], "if-none-match", 0)
+      refute List.keymember?(opts[:headers], "if-modified-since", 0)
+
+      {:ok, %Req.Response{status: 200, body: ~s({"version":2}), headers: %{}}}
+    end
+
+    assert {:ok, ^cache_path} = Remote.pull(@url, @remote_opts ++ [request: request])
+    assert {:ok, %{"version" => 2}} = Remote.load(@url, @remote_opts)
+  end
+
+  test "adds conditional headers from a valid manifest" do
+    cache_path = seed_cache!()
+
+    manifest =
+      cache_path
+      |> manifest_path()
+      |> File.read!()
+      |> Jason.decode!()
+      |> Map.merge(%{"etag" => "tag-1", "last_modified" => "Mon, 01 Jan 2024"})
+
+    File.write!(manifest_path(cache_path), Jason.encode!(manifest))
+
+    request = fn _url, opts ->
+      assert {"if-none-match", "tag-1"} in opts[:headers]
+      assert {"if-modified-since", "Mon, 01 Jan 2024"} in opts[:headers]
+      {:ok, %Req.Response{status: 304}}
+    end
+
+    assert :noop = Remote.pull(@url, @remote_opts ++ [request: request])
+  end
+
+  defp seed_cache! do
+    request = fn _url, _opts ->
+      {:ok, %Req.Response{status: 200, body: ~s({"version":1}), headers: %{}}}
+    end
+
+    {:ok, cache_path} = Remote.pull(@url, @remote_opts ++ [request: request])
+    cache_path
+  end
+
+  defp manifest_path(cache_path),
+    do: String.replace_suffix(cache_path, ".json", ".manifest.json")
+
+  defp sha256(content) do
+    content
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+end

--- a/test/llm_db/sources/remote_test.exs
+++ b/test/llm_db/sources/remote_test.exs
@@ -66,6 +66,20 @@ defmodule LLMDB.Sources.RemoteTest do
     assert File.read!(cache_path) == original
   end
 
+  test "does not hide HTTP status failures behind a stale cache" do
+    cache_path = seed_cache!()
+    original = File.read!(cache_path)
+
+    for status <- [401, 404, 429, 500] do
+      request = fn _url, _opts -> {:ok, %Req.Response{status: status}} end
+
+      assert {:error, {:http_status, ^status}} =
+               Remote.pull(@url, @remote_opts ++ [request: request])
+
+      assert File.read!(cache_path) == original
+    end
+  end
+
   test "reports invalid JSON when there is no stale cache" do
     request = fn _url, _opts ->
       {:ok, %Req.Response{status: 200, body: "not-json", headers: %{}}}


### PR DESCRIPTION
Closes #247

## Summary
- add one internal remote JSON transport for HTTP status handling, decoding, URL/content hashing, atomic cache writes, manifests, conditional requests, and stale-cache fallback
- migrate Models.dev, OpenRouter, OpenAI, xAI, ZenMux, Google, Anthropic, and llmfit while preserving cache filenames and source callbacks
- retain pagination and provider normalization as adapter-specific policy
- cover 200, 304, timeout, invalid JSON, stale cache, conditional headers, and corrupt manifests without external network access

## Verification
- `mix test test/llm_db/sources test/mix/tasks/llm_db.pull_test.exs test/llm_db/tooling_boundary_test.exs test/llm_db/package_manifest_test.exs` (60 passed)
- `mix llm_db.build --check --install`
- `mix quality`