### PR TITLE
refactor: deprecate legacy history backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,16 +338,21 @@ mix llm_db.build
 mix llm_db.build --install
 ```
 
-To migrate legacy Git-tracked metadata history into the snapshot store (one-time maintainer task):
+### Maintained history workflow
+
+Migrate legacy Git-tracked metadata history into the snapshot store once:
 
 ```bash
-mix llm_db.history.migrate_git
+mix llm_db.history.migrate_git --publish
 ```
 
 This writes snapshot-based history artifacts under `priv/llm_db/history/` and
-materializes immutable historical snapshots under `_build/llm_db/snapshot_store/snapshots/`.
+materializes immutable historical snapshots under
+`_build/llm_db/snapshot_store/snapshots/`. With `--publish`, it also seeds the
+immutable snapshot releases and publishes the rebuilt history bundle.
 
-For daily publication and local history maintenance:
+After that one-time migration, publish each current snapshot and rebuild history
+from the published snapshot observation chain:
 
 ```bash
 mix llm_db.snapshot.publish
@@ -356,6 +361,10 @@ mix llm_db.history.sync
 mix llm_db.history.check
 mix llm_db.history.check --allow-outdated
 ```
+
+`mix llm_db.history.backfill` and `LLMDB.History.Backfill` remain functional for
+compatibility but are deprecated. They may be removed no earlier than
+`v2027.0.0`, after at least one minor release deprecation window.
 
 For exceptional spec migrations (renames/provider moves that inference cannot match),
 add optional lineage overrides in `priv/llm_db/history/lineage_overrides.json`:

--- a/guides/runtime-and-maintainer-boundaries.md
+++ b/guides/runtime-and-maintainer-boundaries.md
@@ -42,7 +42,7 @@ module it currently calls:
 | `mix llm_db.pull` | Maintainer-only upstream synchronization and the sole automatic dotenv boundary |
 | `mix llm_db.build`, `mix llm_db.snapshot.build` | Maintainer-only canonical snapshot build (`snapshot.build` is a supported alias) |
 | `mix llm_db.snapshot.publish` | Maintainer-only snapshot publication |
-| `mix llm_db.history.backfill` | Legacy Git-history backfill kept for compatibility |
+| `mix llm_db.history.backfill` | Deprecated legacy Git-history backfill kept callable through the compatibility window |
 | `mix llm_db.history.migrate_git` | One-time migration to snapshot-store history |
 | `mix llm_db.history.rebuild`, `mix llm_db.history.sync`, `mix llm_db.history.check` | Published history maintenance |
 | `mix llm_db.version` | Maintainer-only CalVer bump |
@@ -67,7 +67,8 @@ No module or task is removed in this minor release.
 | `LLMDB.Dotenv.load!/1` | `mix llm_db.pull` | Compiler-deprecated; pull remains task-scoped |
 | `LLMDB.Store` query calls | Equivalent `LLMDB` query/load calls | Compatibility facade; direct use is documentation-deprecated |
 | `LLMDB.Engine.run/1`, `LLMDB.Snapshot.Builder` | `mix llm_db.build` | Documentation-deprecated maintainer orchestration |
-| `LLMDB.History.Backfill`, `LLMDB.History.Migrator`, `LLMDB.History.Rebuilder`, `LLMDB.History.Bundle`, `LLMDB.History.Diff`, `LLMDB.History.Lineage` | Corresponding `mix llm_db.history.*` task | Documentation-deprecated maintainer orchestration with internal shared diff/lineage logic |
+| `LLMDB.History.Backfill` | One-time `mix llm_db.history.migrate_git --publish`, then `mix llm_db.history.rebuild --publish` | Compiler- and runtime-deprecated; remains callable until no earlier than `v2027.0.0` |
+| `LLMDB.History.Migrator`, `LLMDB.History.Rebuilder`, `LLMDB.History.Bundle`, `LLMDB.History.Diff`, `LLMDB.History.Lineage` | Corresponding `mix llm_db.history.*` task | Documentation-deprecated maintainer orchestration with internal shared diff/lineage logic |
 | `LLMDB.Snapshot.ReleaseStore` mutation/publishing calls | `mix llm_db.snapshot.publish` or `mix llm_db.history.rebuild --publish` | Internal shared transport; runtime fetch behavior remains supported through configuration |
 | `LLMDB.Enrich`, `LLMDB.Validate`, `LLMDB.Enrich.AzureWireProtocol`, `LLMDB.Enrich.RuntimeContract` | `mix llm_db.build` | Internal ETL stages |
 | LLMDB.Sources.Anthropic, LLMDB.Sources.Google, LLMDB.Sources.Llmfit, LLMDB.Sources.Local, LLMDB.Sources.ModelsDev, LLMDB.Sources.OpenAI, LLMDB.Sources.OpenRouter, LLMDB.Sources.Remote, LLMDB.Sources.XAI, LLMDB.Sources.Zenmux | `LLMDB.Source` for extensions; `mix llm_db.pull`/`build` for workflows | Internal bundled adapters and shared remote transport |
@@ -108,6 +109,13 @@ Every direct dependency remains available in this minor release:
 5. `toml` can move with source ingestion. `req` can leave the runtime dependency
    graph only after configured GitHub-release snapshot/history reads are moved
    behind an equivalent adapter or companion dependency.
+
+The legacy `mix llm_db.history.backfill` task and `LLMDB.History.Backfill`
+functions may be removed no earlier than `v2027.0.0`, and only after at least
+one minor release has carried their actionable deprecation warnings. The
+maintained replacement is the one-time `mix llm_db.history.migrate_git --publish`
+seed followed by `mix llm_db.snapshot.publish` and
+`mix llm_db.history.rebuild --publish` for new observations.
 
 Upstream synchronization never runs during application startup, lazy catalog
 initialization, explicit `LLMDB.load/1`, or queries. Provider credentials and

--- a/lib/llm_db/history/backfill.ex
+++ b/lib/llm_db/history/backfill.ex
@@ -6,9 +6,13 @@ defmodule LLMDB.History.Backfill do
   `priv/llm_db/providers/*.json` from commit history and writes append-only
   NDJSON event files under a local history directory.
 
-  Direct use is documentation-deprecated. Use
-  `mix llm_db.history.backfill`; new snapshot-store migrations should use
-  `mix llm_db.history.migrate_git`.
+  This legacy Git-to-NDJSON path is deprecated and remains available only for
+  compatibility. For the maintained snapshot workflow, seed historical data
+  once with `mix llm_db.history.migrate_git --publish`, then use
+  `mix llm_db.history.rebuild --publish` for subsequent rebuilds.
+
+  These compatibility functions may be removed no earlier than `v2027.0.0`,
+  after at least one minor release deprecation window.
   """
 
   alias LLMDB.History.{Diff, Lineage}
@@ -43,6 +47,7 @@ defmodule LLMDB.History.Backfill do
   - `:output_dir` - Output directory (default: `"priv/llm_db/history"`)
   - `:force` - Remove previously generated history files first (default: `false`)
   """
+  @deprecated "use mix llm_db.history.migrate_git --publish for the one-time migration; legacy backfill may be removed in v2027.0.0"
   @spec run(keyword()) :: {:ok, summary()} | {:error, term()}
   def run(opts \\ []) do
     output_dir = Keyword.get(opts, :output_dir, @default_output_dir)
@@ -68,6 +73,7 @@ defmodule LLMDB.History.Backfill do
   - `:to` - Optional end commit/reference (default: `"HEAD"`)
   - `:output_dir` - Output directory (default: `"priv/llm_db/history"`)
   """
+  @deprecated "use mix llm_db.snapshot.publish and mix llm_db.history.rebuild --publish; legacy backfill may be removed in v2027.0.0"
   @spec sync(keyword()) :: {:ok, summary()} | {:error, term()}
   def sync(opts \\ []) do
     output_dir = Keyword.get(opts, :output_dir, @default_output_dir)
@@ -100,6 +106,7 @@ defmodule LLMDB.History.Backfill do
   Returns `:history_unavailable` when `meta.json` is missing, `:up_to_date` when no
   metadata commits are pending, or `{:outdated, ...}` when new commits exist.
   """
+  @deprecated "use mix llm_db.history.check; legacy backfill may be removed in v2027.0.0"
   @spec check(keyword()) :: {:ok, check_result()} | {:error, term()}
   def check(opts \\ []) do
     output_dir = Keyword.get(opts, :output_dir, @default_output_dir)
@@ -131,6 +138,7 @@ defmodule LLMDB.History.Backfill do
 
   Expects maps keyed by `"provider:model_id"` with normalized model payload values.
   """
+  @deprecated "use the maintained mix llm_db.history.* workflows; legacy Backfill APIs may be removed in v2027.0.0"
   @spec diff_models(%{optional(String.t()) => map()}, %{optional(String.t()) => map()}) :: [map()]
   def diff_models(previous_models, current_models)
       when is_map(previous_models) and is_map(current_models) do
@@ -138,6 +146,7 @@ defmodule LLMDB.History.Backfill do
   end
 
   @doc false
+  @deprecated "use the maintained mix llm_db.history.* workflows; legacy Backfill APIs may be removed in v2027.0.0"
   @spec snapshot_digest(%{optional(String.t()) => map()}) :: String.t()
   def snapshot_digest(models) when is_map(models) do
     Diff.snapshot_digest(models)

--- a/lib/mix/tasks/llm_db.history.backfill.ex
+++ b/lib/mix/tasks/llm_db.history.backfill.ex
@@ -2,10 +2,25 @@ defmodule Mix.Tasks.LlmDb.History.Backfill do
   use Mix.Task
   @dialyzer {:nowarn_function, run: 1}
 
-  @shortdoc "Backfill model history from git commits into priv/llm_db/history NDJSON"
+  @shortdoc "Deprecated: legacy Git-to-NDJSON history backfill"
+
+  @deprecation """
+  warning: mix llm_db.history.backfill is deprecated and retained only for compatibility.
+  Seed history once with `mix llm_db.history.migrate_git --publish`, then use
+  `mix llm_db.history.rebuild --publish`. The legacy task may be removed no
+  earlier than v2027.0.0.
+  """
 
   @moduledoc """
-  Backfills model history from committed provider snapshots.
+  > #### Deprecated {: .warning}
+  >
+  > This legacy task remains callable for compatibility. Seed snapshot-based
+  > history once with `mix llm_db.history.migrate_git --publish`, then use
+  > `mix llm_db.history.rebuild --publish`. Removal may occur no earlier than
+  > `v2027.0.0`, after at least one minor release deprecation window.
+
+  Backfills model history from committed provider snapshots using the legacy
+  Git-to-NDJSON implementation.
 
   The task walks git history for `priv/llm_db/providers/*.json`, computes model
   deltas per commit, and writes append-only history artifacts:
@@ -31,8 +46,10 @@ defmodule Mix.Tasks.LlmDb.History.Backfill do
   """
 
   @impl Mix.Task
+  @deprecated "use mix llm_db.history.migrate_git --publish once, then mix llm_db.history.rebuild --publish; may be removed in v2027.0.0"
   def run(args) do
     ensure_llm_db_project!()
+    Mix.shell().error(@deprecation)
 
     {opts, _, invalid} =
       OptionParser.parse(args,
@@ -57,7 +74,7 @@ defmodule Mix.Tasks.LlmDb.History.Backfill do
 
     Mix.shell().info("Backfilling model history from git...")
 
-    case LLMDB.History.Backfill.run(runtime_opts) do
+    case apply(LLMDB.History.Backfill, :run, [runtime_opts]) do
       {:ok, summary} ->
         Mix.shell().info("✓ History backfill complete")
         Mix.shell().info("  commits scanned:   #{summary.commits_scanned}")

--- a/test/llm_db/history/backfill_test.exs
+++ b/test/llm_db/history/backfill_test.exs
@@ -37,7 +37,7 @@ defmodule LLMDB.History.BackfillTest do
         "anthropic:claude-sonnet-4" => %{"id" => "claude-sonnet-4", "provider" => "anthropic"}
       }
 
-      events = Backfill.diff_models(previous, current)
+      events = call_backfill(:diff_models, [previous, current])
 
       assert [
                %{type: "introduced", model_key: "anthropic:claude-sonnet-4", changes: []},
@@ -91,7 +91,7 @@ defmodule LLMDB.History.BackfillTest do
         }
       }
 
-      assert Backfill.diff_models(previous_normalized, current_normalized) == []
+      assert call_backfill(:diff_models, [previous_normalized, current_normalized]) == []
     end
   end
 
@@ -127,9 +127,10 @@ defmodule LLMDB.History.BackfillTest do
         }
       }
 
-      assert Backfill.snapshot_digest(models_a) == Backfill.snapshot_digest(models_b)
+      assert call_backfill(:snapshot_digest, [models_a]) ==
+               call_backfill(:snapshot_digest, [models_b])
 
-      assert Backfill.snapshot_digest(models_a) ==
+      assert call_backfill(:snapshot_digest, [models_a]) ==
                "394e65bbcd07442b886d554fb25fddd33bf47393c9b7996e1c71a4f4dae892e0"
     end
   end
@@ -141,7 +142,7 @@ defmodule LLMDB.History.BackfillTest do
 
       on_exit(fn -> File.rm_rf!(output_dir) end)
 
-      assert {:ok, first} = Backfill.sync(output_dir: output_dir, to: first_commit)
+      assert {:ok, first} = call_backfill(:sync, [[output_dir: output_dir, to: first_commit]])
       assert first.from_commit == first_commit
       assert first.to_commit == first_commit
       assert first.commits_processed == 1
@@ -150,7 +151,7 @@ defmodule LLMDB.History.BackfillTest do
       assert File.exists?(Path.join(output_dir, "meta.json"))
       assert File.exists?(Path.join(output_dir, "snapshots.ndjson"))
 
-      assert {:ok, second} = Backfill.sync(output_dir: output_dir, to: first_commit)
+      assert {:ok, second} = call_backfill(:sync, [[output_dir: output_dir, to: first_commit]])
       assert second.from_commit == first_commit
       assert second.to_commit == first_commit
       assert second.commits_processed == first.commits_processed
@@ -163,14 +164,17 @@ defmodule LLMDB.History.BackfillTest do
 
       on_exit(fn -> File.rm_rf!(output_dir) end)
 
-      assert {:ok, _summary} = Backfill.sync(output_dir: output_dir, to: latest_commit)
+      assert {:ok, _summary} =
+               call_backfill(:sync, [[output_dir: output_dir, to: latest_commit]])
 
       snapshot_count = snapshot_line_count(output_dir)
       event_count = event_line_count(output_dir)
 
       overwrite_meta_to_commit(output_dir, String.duplicate("0", 40))
 
-      assert {:ok, repaired} = Backfill.sync(output_dir: output_dir, to: latest_commit)
+      assert {:ok, repaired} =
+               call_backfill(:sync, [[output_dir: output_dir, to: latest_commit]])
+
       assert repaired.to_commit == latest_commit
       assert read_meta_file(output_dir)["to_commit"] == latest_commit
       assert snapshot_line_count(output_dir) == snapshot_count
@@ -184,14 +188,17 @@ defmodule LLMDB.History.BackfillTest do
 
       on_exit(fn -> File.rm_rf!(output_dir) end)
 
-      assert {:ok, _summary} = Backfill.sync(output_dir: output_dir, to: previous_commit)
+      assert {:ok, _summary} =
+               call_backfill(:sync, [[output_dir: output_dir, to: previous_commit]])
 
       snapshot_count = snapshot_line_count(output_dir)
       event_count = event_line_count(output_dir)
 
       overwrite_meta_to_commit(output_dir, String.duplicate("0", 40))
 
-      assert {:ok, repaired} = Backfill.sync(output_dir: output_dir, to: latest_commit)
+      assert {:ok, repaired} =
+               call_backfill(:sync, [[output_dir: output_dir, to: latest_commit]])
+
       assert repaired.to_commit == latest_commit
       assert read_meta_file(output_dir)["to_commit"] == latest_commit
       assert snapshot_line_count(output_dir) == snapshot_count + 1
@@ -206,11 +213,13 @@ defmodule LLMDB.History.BackfillTest do
 
       on_exit(fn -> File.rm_rf!(output_dir) end)
 
-      assert {:ok, _summary} = Backfill.sync(output_dir: output_dir, to: latest_commit)
+      assert {:ok, _summary} =
+               call_backfill(:sync, [[output_dir: output_dir, to: latest_commit]])
 
       overwrite_meta_to_commit(output_dir, nil)
 
-      assert {:ok, :up_to_date} = Backfill.check(output_dir: output_dir, to: latest_commit)
+      assert {:ok, :up_to_date} =
+               call_backfill(:check, [[output_dir: output_dir, to: latest_commit]])
     end
 
     test "treats rewritten anchors as up to date when the snapshot digest matches reachable history" do
@@ -219,11 +228,13 @@ defmodule LLMDB.History.BackfillTest do
 
       on_exit(fn -> File.rm_rf!(output_dir) end)
 
-      assert {:ok, _summary} = Backfill.sync(output_dir: output_dir, to: latest_commit)
+      assert {:ok, _summary} =
+               call_backfill(:sync, [[output_dir: output_dir, to: latest_commit]])
 
       overwrite_meta_to_commit(output_dir, String.duplicate("0", 40))
 
-      assert {:ok, :up_to_date} = Backfill.check(output_dir: output_dir, to: latest_commit)
+      assert {:ok, :up_to_date} =
+               call_backfill(:check, [[output_dir: output_dir, to: latest_commit]])
     end
 
     test "reports pending commits from the resolved reachable anchor" do
@@ -233,12 +244,13 @@ defmodule LLMDB.History.BackfillTest do
 
       on_exit(fn -> File.rm_rf!(output_dir) end)
 
-      assert {:ok, _summary} = Backfill.sync(output_dir: output_dir, to: previous_commit)
+      assert {:ok, _summary} =
+               call_backfill(:sync, [[output_dir: output_dir, to: previous_commit]])
 
       overwrite_meta_to_commit(output_dir, String.duplicate("0", 40))
 
       assert {:ok, {:outdated, %{new_commits: 1, latest_commit: ^latest_commit}}} =
-               Backfill.check(output_dir: output_dir, to: latest_commit)
+               call_backfill(:check, [[output_dir: output_dir, to: latest_commit]])
     end
 
     test "returns backfill guidance when an unreachable anchor cannot be re-anchored" do
@@ -247,12 +259,15 @@ defmodule LLMDB.History.BackfillTest do
 
       on_exit(fn -> File.rm_rf!(output_dir) end)
 
-      assert {:ok, _summary} = Backfill.sync(output_dir: output_dir, to: first_commit)
+      assert {:ok, _summary} =
+               call_backfill(:sync, [[output_dir: output_dir, to: first_commit]])
 
       overwrite_meta_to_commit(output_dir, String.duplicate("0", 40))
       overwrite_last_snapshot_digest(output_dir, String.duplicate("f", 64))
 
-      assert {:error, message} = Backfill.check(output_dir: output_dir, to: first_commit)
+      assert {:error, message} =
+               call_backfill(:check, [[output_dir: output_dir, to: first_commit]])
+
       assert message =~ "cannot be re-anchored"
       assert message =~ "backfill --force"
     end
@@ -269,6 +284,8 @@ defmodule LLMDB.History.BackfillTest do
     File.mkdir_p!(path)
     path
   end
+
+  defp call_backfill(function, arguments), do: apply(Backfill, function, arguments)
 
   defp first_metadata_commit do
     metadata_commits()

--- a/test/llm_db/history/diff_lineage_test.exs
+++ b/test/llm_db/history/diff_lineage_test.exs
@@ -31,7 +31,7 @@ defmodule LLMDB.History.DiffLineageTest do
              }
            ] = Diff.models(previous, current)
 
-    assert Backfill.diff_models(previous, current) == Diff.models(previous, current)
+    assert apply(Backfill, :diff_models, [previous, current]) == Diff.models(previous, current)
   end
 
   test "normalization prevents alias and modality ordering noise" do

--- a/test/llm_db/tooling_boundary_test.exs
+++ b/test/llm_db/tooling_boundary_test.exs
@@ -1,6 +1,8 @@
 defmodule LLMDB.ToolingBoundaryTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   @project_root Path.expand("../..", __DIR__)
   @boundary_guide Path.join(@project_root, "guides/runtime-and-maintainer-boundaries.md")
 
@@ -34,6 +36,52 @@ defmodule LLMDB.ToolingBoundaryTest do
     assert {{:load!, 0}, message} = List.keyfind(deprecations, {:load!, 0}, 0)
     assert message =~ "mix llm_db.pull"
     assert {{:load!, 1}, ^message} = List.keyfind(deprecations, {:load!, 1}, 0)
+  end
+
+  test "legacy history backfill APIs identify the maintained replacement and removal window" do
+    deprecations = LLMDB.History.Backfill.__info__(:deprecated)
+
+    for arity <- [0, 1] do
+      assert {{:run, ^arity}, message} = List.keyfind(deprecations, {:run, arity}, 0)
+      assert message =~ "mix llm_db.history.migrate_git --publish"
+      assert message =~ "v2027.0.0"
+    end
+
+    for arity <- [0, 1] do
+      assert {{:sync, ^arity}, message} = List.keyfind(deprecations, {:sync, arity}, 0)
+      assert message =~ "mix llm_db.history.rebuild --publish"
+      assert message =~ "v2027.0.0"
+    end
+
+    assert {{:run, 1}, task_message} =
+             List.keyfind(Mix.Tasks.LlmDb.History.Backfill.__info__(:deprecated), {:run, 1}, 0)
+
+    assert task_message =~ "mix llm_db.history.migrate_git --publish"
+    assert task_message =~ "mix llm_db.history.rebuild --publish"
+    assert task_message =~ "v2027.0.0"
+
+    assert {:shortdoc, [shortdoc]} =
+             List.keyfind(
+               Mix.Tasks.LlmDb.History.Backfill.module_info(:attributes),
+               :shortdoc,
+               0
+             )
+
+    assert shortdoc =~ "Deprecated"
+  end
+
+  test "legacy history backfill task emits actionable migration guidance" do
+    warning =
+      capture_io(:stderr, fn ->
+        assert_raise Mix.Error, ~r/Invalid options/, fn ->
+          apply(Mix.Tasks.LlmDb.History.Backfill, :run, [["--invalid"]])
+        end
+      end)
+
+    assert warning =~ "mix llm_db.history.backfill is deprecated"
+    assert warning =~ "mix llm_db.history.migrate_git --publish"
+    assert warning =~ "mix llm_db.history.rebuild --publish"
+    assert warning =~ "v2027.0.0"
   end
 
   test "the boundary guide inventories every shipped module and direct dependency" do


### PR DESCRIPTION
Closes #254

## Summary
- deprecate every legacy `LLMDB.History.Backfill` entry point without removing behavior
- mark `mix llm_db.history.backfill` deprecated and emit actionable migration guidance at runtime
- document the one-time migration and maintained snapshot rebuild workflow end to end
- establish `v2027.0.0` as the earliest possible removal, after at least one minor deprecation window
- retain compatibility coverage while routing equivalent diff/digest behavior through the shared implementation

## Compatibility
- all legacy module functions, task options, outputs, and history bundle formats remain callable
- no code is deleted in this minor release

## Validation
- focused backfill, shared diff/lineage, and tooling boundary tests (20 tests)
- `mix quality`
- `mix docs`