### PR TITLE
ci: upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
   - package-ecosystem: "mix"
     directory: "/"
     schedule:

--- a/.github/workflows/build-metadata.yml
+++ b/.github/workflows/build-metadata.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -41,7 +41,7 @@ jobs:
           otp-version: "27"
 
       - name: Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       MIX_ENV: dev
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check for CHANGELOG.md modifications
         if: github.event_name == 'pull_request'
@@ -45,7 +45,7 @@ jobs:
           elixir-version: "1.19"
 
       - name: Restore Hex/Mix cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.hex
@@ -62,7 +62,7 @@ jobs:
 
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -90,7 +90,7 @@ jobs:
         run: mkdir -p priv/plts
 
       - name: Restore Dialyzer PLT cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: priv/plts
           key: ${{ runner.os }}-plt-otp28-elixir1.19-${{ hashFiles('mix.lock', 'mix.exs') }}
@@ -130,13 +130,13 @@ jobs:
       MIX_ENV: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       # Cache only immutable package downloads; avoid cached archives/binaries.
       - name: Restore Hex package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.hex/packages
@@ -144,7 +144,7 @@ jobs:
           key: ${{ runner.os }}-hex-v2-otp${{ matrix.otp }}-elixir${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
 
       - name: Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -187,7 +187,7 @@ jobs:
     name: Build Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -53,7 +53,7 @@ jobs:
           otp-version: "27"
 
       - name: Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps


### PR DESCRIPTION
## Summary

- upgrade all five `actions/checkout` usages from v4 to v6
- upgrade all seven `actions/cache` usages from v4 to v5
- add weekly Dependabot coverage for the `github-actions` ecosystem

## Why

GitHub now warns that the v4 releases of these actions use the deprecated Node.js 20 action runtime and force them onto Node.js 24. The upgraded releases natively target Node.js 24, removing the warning and keeping the workflows on supported first-party actions.

This covers CI, nightly snapshot publication, and Hex release workflows. `checkout@v6` retains authenticated Git behavior needed by the snapshot workflow while moving persisted credentials into runner temporary storage.

## Validation

- all workflow and Dependabot YAML parses successfully
- verified `actions/checkout@v6` and `actions/cache@v5` tags resolve upstream
- confirmed no v4 checkout/cache references remain
- pre-commit snapshot integrity check passed
- pre-push gate: 41 doctests and 827 tests passed; Credo clean; Dialyzer 0 errors