### PR TITLE
refactor: use immutable history cache

### DIFF
--- a/lib/llm_db/history.ex
+++ b/lib/llm_db/history.ex
@@ -79,8 +79,10 @@ defmodule LLMDB.History do
   @doc false
   @spec clear_cache() :: :ok
   def clear_cache do
-    :persistent_term.erase(@cache_key)
-    :ok
+    with_load_lock(fn ->
+      :persistent_term.erase(@cache_key)
+      :ok
+    end)
   end
 
   @doc false

--- a/lib/llm_db/history.ex
+++ b/lib/llm_db/history.ex
@@ -3,11 +3,14 @@ defmodule LLMDB.History do
   Read-only runtime access to generated model history artifacts.
 
   History is loaded from `priv/llm_db/history` (or `config :llm_db, :history_dir`).
-  NDJSON files are parsed into ETS-backed indexes for fast timeline/recent lookups.
+  NDJSON files are parsed into one immutable index published atomically through
+  `:persistent_term` for fast timeline/recent lookups without a cache process.
+
+  The cache uses one bounded key. Reloading replaces that key and therefore has
+  the normal `:persistent_term` global-GC update cost; reads remain lock-free.
   """
 
-  @table :llm_db_history
-  @table_heir_key {__MODULE__, :table_heir}
+  @cache_key {__MODULE__, :index}
   @load_lock {__MODULE__, :index_load}
   @max_limit 500
 
@@ -29,12 +32,10 @@ defmodule LLMDB.History do
   """
   @spec meta() :: {:ok, map()} | {:error, :history_unavailable | term()}
   def meta do
-    with {:ok, _} <- ensure_loaded(),
-         [{:meta, meta}] <- :ets.lookup(@table, :meta) do
-      {:ok, meta}
+    with {:ok, index} <- ensure_loaded() do
+      {:ok, index.meta}
     else
       {:error, _reason} -> {:error, :history_unavailable}
-      _ -> {:error, :history_unavailable}
     end
   end
 
@@ -45,21 +46,17 @@ defmodule LLMDB.History do
   @spec timeline(atom() | String.t(), String.t()) :: {:ok, [event()]} | {:error, term()}
   def timeline(provider, model_id) when is_binary(model_id) do
     with {:ok, provider_str} <- normalize_provider(provider),
-         {:ok, _} <- ensure_loaded(),
-         [{:model_index, model_index}] <- :ets.lookup(@table, :model_index),
-         [{:lineage_index, lineage_index}] <- :ets.lookup(@table, :lineage_index),
-         [{:lineage_by_model, lineage_by_model}] <- :ets.lookup(@table, :lineage_by_model) do
+         {:ok, index} <- ensure_loaded() do
       model_key = provider_str <> ":" <> model_id
-      lineage_key = Map.get(lineage_by_model, model_key, model_key)
+      lineage_key = Map.get(index.lineage_by_model, model_key, model_key)
 
       events =
-        Map.get(lineage_index, lineage_key) ||
-          Map.get(model_index, model_key, [])
+        Map.get(index.lineage_index, lineage_key) ||
+          Map.get(index.model_index, model_key, [])
 
       {:ok, events}
     else
       {:error, reason} -> {:error, reason}
-      _ -> {:error, :history_unavailable}
     end
   end
 
@@ -70,16 +67,33 @@ defmodule LLMDB.History do
   """
   @spec recent(pos_integer()) :: {:ok, [event()]} | {:error, term()}
   def recent(limit) when is_integer(limit) and limit > 0 do
-    with {:ok, _} <- ensure_loaded(),
-         [{:recent_events, recent_events}] <- :ets.lookup(@table, :recent_events) do
-      {:ok, Enum.take(recent_events, min(limit, @max_limit))}
+    with {:ok, index} <- ensure_loaded() do
+      {:ok, Enum.take(index.recent_events, min(limit, @max_limit))}
     else
       {:error, reason} -> {:error, reason}
-      _ -> {:error, :history_unavailable}
     end
   end
 
   def recent(_), do: {:error, :invalid_limit}
+
+  @doc false
+  @spec clear_cache() :: :ok
+  def clear_cache do
+    :persistent_term.erase(@cache_key)
+    :ok
+  end
+
+  @doc false
+  @spec reload() :: {:ok, :loaded} | {:error, term()}
+  def reload do
+    with_load_lock(fn ->
+      with {:ok, signature} <- history_signature(),
+           {:ok, index} <- load_index() do
+        publish_index(signature, index)
+        {:ok, :loaded}
+      end
+    end)
+  end
 
   defp normalize_provider(provider) when is_atom(provider), do: {:ok, Atom.to_string(provider)}
 
@@ -96,155 +110,41 @@ defmodule LLMDB.History do
   defp normalize_provider(_), do: {:error, :bad_provider}
 
   defp ensure_loaded do
-    do_ensure_loaded(1)
-  end
+    with {:ok, signature} <- history_signature() do
+      case cached_index(signature) do
+        {:ok, index} ->
+          {:ok, index}
 
-  defp do_ensure_loaded(retries_left) when is_integer(retries_left) and retries_left >= 0 do
-    table = ensure_table()
-
-    with {:ok, signature} <- history_signature(),
-         stale? <- stale_index?(table, signature) do
-      if stale? do
-        case with_load_lock(fn -> maybe_refresh_index(table, signature) end) do
-          :retry when retries_left > 0 ->
-            do_ensure_loaded(retries_left - 1)
-
-          :retry ->
-            {:error, :history_unavailable}
-
-          result ->
-            result
-        end
-      else
-        {:ok, :loaded}
+        :stale ->
+          with_load_lock(fn -> load_and_publish_if_stale(signature) end)
       end
     end
   end
 
-  defp with_load_lock(fun) do
-    :global.trans(@load_lock, fun)
-  end
+  defp with_load_lock(fun), do: :global.trans(@load_lock, fun)
 
-  defp ensure_table do
-    case :ets.whereis(@table) do
-      :undefined ->
-        create_table()
-
-      tid ->
-        tid
+  defp cached_index(signature) do
+    case :persistent_term.get(@cache_key, :missing) do
+      %{signature: ^signature, index: index} -> {:ok, index}
+      _other -> :stale
     end
   end
 
-  defp create_table do
-    heir = ensure_table_heir()
+  defp load_and_publish_if_stale(signature) do
+    case cached_index(signature) do
+      {:ok, index} ->
+        {:ok, index}
 
-    tid =
-      try do
-        :ets.new(@table, [
-          :named_table,
-          :public,
-          {:heir, heir, :llm_db_history},
-          read_concurrency: true
-        ])
-      rescue
-        ArgumentError ->
-          :ets.whereis(@table)
-      end
-
-    if tid == :undefined do
-      create_table()
-    else
-      tid
-    end
-  end
-
-  defp ensure_table_heir do
-    case :persistent_term.get(@table_heir_key, nil) do
-      pid when is_pid(pid) ->
-        if Process.alive?(pid) do
-          pid
-        else
-          start_table_heir()
+      :stale ->
+        with {:ok, index} <- load_index() do
+          publish_index(signature, index)
+          {:ok, index}
         end
-
-      _ ->
-        start_table_heir()
     end
   end
 
-  defp start_table_heir do
-    pid = spawn(fn -> table_heir_loop() end)
-
-    case :persistent_term.get(@table_heir_key, nil) do
-      existing when is_pid(existing) ->
-        if Process.alive?(existing) do
-          if existing != pid do
-            Process.exit(pid, :normal)
-          end
-
-          existing
-        else
-          :persistent_term.put(@table_heir_key, pid)
-          pid
-        end
-
-      _ ->
-        :persistent_term.put(@table_heir_key, pid)
-        pid
-    end
-  end
-
-  defp table_heir_loop do
-    receive do
-      {:"ETS-TRANSFER", _table, _from, _data} ->
-        table_heir_loop()
-
-      _ ->
-        table_heir_loop()
-    end
-  end
-
-  defp put_index(table, signature, index) do
-    try do
-      :ets.insert(table, [
-        {:signature, signature},
-        {:meta, index.meta},
-        {:model_index, index.model_index},
-        {:lineage_index, index.lineage_index},
-        {:lineage_by_model, index.lineage_by_model},
-        {:recent_events, index.recent_events}
-      ])
-
-      :ok
-    rescue
-      ArgumentError ->
-        :retry
-    end
-  end
-
-  defp stale_index?(table, signature) do
-    try do
-      case :ets.lookup(table, :signature) do
-        [{:signature, ^signature}] -> false
-        _ -> true
-      end
-    rescue
-      ArgumentError ->
-        true
-    end
-  end
-
-  defp maybe_refresh_index(table, signature) do
-    if stale_index?(table, signature) do
-      with {:ok, index} <- load_index() do
-        case put_index(table, signature, index) do
-          :ok -> {:ok, :loaded}
-          :retry -> :retry
-        end
-      end
-    else
-      {:ok, :loaded}
-    end
+  defp publish_index(signature, index) do
+    :persistent_term.put(@cache_key, %{signature: signature, index: index})
   end
 
   defp load_index do
@@ -382,7 +282,7 @@ defmodule LLMDB.History do
           _ -> {0, nil}
         end
 
-      {:ok, {meta_stat.size, meta_stat.mtime, snapshots_stat, event_stats}}
+      {:ok, {history_dir, meta_stat.size, meta_stat.mtime, snapshots_stat, event_stats}}
     else
       false -> {:error, :history_unavailable}
       {:error, reason} -> {:error, reason}

--- a/test/llm_db/history/rebuilder_test.exs
+++ b/test/llm_db/history/rebuilder_test.exs
@@ -119,10 +119,5 @@ defmodule LLMDB.History.RebuilderTest do
     path
   end
 
-  defp clear_history_cache do
-    case :ets.whereis(:llm_db_history) do
-      :undefined -> :ok
-      tid -> :ets.delete(tid)
-    end
-  end
+  defp clear_history_cache, do: History.clear_cache()
 end

--- a/test/llm_db/history_test.exs
+++ b/test/llm_db/history_test.exs
@@ -30,6 +30,22 @@ defmodule LLMDB.HistoryTest do
     assert {:error, :history_unavailable} = History.meta()
   end
 
+  test "corrupt metadata is unavailable without replacing a valid published index" do
+    dir = temp_history_dir()
+    write_meta(dir)
+    write_events(dir, "2026", [event("a:1")])
+
+    Application.put_env(:llm_db, :history_dir, dir)
+    clear_history_cache()
+
+    assert History.available?()
+    File.write!(Path.join(dir, "meta.json"), "not-json")
+
+    assert {:error, _reason} = History.reload()
+    refute History.available?()
+    assert {:error, :history_unavailable} = History.meta()
+  end
+
   test "timeline/2 follows lineage_key and returns deterministic ordering" do
     dir = temp_history_dir()
     write_meta(dir)
@@ -170,9 +186,31 @@ defmodule LLMDB.HistoryTest do
     refute Enum.any?(results, &match?({:exit, _}, &1))
 
     assert Enum.all?(results, fn
-             {:ok, value} when is_boolean(value) -> true
+             {:ok, true} -> true
              _ -> false
            end)
+
+    assert :ets.whereis(:llm_db_history) == :undefined
+  end
+
+  test "reload and clear replace one immutable cache entry deterministically" do
+    dir = temp_history_dir()
+    write_meta(dir)
+    write_events(dir, "2026", [event("a:1")])
+
+    Application.put_env(:llm_db, :history_dir, dir)
+    clear_history_cache()
+
+    assert {:ok, [%{"event_id" => "a:1"}]} = History.recent(1)
+
+    write_events(dir, "2026", [event("b:1")])
+    assert {:ok, :loaded} = History.reload()
+    assert {:ok, [%{"event_id" => "b:1"}]} = History.recent(1)
+
+    assert :ok = History.clear_cache()
+    assert :ok = History.clear_cache()
+    assert {:ok, [%{"event_id" => "b:1"}]} = History.recent(1)
+    assert :ets.whereis(:llm_db_history) == :undefined
   end
 
   defp write_meta(dir) do
@@ -210,10 +248,21 @@ defmodule LLMDB.HistoryTest do
     path
   end
 
-  defp clear_history_cache do
-    case :ets.whereis(:llm_db_history) do
-      :undefined -> :ok
-      tid -> :ets.delete(tid)
-    end
+  defp event(event_id) do
+    %{
+      "schema_version" => 1,
+      "event_id" => event_id,
+      "snapshot_id" => event_id,
+      "source_commit" => event_id,
+      "captured_at" => "2026-01-01T00:00:00Z",
+      "type" => "introduced",
+      "model_key" => "openai:gpt-4o",
+      "lineage_key" => "openai:gpt-4o",
+      "provider" => "openai",
+      "model_id" => "gpt-4o",
+      "changes" => []
+    }
   end
+
+  defp clear_history_cache, do: History.clear_cache()
 end


### PR DESCRIPTION
Closes #252

## Summary
- replace the History ETS table, owner, and heir lifecycle with one immutable `:persistent_term` entry
- publish cache replacements atomically behind the existing load lock while keeping reads process-free
- add deterministic concurrent-load, reload, clear, missing, and corrupt bundle coverage
- document the bounded cache identity and `:persistent_term` update tradeoff

## Compatibility
- preserves the public `LLMDB.History` APIs, return values, and history bundle format
- requires no supervised cache process

## Validation
- `mix test` (858 tests, 41 doctests)
- `mix quality`
- focused history and tooling boundary tests