### PR TITLE
refactor: consolidate history diff and lineage

### DIFF
--- a/guides/runtime-and-maintainer-boundaries.md
+++ b/guides/runtime-and-maintainer-boundaries.md
@@ -67,7 +67,7 @@ No module or task is removed in this minor release.
 | `LLMDB.Dotenv.load!/1` | `mix llm_db.pull` | Compiler-deprecated; pull remains task-scoped |
 | `LLMDB.Store` query calls | Equivalent `LLMDB` query/load calls | Compatibility facade; direct use is documentation-deprecated |
 | `LLMDB.Engine.run/1`, `LLMDB.Snapshot.Builder` | `mix llm_db.build` | Documentation-deprecated maintainer orchestration |
-| `LLMDB.History.Backfill`, `LLMDB.History.Migrator`, `LLMDB.History.Rebuilder`, `LLMDB.History.Bundle` | Corresponding `mix llm_db.history.*` task | Documentation-deprecated maintainer orchestration |
+| `LLMDB.History.Backfill`, `LLMDB.History.Migrator`, `LLMDB.History.Rebuilder`, `LLMDB.History.Bundle`, `LLMDB.History.Diff`, `LLMDB.History.Lineage` | Corresponding `mix llm_db.history.*` task | Documentation-deprecated maintainer orchestration with internal shared diff/lineage logic |
 | `LLMDB.Snapshot.ReleaseStore` mutation/publishing calls | `mix llm_db.snapshot.publish` or `mix llm_db.history.rebuild --publish` | Internal shared transport; runtime fetch behavior remains supported through configuration |
 | `LLMDB.Enrich`, `LLMDB.Validate`, `LLMDB.Enrich.AzureWireProtocol`, `LLMDB.Enrich.RuntimeContract` | `mix llm_db.build` | Internal ETL stages |
 | LLMDB.Sources.Anthropic, LLMDB.Sources.Google, LLMDB.Sources.Llmfit, LLMDB.Sources.Local, LLMDB.Sources.ModelsDev, LLMDB.Sources.OpenAI, LLMDB.Sources.OpenRouter, LLMDB.Sources.Remote, LLMDB.Sources.XAI, LLMDB.Sources.Zenmux | `LLMDB.Source` for extensions; `mix llm_db.pull`/`build` for workflows | Internal bundled adapters and shared remote transport |

--- a/lib/llm_db/history/backfill.ex
+++ b/lib/llm_db/history/backfill.ex
@@ -11,15 +11,12 @@ defmodule LLMDB.History.Backfill do
   `mix llm_db.history.migrate_git`.
   """
 
+  alias LLMDB.History.{Diff, Lineage}
+
   @providers_dir "priv/llm_db/providers"
   @manifest_path "priv/llm_db/manifest.json"
   @default_output_dir Path.join(["priv", "llm_db", "history"])
   @lineage_overrides_file "lineage_overrides.json"
-
-  @sortable_list_keys MapSet.new(["aliases", "tags", "input", "output"])
-
-  # Keep inference conservative. Use lineage overrides for ambiguous migrations.
-  @lineage_inference_threshold 30
 
   @type summary :: %{
           commits_scanned: non_neg_integer(),
@@ -137,53 +134,13 @@ defmodule LLMDB.History.Backfill do
   @spec diff_models(%{optional(String.t()) => map()}, %{optional(String.t()) => map()}) :: [map()]
   def diff_models(previous_models, current_models)
       when is_map(previous_models) and is_map(current_models) do
-    previous_keys = Map.keys(previous_models) |> MapSet.new()
-    current_keys = Map.keys(current_models) |> MapSet.new()
-
-    introduced =
-      MapSet.difference(current_keys, previous_keys)
-      |> MapSet.to_list()
-      |> Enum.sort()
-      |> Enum.map(fn model_key ->
-        %{type: "introduced", model_key: model_key, changes: []}
-      end)
-
-    removed =
-      MapSet.difference(previous_keys, current_keys)
-      |> MapSet.to_list()
-      |> Enum.sort()
-      |> Enum.map(fn model_key ->
-        %{type: "removed", model_key: model_key, changes: []}
-      end)
-
-    changed =
-      MapSet.intersection(previous_keys, current_keys)
-      |> MapSet.to_list()
-      |> Enum.sort()
-      |> Enum.reduce([], fn model_key, acc ->
-        before_model = Map.fetch!(previous_models, model_key)
-        after_model = Map.fetch!(current_models, model_key)
-        changes = deep_changes(before_model, after_model, [])
-
-        if changes == [] do
-          acc
-        else
-          [%{type: "changed", model_key: model_key, changes: changes} | acc]
-        end
-      end)
-      |> Enum.reverse()
-
-    introduced ++ removed ++ changed
+    Diff.models(previous_models, current_models)
   end
 
   @doc false
   @spec snapshot_digest(%{optional(String.t()) => map()}) :: String.t()
   def snapshot_digest(models) when is_map(models) do
-    models
-    |> canonical_digest_term()
-    |> :erlang.term_to_binary()
-    |> then(&:crypto.hash(:sha256, &1))
-    |> Base.encode16(case: :lower)
+    Diff.snapshot_digest(models)
   end
 
   # Internal pipeline
@@ -561,8 +518,8 @@ defmodule LLMDB.History.Backfill do
 
       {:ok, state_by_file} ->
         models = flatten_state_models(state_by_file)
-        lineage_by_key = initialize_lineage(models, acc.lineage_overrides)
-        events = diff_models(%{}, models) |> attach_lineage(%{}, lineage_by_key)
+        lineage_by_key = Lineage.initialize(models, acc.lineage_overrides)
+        events = diff_models(%{}, models) |> Lineage.attach(%{}, lineage_by_key)
         commit_date = commit_date_iso8601(sha)
         manifest_generated_at = manifest_generated_at(sha)
 
@@ -596,7 +553,7 @@ defmodule LLMDB.History.Backfill do
     current_models = flatten_state_models(next_state_by_file)
 
     current_lineage_by_key =
-      resolve_current_lineage(
+      Lineage.resolve(
         previous_models,
         current_models,
         previous_lineage_by_key,
@@ -605,7 +562,7 @@ defmodule LLMDB.History.Backfill do
 
     events =
       diff_models(previous_models, current_models)
-      |> attach_lineage(previous_lineage_by_key, current_lineage_by_key)
+      |> Lineage.attach(previous_lineage_by_key, current_lineage_by_key)
 
     if events == [] do
       %{
@@ -644,293 +601,6 @@ defmodule LLMDB.History.Backfill do
           previous_lineage_by_key: current_lineage_by_key
       }
     end
-  end
-
-  defp initialize_lineage(models, lineage_overrides) do
-    models
-    |> Map.keys()
-    |> Enum.sort()
-    |> Enum.reduce(%{}, fn model_key, acc ->
-      lineage = lineage_for_model_key(model_key, lineage_overrides, %{}, acc, model_key)
-      Map.put(acc, model_key, lineage)
-    end)
-  end
-
-  defp resolve_current_lineage(
-         previous_models,
-         current_models,
-         previous_lineage_by_key,
-         lineage_overrides
-       ) do
-    previous_keys = Map.keys(previous_models) |> MapSet.new()
-    current_keys = Map.keys(current_models) |> MapSet.new()
-
-    shared_keys =
-      MapSet.intersection(previous_keys, current_keys)
-      |> MapSet.to_list()
-      |> Enum.sort()
-
-    removed_keys =
-      MapSet.difference(previous_keys, current_keys)
-      |> MapSet.to_list()
-      |> Enum.sort()
-
-    introduced_keys =
-      MapSet.difference(current_keys, previous_keys)
-      |> MapSet.to_list()
-      |> Enum.sort()
-
-    current_lineage_by_key =
-      Enum.reduce(shared_keys, %{}, fn model_key, acc ->
-        default_lineage = Map.get(previous_lineage_by_key, model_key, model_key)
-
-        lineage =
-          lineage_for_model_key(
-            model_key,
-            lineage_overrides,
-            previous_lineage_by_key,
-            acc,
-            default_lineage
-          )
-
-        Map.put(acc, model_key, lineage)
-      end)
-
-    {current_lineage_by_key, unresolved_introduced} =
-      Enum.reduce(introduced_keys, {current_lineage_by_key, []}, fn model_key,
-                                                                    {acc, unresolved} ->
-        if Map.has_key?(lineage_overrides, model_key) do
-          lineage =
-            lineage_for_model_key(
-              model_key,
-              lineage_overrides,
-              previous_lineage_by_key,
-              acc,
-              model_key
-            )
-
-          {Map.put(acc, model_key, lineage), unresolved}
-        else
-          {acc, [model_key | unresolved]}
-        end
-      end)
-
-    unresolved_introduced = Enum.reverse(unresolved_introduced)
-
-    inferred_matches =
-      infer_lineage_matches(removed_keys, unresolved_introduced, previous_models, current_models)
-
-    {current_lineage_by_key, matched_introduced} =
-      Enum.reduce(inferred_matches, {current_lineage_by_key, MapSet.new()}, fn {new_key, old_key},
-                                                                               {acc, matched} ->
-        default_lineage = Map.get(previous_lineage_by_key, old_key, old_key)
-
-        lineage =
-          lineage_for_model_key(
-            new_key,
-            lineage_overrides,
-            previous_lineage_by_key,
-            acc,
-            default_lineage
-          )
-
-        {Map.put(acc, new_key, lineage), MapSet.put(matched, new_key)}
-      end)
-
-    Enum.reduce(unresolved_introduced, current_lineage_by_key, fn model_key, acc ->
-      if MapSet.member?(matched_introduced, model_key) do
-        acc
-      else
-        lineage =
-          lineage_for_model_key(
-            model_key,
-            lineage_overrides,
-            previous_lineage_by_key,
-            acc,
-            model_key
-          )
-
-        Map.put(acc, model_key, lineage)
-      end
-    end)
-  end
-
-  defp infer_lineage_matches(removed_keys, introduced_keys, previous_models, current_models) do
-    candidates =
-      for removed_key <- removed_keys,
-          introduced_key <- introduced_keys,
-          score =
-            lineage_inference_score(
-              Map.get(previous_models, removed_key, %{}),
-              Map.get(current_models, introduced_key, %{})
-            ),
-          score >= @lineage_inference_threshold do
-        {score, introduced_key, removed_key}
-      end
-
-    candidates
-    |> Enum.sort_by(fn {score, introduced_key, removed_key} ->
-      {-score, introduced_key, removed_key}
-    end)
-    |> Enum.reduce({[], MapSet.new(), MapSet.new()}, fn {_score, introduced_key, removed_key},
-                                                        {acc, claimed_new, claimed_old} ->
-      cond do
-        MapSet.member?(claimed_new, introduced_key) ->
-          {acc, claimed_new, claimed_old}
-
-        MapSet.member?(claimed_old, removed_key) ->
-          {acc, claimed_new, claimed_old}
-
-        true ->
-          {
-            [{introduced_key, removed_key} | acc],
-            MapSet.put(claimed_new, introduced_key),
-            MapSet.put(claimed_old, removed_key)
-          }
-      end
-    end)
-    |> elem(0)
-    |> Enum.reverse()
-  end
-
-  defp lineage_inference_score(previous_model, current_model)
-       when is_map(previous_model) and is_map(current_model) do
-    previous_id = Map.get(previous_model, "id")
-    current_id = Map.get(current_model, "id")
-
-    previous_provider_model_id = Map.get(previous_model, "provider_model_id")
-    current_provider_model_id = Map.get(current_model, "provider_model_id")
-
-    previous_aliases = string_list(Map.get(previous_model, "aliases"))
-    current_aliases = string_list(Map.get(current_model, "aliases"))
-
-    alias_overlap = overlap_count(previous_aliases, current_aliases)
-
-    id_match_score =
-      if is_binary(previous_id) and previous_id == current_id do
-        50
-      else
-        0
-      end
-
-    provider_model_score =
-      if is_binary(previous_provider_model_id) and
-           previous_provider_model_id == current_provider_model_id do
-        40
-      else
-        0
-      end
-
-    previous_id_in_current_aliases_score =
-      if is_binary(previous_id) and previous_id in current_aliases do
-        30
-      else
-        0
-      end
-
-    current_id_in_previous_aliases_score =
-      if is_binary(current_id) and current_id in previous_aliases do
-        30
-      else
-        0
-      end
-
-    model_field_score =
-      if is_binary(Map.get(previous_model, "model")) and
-           Map.get(previous_model, "model") == Map.get(current_model, "model") do
-        5
-      else
-        0
-      end
-
-    name_field_score =
-      if is_binary(Map.get(previous_model, "name")) and
-           Map.get(previous_model, "name") == Map.get(current_model, "name") do
-        2
-      else
-        0
-      end
-
-    id_match_score + provider_model_score + previous_id_in_current_aliases_score +
-      current_id_in_previous_aliases_score + alias_overlap * 5 + model_field_score +
-      name_field_score
-  end
-
-  defp string_list(value) when is_list(value) do
-    value
-    |> Enum.filter(&is_binary/1)
-    |> Enum.uniq()
-  end
-
-  defp string_list(_), do: []
-
-  defp overlap_count(left, right) do
-    right_lookup = Map.new(right, &{&1, true})
-    Enum.count(left, &Map.has_key?(right_lookup, &1))
-  end
-
-  defp lineage_for_model_key(
-         model_key,
-         lineage_overrides,
-         previous_lineage_by_key,
-         current_lineage_by_key,
-         default_lineage
-       ) do
-    case resolve_override_target(model_key, lineage_overrides) do
-      nil ->
-        default_lineage
-
-      target_key ->
-        Map.get(current_lineage_by_key, target_key) ||
-          Map.get(previous_lineage_by_key, target_key) ||
-          target_key
-    end
-  end
-
-  defp resolve_override_target(model_key, lineage_overrides) do
-    if Map.has_key?(lineage_overrides, model_key) do
-      follow_override_target(model_key, lineage_overrides, [], 0)
-    else
-      nil
-    end
-  end
-
-  defp follow_override_target(model_key, _lineage_overrides, _seen, depth) when depth >= 32,
-    do: model_key
-
-  defp follow_override_target(model_key, lineage_overrides, seen, depth) do
-    if model_key in seen do
-      model_key
-    else
-      case Map.get(lineage_overrides, model_key) do
-        nil ->
-          model_key
-
-        target when is_binary(target) ->
-          follow_override_target(
-            target,
-            lineage_overrides,
-            [model_key | seen],
-            depth + 1
-          )
-      end
-    end
-  end
-
-  defp attach_lineage(events, previous_lineage_by_key, current_lineage_by_key) do
-    Enum.map(events, fn event ->
-      lineage_key =
-        case event.type do
-          "removed" ->
-            Map.get(previous_lineage_by_key, event.model_key, event.model_key)
-
-          _ ->
-            Map.get(current_lineage_by_key, event.model_key) ||
-              Map.get(previous_lineage_by_key, event.model_key, event.model_key)
-        end
-
-      Map.put(event, :lineage_key, lineage_key)
-    end)
   end
 
   defp load_previous_lineage(output_dir, model_keys, previous_models) do
@@ -1028,7 +698,7 @@ defmodule LLMDB.History.Backfill do
               model_data
               |> Map.put_new("id", model_id)
               |> Map.put_new("provider", provider_id)
-              |> normalize_value([])
+              |> Diff.normalize()
 
             Map.put(acc, "#{provider_id}:#{model_id}", model)
           end)
@@ -1044,93 +714,6 @@ defmodule LLMDB.History.Backfill do
     Enum.reduce(state_by_file, %{}, fn {_path, models}, acc ->
       Map.merge(acc, models)
     end)
-  end
-
-  defp normalize_value(value, path)
-
-  defp normalize_value(value, path) when is_map(value) do
-    value
-    |> Enum.map(fn {k, v} -> {k, normalize_value(v, [to_string(k) | path])} end)
-    |> Map.new()
-  end
-
-  defp normalize_value(value, path) when is_list(value) do
-    normalized = Enum.map(value, &normalize_value(&1, path))
-
-    case path do
-      [key | _] ->
-        if key in @sortable_list_keys and Enum.all?(normalized, &scalar?/1) do
-          Enum.sort(normalized)
-        else
-          normalized
-        end
-
-      _ ->
-        normalized
-    end
-  end
-
-  defp normalize_value(value, _path), do: value
-
-  defp scalar?(value),
-    do: is_binary(value) or is_number(value) or is_boolean(value) or is_nil(value)
-
-  defp deep_changes(before_value, after_value, path)
-
-  defp deep_changes(before_value, after_value, path)
-       when is_map(before_value) and is_map(after_value) do
-    keys =
-      (Map.keys(before_value) ++ Map.keys(after_value))
-      |> Enum.uniq()
-      |> Enum.sort()
-
-    Enum.flat_map(keys, fn key ->
-      in_before = Map.has_key?(before_value, key)
-      in_after = Map.has_key?(after_value, key)
-      next_path = path ++ [to_string(key)]
-
-      cond do
-        in_before and in_after ->
-          deep_changes(Map.get(before_value, key), Map.get(after_value, key), next_path)
-
-        in_before ->
-          [
-            %{
-              path: Enum.join(next_path, "."),
-              op: "remove",
-              before: Map.get(before_value, key),
-              after: nil
-            }
-          ]
-
-        in_after ->
-          [
-            %{
-              path: Enum.join(next_path, "."),
-              op: "add",
-              before: nil,
-              after: Map.get(after_value, key)
-            }
-          ]
-      end
-    end)
-  end
-
-  defp deep_changes(before_value, after_value, path)
-       when is_list(before_value) and is_list(after_value) do
-    if before_value == after_value do
-      []
-    else
-      [%{path: Enum.join(path, "."), op: "replace", before: before_value, after: after_value}]
-    end
-  end
-
-  defp deep_changes(before_value, after_value, path) do
-    if before_value == after_value do
-      []
-    else
-      [%{path: Enum.join(path, "."), op: "replace", before: before_value, after: after_value}]
-    end
   end
 
   defp write_snapshot(sha, commit_date, manifest_generated_at, models, events, output_dir) do
@@ -1264,27 +847,6 @@ defmodule LLMDB.History.Backfill do
     line = Jason.encode!(map) <> "\n"
     File.write!(path, line, [:append])
   end
-
-  defp canonical_digest_term(value) when is_map(value) do
-    entries =
-      value
-      |> Enum.map(fn {key, nested} -> {key, canonical_digest_term(nested)} end)
-      |> Enum.sort_by(fn {key, _nested} -> canonical_sort_key(key) end)
-
-    {:map, entries}
-  end
-
-  defp canonical_digest_term(value) when is_list(value) do
-    {:list, Enum.map(value, &canonical_digest_term/1)}
-  end
-
-  defp canonical_digest_term(value), do: value
-
-  defp canonical_sort_key(value) when is_binary(value), do: {0, value}
-  defp canonical_sort_key(value) when is_atom(value), do: {1, Atom.to_string(value)}
-  defp canonical_sort_key(value) when is_integer(value), do: {2, value}
-  defp canonical_sort_key(value) when is_float(value), do: {3, value}
-  defp canonical_sort_key(value), do: {6, inspect(value)}
 
   defp commit_date_iso8601(sha) do
     case git(["show", "-s", "--format=%cI", sha]) do

--- a/lib/llm_db/history/diff.ex
+++ b/lib/llm_db/history/diff.ex
@@ -1,0 +1,158 @@
+defmodule LLMDB.History.Diff do
+  @moduledoc false
+
+  @sortable_list_keys MapSet.new(["aliases", "tags", "input", "output"])
+
+  @spec models(%{optional(String.t()) => map()}, %{optional(String.t()) => map()}) :: [map()]
+  def models(previous_models, current_models)
+      when is_map(previous_models) and is_map(current_models) do
+    previous_keys = Map.keys(previous_models) |> MapSet.new()
+    current_keys = Map.keys(current_models) |> MapSet.new()
+
+    introduced =
+      current_keys
+      |> MapSet.difference(previous_keys)
+      |> MapSet.to_list()
+      |> Enum.sort()
+      |> Enum.map(&%{type: "introduced", model_key: &1, changes: []})
+
+    removed =
+      previous_keys
+      |> MapSet.difference(current_keys)
+      |> MapSet.to_list()
+      |> Enum.sort()
+      |> Enum.map(&%{type: "removed", model_key: &1, changes: []})
+
+    changed =
+      previous_keys
+      |> MapSet.intersection(current_keys)
+      |> MapSet.to_list()
+      |> Enum.sort()
+      |> Enum.reduce([], fn model_key, acc ->
+        changes =
+          deep_changes(
+            Map.fetch!(previous_models, model_key),
+            Map.fetch!(current_models, model_key),
+            []
+          )
+
+        if changes == [] do
+          acc
+        else
+          [%{type: "changed", model_key: model_key, changes: changes} | acc]
+        end
+      end)
+      |> Enum.reverse()
+
+    introduced ++ removed ++ changed
+  end
+
+  @spec normalize(term()) :: term()
+  def normalize(value), do: normalize_value(value, [])
+
+  @spec snapshot_digest(%{optional(String.t()) => map()}) :: String.t()
+  def snapshot_digest(models) when is_map(models) do
+    models
+    |> canonical_digest_term()
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  defp normalize_value(value, path) when is_map(value) do
+    value
+    |> Enum.map(fn {key, nested} ->
+      {key, normalize_value(nested, [to_string(key) | path])}
+    end)
+    |> Map.new()
+  end
+
+  defp normalize_value(value, path) when is_list(value) do
+    normalized = Enum.map(value, &normalize_value(&1, path))
+
+    case path do
+      [key | _rest] ->
+        if key in @sortable_list_keys and Enum.all?(normalized, &scalar?/1) do
+          Enum.sort(normalized)
+        else
+          normalized
+        end
+
+      [] ->
+        normalized
+    end
+  end
+
+  defp normalize_value(value, _path), do: value
+
+  defp scalar?(value),
+    do: is_binary(value) or is_number(value) or is_boolean(value) or is_nil(value)
+
+  defp deep_changes(before_value, after_value, path)
+       when is_map(before_value) and is_map(after_value) do
+    keys =
+      (Map.keys(before_value) ++ Map.keys(after_value))
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    Enum.flat_map(keys, fn key ->
+      in_before = Map.has_key?(before_value, key)
+      in_after = Map.has_key?(after_value, key)
+      next_path = path ++ [to_string(key)]
+
+      cond do
+        in_before and in_after ->
+          deep_changes(Map.get(before_value, key), Map.get(after_value, key), next_path)
+
+        in_before ->
+          [
+            %{
+              path: Enum.join(next_path, "."),
+              op: "remove",
+              before: Map.get(before_value, key),
+              after: nil
+            }
+          ]
+
+        in_after ->
+          [
+            %{
+              path: Enum.join(next_path, "."),
+              op: "add",
+              before: nil,
+              after: Map.get(after_value, key)
+            }
+          ]
+      end
+    end)
+  end
+
+  defp deep_changes(before_value, after_value, path) do
+    if before_value == after_value do
+      []
+    else
+      [%{path: Enum.join(path, "."), op: "replace", before: before_value, after: after_value}]
+    end
+  end
+
+  defp canonical_digest_term(value) when is_map(value) do
+    entries =
+      value
+      |> Enum.map(fn {key, nested} -> {key, canonical_digest_term(nested)} end)
+      |> Enum.sort_by(fn {key, _nested} -> canonical_sort_key(key) end)
+
+    {:map, entries}
+  end
+
+  defp canonical_digest_term(value) when is_list(value) do
+    {:list, Enum.map(value, &canonical_digest_term/1)}
+  end
+
+  defp canonical_digest_term(value), do: value
+
+  defp canonical_sort_key(value) when is_binary(value), do: {0, value}
+  defp canonical_sort_key(value) when is_atom(value), do: {1, Atom.to_string(value)}
+  defp canonical_sort_key(value) when is_integer(value), do: {2, value}
+  defp canonical_sort_key(value) when is_float(value), do: {3, value}
+  defp canonical_sort_key(value), do: {6, inspect(value)}
+end

--- a/lib/llm_db/history/lineage.ex
+++ b/lib/llm_db/history/lineage.ex
@@ -1,0 +1,272 @@
+defmodule LLMDB.History.Lineage do
+  @moduledoc false
+
+  @lineage_inference_threshold 30
+
+  @spec initialize(map(), map()) :: map()
+  def initialize(models, lineage_overrides) when is_map(models) and is_map(lineage_overrides) do
+    models
+    |> Map.keys()
+    |> Enum.sort()
+    |> Enum.reduce(%{}, fn model_key, acc ->
+      lineage = lineage_for_model_key(model_key, lineage_overrides, %{}, acc, model_key)
+      Map.put(acc, model_key, lineage)
+    end)
+  end
+
+  @spec resolve(map(), map(), map(), map()) :: map()
+  def resolve(previous_models, current_models, previous_lineage_by_key, lineage_overrides)
+      when is_map(previous_models) and is_map(current_models) and
+             is_map(previous_lineage_by_key) and is_map(lineage_overrides) do
+    previous_keys = Map.keys(previous_models) |> MapSet.new()
+    current_keys = Map.keys(current_models) |> MapSet.new()
+
+    shared_keys = previous_keys |> MapSet.intersection(current_keys) |> sorted_keys()
+    removed_keys = sorted_difference(previous_keys, current_keys)
+    introduced_keys = sorted_difference(current_keys, previous_keys)
+
+    current_lineage_by_key =
+      Enum.reduce(shared_keys, %{}, fn model_key, acc ->
+        default_lineage = Map.get(previous_lineage_by_key, model_key, model_key)
+
+        lineage =
+          lineage_for_model_key(
+            model_key,
+            lineage_overrides,
+            previous_lineage_by_key,
+            acc,
+            default_lineage
+          )
+
+        Map.put(acc, model_key, lineage)
+      end)
+
+    {current_lineage_by_key, unresolved_introduced} =
+      Enum.reduce(introduced_keys, {current_lineage_by_key, []}, fn model_key,
+                                                                    {acc, unresolved} ->
+        if Map.has_key?(lineage_overrides, model_key) do
+          lineage =
+            lineage_for_model_key(
+              model_key,
+              lineage_overrides,
+              previous_lineage_by_key,
+              acc,
+              model_key
+            )
+
+          {Map.put(acc, model_key, lineage), unresolved}
+        else
+          {acc, [model_key | unresolved]}
+        end
+      end)
+
+    unresolved_introduced = Enum.reverse(unresolved_introduced)
+
+    inferred_matches =
+      infer_matches(removed_keys, unresolved_introduced, previous_models, current_models)
+
+    {current_lineage_by_key, matched_introduced} =
+      Enum.reduce(inferred_matches, {current_lineage_by_key, MapSet.new()}, fn {new_key, old_key},
+                                                                               {acc, matched} ->
+        default_lineage = Map.get(previous_lineage_by_key, old_key, old_key)
+
+        lineage =
+          lineage_for_model_key(
+            new_key,
+            lineage_overrides,
+            previous_lineage_by_key,
+            acc,
+            default_lineage
+          )
+
+        {Map.put(acc, new_key, lineage), MapSet.put(matched, new_key)}
+      end)
+
+    Enum.reduce(unresolved_introduced, current_lineage_by_key, fn model_key, acc ->
+      if MapSet.member?(matched_introduced, model_key) do
+        acc
+      else
+        lineage =
+          lineage_for_model_key(
+            model_key,
+            lineage_overrides,
+            previous_lineage_by_key,
+            acc,
+            model_key
+          )
+
+        Map.put(acc, model_key, lineage)
+      end
+    end)
+  end
+
+  @spec attach([map()], map(), map()) :: [map()]
+  def attach(events, previous_lineage_by_key, current_lineage_by_key)
+      when is_list(events) and is_map(previous_lineage_by_key) and
+             is_map(current_lineage_by_key) do
+    Enum.map(events, fn event ->
+      lineage_key =
+        case event.type do
+          "removed" ->
+            Map.get(previous_lineage_by_key, event.model_key, event.model_key)
+
+          _other ->
+            Map.get(current_lineage_by_key, event.model_key) ||
+              Map.get(previous_lineage_by_key, event.model_key, event.model_key)
+        end
+
+      Map.put(event, :lineage_key, lineage_key)
+    end)
+  end
+
+  defp sorted_difference(left, right) do
+    left
+    |> MapSet.difference(right)
+    |> sorted_keys()
+  end
+
+  defp sorted_keys(keys) do
+    keys
+    |> MapSet.to_list()
+    |> Enum.sort()
+  end
+
+  defp infer_matches(removed_keys, introduced_keys, previous_models, current_models) do
+    candidates =
+      for removed_key <- removed_keys,
+          introduced_key <- introduced_keys,
+          score =
+            inference_score(
+              Map.get(previous_models, removed_key, %{}),
+              Map.get(current_models, introduced_key, %{})
+            ),
+          score >= @lineage_inference_threshold do
+        {score, introduced_key, removed_key}
+      end
+
+    candidates
+    |> Enum.sort_by(fn {score, introduced_key, removed_key} ->
+      {-score, introduced_key, removed_key}
+    end)
+    |> Enum.reduce({[], MapSet.new(), MapSet.new()}, fn {_score, introduced_key, removed_key},
+                                                        {acc, claimed_new, claimed_old} ->
+      cond do
+        MapSet.member?(claimed_new, introduced_key) ->
+          {acc, claimed_new, claimed_old}
+
+        MapSet.member?(claimed_old, removed_key) ->
+          {acc, claimed_new, claimed_old}
+
+        true ->
+          {
+            [{introduced_key, removed_key} | acc],
+            MapSet.put(claimed_new, introduced_key),
+            MapSet.put(claimed_old, removed_key)
+          }
+      end
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+  end
+
+  defp inference_score(previous_model, current_model)
+       when is_map(previous_model) and is_map(current_model) do
+    previous_id = Map.get(previous_model, "id")
+    current_id = Map.get(current_model, "id")
+    previous_provider_model_id = Map.get(previous_model, "provider_model_id")
+    current_provider_model_id = Map.get(current_model, "provider_model_id")
+    previous_aliases = string_list(Map.get(previous_model, "aliases"))
+    current_aliases = string_list(Map.get(current_model, "aliases"))
+
+    id_match_score = score(is_binary(previous_id) and previous_id == current_id, 50)
+
+    provider_model_score =
+      score(
+        is_binary(previous_provider_model_id) and
+          previous_provider_model_id == current_provider_model_id,
+        40
+      )
+
+    previous_id_in_current_aliases_score =
+      score(is_binary(previous_id) and previous_id in current_aliases, 30)
+
+    current_id_in_previous_aliases_score =
+      score(is_binary(current_id) and current_id in previous_aliases, 30)
+
+    model_field_score =
+      score(
+        is_binary(Map.get(previous_model, "model")) and
+          Map.get(previous_model, "model") == Map.get(current_model, "model"),
+        5
+      )
+
+    name_field_score =
+      score(
+        is_binary(Map.get(previous_model, "name")) and
+          Map.get(previous_model, "name") == Map.get(current_model, "name"),
+        2
+      )
+
+    id_match_score + provider_model_score + previous_id_in_current_aliases_score +
+      current_id_in_previous_aliases_score +
+      overlap_count(previous_aliases, current_aliases) * 5 + model_field_score +
+      name_field_score
+  end
+
+  defp score(true, value), do: value
+  defp score(false, _value), do: 0
+
+  defp string_list(value) when is_list(value) do
+    value
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+  end
+
+  defp string_list(_value), do: []
+
+  defp overlap_count(left, right) do
+    right_lookup = MapSet.new(right)
+    Enum.count(left, &MapSet.member?(right_lookup, &1))
+  end
+
+  defp lineage_for_model_key(
+         model_key,
+         lineage_overrides,
+         previous_lineage_by_key,
+         current_lineage_by_key,
+         default_lineage
+       ) do
+    case resolve_override_target(model_key, lineage_overrides) do
+      nil ->
+        default_lineage
+
+      target_key ->
+        Map.get(current_lineage_by_key, target_key) ||
+          Map.get(previous_lineage_by_key, target_key) ||
+          target_key
+    end
+  end
+
+  defp resolve_override_target(model_key, lineage_overrides) do
+    if Map.has_key?(lineage_overrides, model_key) do
+      follow_override_target(model_key, lineage_overrides, [], 0)
+    end
+  end
+
+  defp follow_override_target(model_key, _lineage_overrides, _seen, depth) when depth >= 32,
+    do: model_key
+
+  defp follow_override_target(model_key, lineage_overrides, seen, depth) do
+    if model_key in seen do
+      model_key
+    else
+      case Map.get(lineage_overrides, model_key) do
+        nil ->
+          model_key
+
+        target when is_binary(target) ->
+          follow_override_target(target, lineage_overrides, [model_key | seen], depth + 1)
+      end
+    end
+  end
+end

--- a/lib/llm_db/history/migrator.ex
+++ b/lib/llm_db/history/migrator.ex
@@ -11,12 +11,10 @@ defmodule LLMDB.History.Migrator do
   `mix llm_db.history.migrate_git`.
   """
 
-  alias LLMDB.{History.Rebuilder, Snapshot}
+  alias LLMDB.{History.Diff, History.Rebuilder, Snapshot}
 
   @providers_dir "priv/llm_db/providers"
   @manifest_path "priv/llm_db/manifest.json"
-  @sortable_list_keys MapSet.new(["aliases", "tags", "input", "output"])
-
   @type summary :: %{
           commits_scanned: non_neg_integer(),
           commits_processed: non_neg_integer(),
@@ -198,14 +196,14 @@ defmodule LLMDB.History.Migrator do
           model_data
           |> Map.put_new("id", model_id)
           |> Map.put_new("provider", provider_data["id"])
-          |> normalize_value([])
+          |> Diff.normalize()
 
         {model_id, normalized}
       end)
 
     provider_data
     |> Map.put("models", models)
-    |> normalize_value([])
+    |> Diff.normalize()
   end
 
   defp manifest_for_commit(sha) do
@@ -312,36 +310,6 @@ defmodule LLMDB.History.Migrator do
       _ -> true
     end
   end
-
-  defp normalize_value(value, path)
-
-  defp normalize_value(value, path) when is_map(value) do
-    value
-    |> Enum.map(fn {k, v} -> {k, normalize_value(v, [to_string(k) | path])} end)
-    |> Enum.sort_by(fn {k, _v} -> k end)
-    |> Map.new()
-  end
-
-  defp normalize_value(value, path) when is_list(value) do
-    normalized = Enum.map(value, &normalize_value(&1, path))
-
-    case path do
-      [key | _] ->
-        if key in @sortable_list_keys and Enum.all?(normalized, &scalar?/1) do
-          Enum.sort(normalized)
-        else
-          normalized
-        end
-
-      _ ->
-        normalized
-    end
-  end
-
-  defp normalize_value(value, _path), do: value
-
-  defp scalar?(value),
-    do: is_binary(value) or is_number(value) or is_boolean(value) or is_nil(value)
 
   defp commit_date_iso8601(sha) do
     case git(["show", "-s", "--format=%cI", sha]) do

--- a/lib/llm_db/history/rebuilder.ex
+++ b/lib/llm_db/history/rebuilder.ex
@@ -10,12 +10,9 @@ defmodule LLMDB.History.Rebuilder do
   `mix llm_db.history.rebuild`.
   """
 
-  alias LLMDB.{History.Backfill, Snapshot}
+  alias LLMDB.{History.Diff, History.Lineage, Snapshot}
 
   @lineage_overrides_file "lineage_overrides.json"
-  @lineage_inference_threshold 30
-  @sortable_list_keys MapSet.new(["aliases", "tags", "input", "output"])
-
   @type observation :: map()
 
   @type summary :: %{
@@ -90,17 +87,17 @@ defmodule LLMDB.History.Rebuilder do
             {events, current_lineage_by_key} =
               case acc.snapshot_records do
                 [] ->
-                  current_lineage_by_key = initialize_lineage(current_models, lineage_overrides)
+                  current_lineage_by_key = Lineage.initialize(current_models, lineage_overrides)
 
                   events =
-                    Backfill.diff_models(%{}, current_models)
-                    |> attach_lineage(%{}, current_lineage_by_key)
+                    Diff.models(%{}, current_models)
+                    |> Lineage.attach(%{}, current_lineage_by_key)
 
                   {events, current_lineage_by_key}
 
                 _ ->
                   current_lineage_by_key =
-                    resolve_current_lineage(
+                    Lineage.resolve(
                       acc.previous_models,
                       current_models,
                       acc.previous_lineage_by_key,
@@ -108,8 +105,8 @@ defmodule LLMDB.History.Rebuilder do
                     )
 
                   events =
-                    Backfill.diff_models(acc.previous_models, current_models)
-                    |> attach_lineage(acc.previous_lineage_by_key, current_lineage_by_key)
+                    Diff.models(acc.previous_models, current_models)
+                    |> Lineage.attach(acc.previous_lineage_by_key, current_lineage_by_key)
 
                   {events, current_lineage_by_key}
               end
@@ -127,7 +124,7 @@ defmodule LLMDB.History.Rebuilder do
                 "parent_snapshot_id" => observation["parent_snapshot_id"],
                 "provider_count" => observation["provider_count"] || counts.provider_count,
                 "model_count" => observation["model_count"] || map_size(current_models),
-                "digest" => Backfill.snapshot_digest(current_models),
+                "digest" => Diff.snapshot_digest(current_models),
                 "event_count" => length(events)
               }
               |> compact_nils()
@@ -236,7 +233,7 @@ defmodule LLMDB.History.Rebuilder do
           |> stringify_map()
           |> Map.put_new("id", model_id)
           |> Map.put_new("provider", provider_id)
-          |> normalize_value([])
+          |> Diff.normalize()
 
         Map.put(inner_acc, "#{provider_id}:#{model_id}", normalized)
       end)
@@ -244,282 +241,6 @@ defmodule LLMDB.History.Rebuilder do
   end
 
   defp flatten_snapshot_models(_), do: %{}
-
-  defp initialize_lineage(models, lineage_overrides) do
-    models
-    |> Map.keys()
-    |> Enum.sort()
-    |> Enum.reduce(%{}, fn model_key, acc ->
-      lineage = lineage_for_model_key(model_key, lineage_overrides, %{}, acc, model_key)
-      Map.put(acc, model_key, lineage)
-    end)
-  end
-
-  defp resolve_current_lineage(
-         previous_models,
-         current_models,
-         previous_lineage_by_key,
-         lineage_overrides
-       ) do
-    previous_keys = Map.keys(previous_models) |> MapSet.new()
-    current_keys = Map.keys(current_models) |> MapSet.new()
-
-    shared_keys =
-      MapSet.intersection(previous_keys, current_keys)
-      |> MapSet.to_list()
-      |> Enum.sort()
-
-    removed_keys =
-      MapSet.difference(previous_keys, current_keys)
-      |> MapSet.to_list()
-      |> Enum.sort()
-
-    introduced_keys =
-      MapSet.difference(current_keys, previous_keys)
-      |> MapSet.to_list()
-      |> Enum.sort()
-
-    current_lineage_by_key =
-      Enum.reduce(shared_keys, %{}, fn model_key, acc ->
-        default_lineage = Map.get(previous_lineage_by_key, model_key, model_key)
-
-        lineage =
-          lineage_for_model_key(
-            model_key,
-            lineage_overrides,
-            previous_lineage_by_key,
-            acc,
-            default_lineage
-          )
-
-        Map.put(acc, model_key, lineage)
-      end)
-
-    {current_lineage_by_key, unresolved_introduced} =
-      Enum.reduce(introduced_keys, {current_lineage_by_key, []}, fn model_key,
-                                                                    {acc, unresolved} ->
-        if Map.has_key?(lineage_overrides, model_key) do
-          lineage =
-            lineage_for_model_key(
-              model_key,
-              lineage_overrides,
-              previous_lineage_by_key,
-              acc,
-              model_key
-            )
-
-          {Map.put(acc, model_key, lineage), unresolved}
-        else
-          {acc, [model_key | unresolved]}
-        end
-      end)
-
-    unresolved_introduced = Enum.reverse(unresolved_introduced)
-
-    inferred_matches =
-      infer_lineage_matches(removed_keys, unresolved_introduced, previous_models, current_models)
-
-    {current_lineage_by_key, matched_introduced} =
-      Enum.reduce(inferred_matches, {current_lineage_by_key, MapSet.new()}, fn {new_key, old_key},
-                                                                               {acc, matched} ->
-        default_lineage = Map.get(previous_lineage_by_key, old_key, old_key)
-
-        lineage =
-          lineage_for_model_key(
-            new_key,
-            lineage_overrides,
-            previous_lineage_by_key,
-            acc,
-            default_lineage
-          )
-
-        {Map.put(acc, new_key, lineage), MapSet.put(matched, new_key)}
-      end)
-
-    Enum.reduce(unresolved_introduced, current_lineage_by_key, fn model_key, acc ->
-      if MapSet.member?(matched_introduced, model_key) do
-        acc
-      else
-        lineage =
-          lineage_for_model_key(
-            model_key,
-            lineage_overrides,
-            previous_lineage_by_key,
-            acc,
-            model_key
-          )
-
-        Map.put(acc, model_key, lineage)
-      end
-    end)
-  end
-
-  defp infer_lineage_matches(removed_keys, introduced_keys, previous_models, current_models) do
-    candidates =
-      for removed_key <- removed_keys,
-          introduced_key <- introduced_keys,
-          score =
-            lineage_inference_score(
-              Map.get(previous_models, removed_key, %{}),
-              Map.get(current_models, introduced_key, %{})
-            ),
-          score >= @lineage_inference_threshold do
-        {score, introduced_key, removed_key}
-      end
-
-    candidates
-    |> Enum.sort_by(fn {score, introduced_key, removed_key} ->
-      {-score, introduced_key, removed_key}
-    end)
-    |> Enum.reduce({[], MapSet.new(), MapSet.new()}, fn {_score, introduced_key, removed_key},
-                                                        {acc, claimed_new, claimed_old} ->
-      cond do
-        MapSet.member?(claimed_new, introduced_key) ->
-          {acc, claimed_new, claimed_old}
-
-        MapSet.member?(claimed_old, removed_key) ->
-          {acc, claimed_new, claimed_old}
-
-        true ->
-          {
-            [{introduced_key, removed_key} | acc],
-            MapSet.put(claimed_new, introduced_key),
-            MapSet.put(claimed_old, removed_key)
-          }
-      end
-    end)
-    |> elem(0)
-    |> Enum.reverse()
-  end
-
-  defp lineage_inference_score(previous_model, current_model)
-       when is_map(previous_model) and is_map(current_model) do
-    previous_id = Map.get(previous_model, "id")
-    current_id = Map.get(current_model, "id")
-
-    previous_provider_model_id = Map.get(previous_model, "provider_model_id")
-    current_provider_model_id = Map.get(current_model, "provider_model_id")
-
-    previous_aliases = string_list(Map.get(previous_model, "aliases"))
-    current_aliases = string_list(Map.get(current_model, "aliases"))
-
-    alias_overlap = overlap_count(previous_aliases, current_aliases)
-
-    id_match_score =
-      if is_binary(previous_id) and previous_id == current_id do
-        50
-      else
-        0
-      end
-
-    provider_model_score =
-      if is_binary(previous_provider_model_id) and
-           previous_provider_model_id == current_provider_model_id do
-        40
-      else
-        0
-      end
-
-    previous_id_in_current_aliases_score =
-      if is_binary(previous_id) and previous_id in current_aliases do
-        30
-      else
-        0
-      end
-
-    current_id_in_previous_aliases_score =
-      if is_binary(current_id) and current_id in previous_aliases do
-        30
-      else
-        0
-      end
-
-    model_field_score =
-      if is_binary(Map.get(previous_model, "model")) and
-           Map.get(previous_model, "model") == Map.get(current_model, "model") do
-        5
-      else
-        0
-      end
-
-    name_field_score =
-      if is_binary(Map.get(previous_model, "name")) and
-           Map.get(previous_model, "name") == Map.get(current_model, "name") do
-        2
-      else
-        0
-      end
-
-    id_match_score + provider_model_score + previous_id_in_current_aliases_score +
-      current_id_in_previous_aliases_score + alias_overlap * 5 + model_field_score +
-      name_field_score
-  end
-
-  defp lineage_inference_score(_previous_model, _current_model), do: 0
-
-  defp lineage_for_model_key(
-         model_key,
-         lineage_overrides,
-         previous_lineage_by_key,
-         current_lineage_by_key,
-         default_lineage
-       ) do
-    case resolve_override_target(model_key, lineage_overrides) do
-      nil ->
-        default_lineage
-
-      target_key ->
-        Map.get(current_lineage_by_key, target_key) ||
-          Map.get(previous_lineage_by_key, target_key) ||
-          target_key
-    end
-  end
-
-  defp resolve_override_target(model_key, lineage_overrides) do
-    if Map.has_key?(lineage_overrides, model_key) do
-      follow_override_target(model_key, lineage_overrides, [], 0)
-    else
-      nil
-    end
-  end
-
-  defp follow_override_target(model_key, _lineage_overrides, _seen, depth) when depth >= 32,
-    do: model_key
-
-  defp follow_override_target(model_key, lineage_overrides, seen, depth) do
-    if model_key in seen do
-      model_key
-    else
-      case Map.get(lineage_overrides, model_key) do
-        nil ->
-          model_key
-
-        target when is_binary(target) ->
-          follow_override_target(
-            target,
-            lineage_overrides,
-            [model_key | seen],
-            depth + 1
-          )
-      end
-    end
-  end
-
-  defp attach_lineage(events, previous_lineage_by_key, current_lineage_by_key) do
-    Enum.map(events, fn event ->
-      lineage_key =
-        case event.type do
-          "removed" ->
-            Map.get(previous_lineage_by_key, event.model_key, event.model_key)
-
-          _ ->
-            Map.get(current_lineage_by_key, event.model_key) ||
-              Map.get(previous_lineage_by_key, event.model_key, event.model_key)
-        end
-
-      Map.put(event, :lineage_key, lineage_key)
-    end)
-  end
 
   defp load_lineage_overrides(output_dir) do
     path = Path.join(output_dir, @lineage_overrides_file)
@@ -595,48 +316,6 @@ defmodule LLMDB.History.Rebuilder do
 
   defp stringify_nested(value) when is_map(value), do: stringify_map(value)
   defp stringify_nested(value), do: value
-
-  defp normalize_value(value, path)
-
-  defp normalize_value(value, path) when is_map(value) do
-    value
-    |> Enum.map(fn {k, v} -> {k, normalize_value(v, [to_string(k) | path])} end)
-    |> Map.new()
-  end
-
-  defp normalize_value(value, path) when is_list(value) do
-    normalized = Enum.map(value, &normalize_value(&1, path))
-
-    case path do
-      [key | _] ->
-        if key in @sortable_list_keys and Enum.all?(normalized, &scalar?/1) do
-          Enum.sort(normalized)
-        else
-          normalized
-        end
-
-      _ ->
-        normalized
-    end
-  end
-
-  defp normalize_value(value, _path), do: value
-
-  defp scalar?(value),
-    do: is_binary(value) or is_number(value) or is_boolean(value) or is_nil(value)
-
-  defp string_list(value) when is_list(value) do
-    value
-    |> Enum.filter(&is_binary/1)
-    |> Enum.uniq()
-  end
-
-  defp string_list(_), do: []
-
-  defp overlap_count(left, right) do
-    right_lookup = Map.new(right, &{&1, true})
-    Enum.count(left, &Map.has_key?(right_lookup, &1))
-  end
 
   defp validate_observations([]), do: {:error, :no_snapshots}
 

--- a/test/llm_db/history/diff_lineage_test.exs
+++ b/test/llm_db/history/diff_lineage_test.exs
@@ -1,0 +1,117 @@
+defmodule LLMDB.History.DiffLineageTest do
+  use ExUnit.Case, async: true
+
+  alias LLMDB.History.{Backfill, Diff, Lineage}
+
+  test "classifies additions, removals, and lifecycle changes deterministically" do
+    previous = %{
+      "openai:removed" => model("removed"),
+      "openai:stable" => model("stable", %{"status" => %{"state" => "active"}})
+    }
+
+    current = %{
+      "openai:added" => model("added"),
+      "openai:stable" => model("stable", %{"status" => %{"state" => "deprecated"}})
+    }
+
+    assert [
+             %{type: "introduced", model_key: "openai:added", changes: []},
+             %{type: "removed", model_key: "openai:removed", changes: []},
+             %{
+               type: "changed",
+               model_key: "openai:stable",
+               changes: [
+                 %{
+                   path: "status.state",
+                   op: "replace",
+                   before: "active",
+                   after: "deprecated"
+                 }
+               ]
+             }
+           ] = Diff.models(previous, current)
+
+    assert Backfill.diff_models(previous, current) == Diff.models(previous, current)
+  end
+
+  test "normalization prevents alias and modality ordering noise" do
+    previous = %{
+      "aliases" => ["latest", "stable"],
+      "modalities" => %{"input" => ["text", "image"], "output" => ["text"]}
+    }
+
+    current = %{
+      "aliases" => ["stable", "latest"],
+      "modalities" => %{"input" => ["image", "text"], "output" => ["text"]}
+    }
+
+    assert Diff.models(%{"openai:model" => Diff.normalize(previous)}, %{
+             "openai:model" => Diff.normalize(current)
+           }) == []
+  end
+
+  test "carries lineage through an alias-based rename" do
+    previous = %{"openai:gpt-old" => model("gpt-old")}
+
+    current = %{
+      "openai:gpt-new" => model("gpt-new", %{"aliases" => ["gpt-old"]})
+    }
+
+    previous_lineage = %{"openai:gpt-old" => "openai:gpt-old"}
+    current_lineage = Lineage.resolve(previous, current, previous_lineage, %{})
+
+    assert current_lineage == %{"openai:gpt-new" => "openai:gpt-old"}
+
+    assert Diff.models(previous, current)
+           |> Lineage.attach(previous_lineage, current_lineage)
+           |> Enum.map(&{&1.type, &1.model_key, &1.lineage_key}) == [
+             {"introduced", "openai:gpt-new", "openai:gpt-old"},
+             {"removed", "openai:gpt-old", "openai:gpt-old"}
+           ]
+  end
+
+  test "uses provider model identity and explicit overrides" do
+    previous = %{
+      "provider:old" => model("old", %{"provider_model_id" => "upstream-id"})
+    }
+
+    current = %{
+      "provider:new" => model("new", %{"provider_model_id" => "upstream-id"}),
+      "provider:manual" => model("manual")
+    }
+
+    previous_lineage = %{"provider:old" => "provider:origin"}
+    overrides = %{"provider:manual" => "provider:old"}
+
+    assert Lineage.resolve(previous, current, previous_lineage, overrides) == %{
+             "provider:new" => "provider:origin",
+             "provider:manual" => "provider:origin"
+           }
+  end
+
+  test "resolves equally-scored ambiguous candidates deterministically one-to-one" do
+    previous = %{
+      "provider:old-a" => model("old-a", %{"provider_model_id" => "shared"}),
+      "provider:old-b" => model("old-b", %{"provider_model_id" => "shared"})
+    }
+
+    current = %{
+      "provider:new-a" => model("new-a", %{"provider_model_id" => "shared"}),
+      "provider:new-b" => model("new-b", %{"provider_model_id" => "shared"})
+    }
+
+    previous_lineage = %{
+      "provider:old-a" => "lineage:a",
+      "provider:old-b" => "lineage:b"
+    }
+
+    assert Lineage.resolve(previous, current, previous_lineage, %{}) == %{
+             "provider:new-a" => "lineage:a",
+             "provider:new-b" => "lineage:b"
+           }
+  end
+
+  defp model(id, extra \\ %{}) do
+    Map.merge(%{"id" => id, "provider" => "provider"}, extra)
+  end
+end


### PR DESCRIPTION
Closes #251

## Summary
- introduce pure shared history diff/normalization/digest and lineage modules
- route Backfill, Migrator, and Rebuilder through the shared behavior
- retain Backfill diff/digest entry points as compatibility delegates
- remove duplicate classification, normalization, identity scoring, override resolution, and lineage attachment code
- add fixtures for additions, removals, lifecycle changes, ordering, aliases, renames, provider IDs, overrides, and ambiguous matches

## Verification
- `mix test test/llm_db/history test/llm_db/history_test.exs test/llm_db/tooling_boundary_test.exs` (24 passed)
- `mix quality`