### PR TITLE
build: require Elixir 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
       matrix:
         otp: ["27", "28"]
         elixir: ["1.18", "1.19"]
+        include:
+          - otp: "27"
+            elixir: "1.17"
 
     env:
       MIX_ENV: test

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule LLMDB.MixProject do
     [
       app: :llm_db,
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),


### PR DESCRIPTION
## Summary

- raise the declared Elixir requirement from `~> 1.14` to `~> 1.17`
- add Elixir 1.17 / OTP 27 to the CI matrix as the minimum-version lane
- retain the existing Elixir 1.18/1.19 and OTP 27/28 coverage

## Rationale

The current dependency graph no longer builds reliably on Elixir 1.14, so the package declaration should reflect the supported floor we actually validate. Elixir 1.17 is a reasonable compatibility baseline for current consumers, while OTP 27 avoids asserting an unsupported 1.17/OTP 28 pairing.

This changes package/toolchain metadata only. It does not change the public API, runtime behavior, snapshot format, or release workflow runtime.

## Validation

- Elixir 1.17.2 / OTP 27: 41 doctests, 827 tests, 0 failures
- `mix quality`: Credo clean, Dialyzer 0 errors
- pre-push hook: 868 checks passed plus full quality gate