### PR TITLE
fix: update Moonshot Kimi metadata

### DIFF
--- a/priv/llm_db/local/moonshotai/kimi-k2.5.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k2.5.toml
@@ -14,3 +14,9 @@ family = "openai_chat_compatible"
 wire_protocol = "openai_chat"
 transport = "http_request"
 path = "/chat/completions"
+
+[lifecycle]
+status = "deprecated"
+deprecated_at = "2026-07-17"
+retires_at = "2026-08-31"
+replacement = "kimi-k3"

--- a/priv/llm_db/local/moonshotai/kimi-k3.toml
+++ b/priv/llm_db/local/moonshotai/kimi-k3.toml
@@ -1,0 +1,35 @@
+id = "kimi-k3"
+catalog_only = false
+
+[limits]
+output = 1048576
+
+[capabilities.json]
+native = true
+schema = true
+strict = true
+
+[extra]
+description = "Multimodal Kimi flagship with a 1M-token context window and always-on max-effort reasoning"
+reasoning_options = [{ type = "effort", values = ["max"] }]
+structured_output = true
+temperature = false
+
+[extra.constraints]
+token_limit_key = "max_completion_tokens"
+temperature = "fixed_1"
+reasoning_effort = "required"
+
+[execution.text]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"
+
+[execution.object]
+supported = true
+family = "openai_chat_compatible"
+wire_protocol = "openai_chat"
+transport = "http_request"
+path = "/chat/completions"

--- a/priv/llm_db/local/moonshotai/provider.toml
+++ b/priv/llm_db/local/moonshotai/provider.toml
@@ -2,13 +2,13 @@
 id = "moonshotai"
 name = "Moonshot AI"
 base_url = "https://api.moonshot.ai/v1"
-doc = "https://platform.moonshot.ai/docs/api/chat"
+doc = "https://platform.kimi.ai/docs/api/chat"
 
 env = ["MOONSHOT_API_KEY"]
 
 [runtime]
 base_url = "https://api.moonshot.ai/v1"
-doc_url = "https://platform.moonshot.ai/docs/api/chat"
+doc_url = "https://platform.kimi.ai/docs/api/chat"
 
 [runtime.auth]
 type = "bearer"

--- a/test/llm_db/packaged_test.exs
+++ b/test/llm_db/packaged_test.exs
@@ -116,6 +116,7 @@ defmodule LLMDB.PackagedTest do
         refute Map.get(nearai, "catalog_only", false)
         assert moonshot["runtime"]["auth"]["type"] == "bearer"
         assert moonshot["runtime"]["base_url"] == "https://api.moonshot.ai/v1"
+        assert moonshot["runtime"]["doc_url"] == "https://platform.kimi.ai/docs/api/chat"
         assert moonshot_cn["runtime"]["auth"]["type"] == "bearer"
         assert moonshot_cn["runtime"]["base_url"] == "https://api.moonshot.cn/v1"
         assert opencode["runtime"]["auth"]["type"] == "bearer"
@@ -231,6 +232,66 @@ defmodule LLMDB.PackagedTest do
           assert model["execution"]["object"]["wire_protocol"] == "openai_chat"
           assert model["execution"]["object"]["path"] == "/chat/completions"
         end
+      end
+    end
+
+    test "snapshot carries verified Moonshot Kimi K3 metadata" do
+      snapshot = Packaged.snapshot()
+
+      if snapshot do
+        model = snapshot["providers"]["moonshotai"]["models"]["kimi-k3"]
+
+        refute model["catalog_only"] == true
+        assert model["limits"]["context"] == 1_048_576
+        assert model["limits"]["output"] == 1_048_576
+        assert model["cost"] == %{"cache_read" => 0.3, "input" => 3, "output" => 15}
+
+        assert model["modalities"] == %{
+                 "input" => ["text", "image", "video"],
+                 "output" => ["text"]
+               }
+
+        assert model["capabilities"]["reasoning"]["enabled"] == true
+
+        assert model["capabilities"]["json"] == %{
+                 "native" => true,
+                 "schema" => true,
+                 "strict" => true
+               }
+
+        assert model["extra"]["reasoning_options"] == [
+                 %{"type" => "effort", "values" => ["max"]}
+               ]
+
+        assert model["extra"]["temperature"] == false
+
+        assert model["extra"]["constraints"] == %{
+                 "reasoning_effort" => "required",
+                 "temperature" => "fixed_1",
+                 "token_limit_key" => "max_completion_tokens"
+               }
+
+        assert model["execution"]["text"]["family"] == "openai_chat_compatible"
+        assert model["execution"]["text"]["wire_protocol"] == "openai_chat"
+        assert model["execution"]["text"]["path"] == "/chat/completions"
+        assert model["execution"]["object"]["family"] == "openai_chat_compatible"
+        assert model["execution"]["object"]["wire_protocol"] == "openai_chat"
+        assert model["execution"]["object"]["path"] == "/chat/completions"
+      end
+    end
+
+    test "snapshot carries Moonshot Kimi K2.5 retirement metadata" do
+      snapshot = Packaged.snapshot()
+
+      if snapshot do
+        model = snapshot["providers"]["moonshotai"]["models"]["kimi-k2.5"]
+
+        assert model["deprecated"] == true
+        assert model["retired"] == false
+        assert model["lifecycle"]["status"] == "deprecated"
+        assert model["lifecycle"]["deprecated_at"] == "2026-07-17"
+        assert model["lifecycle"]["retires_at"] == "2026-08-31"
+        assert model["lifecycle"]["replacement"] == "kimi-k3"
       end
     end
 


### PR DESCRIPTION
## Summary

- add a sparse Moonshot Kimi K3 override so the direct model has a verified OpenAI-compatible execution contract
- correct K3's maximum output, always-on max reasoning, fixed temperature, and strict JSON Schema metadata
- record Kimi K2.5's documented deprecation and August 31, 2026 retirement
- update Moonshot's provider documentation URL and regenerate the packaged snapshot

## Why

The refreshed aggregate metadata made `moonshotai:kimi-k3` discoverable, but it remained `catalog_only` and therefore non-executable to runtime consumers. It also treated K3's default completion limit as its maximum and described reasoning and temperature as configurable in ways the official Moonshot API does not support.

These docs-only facts belong in sparse local overrides because Moonshot does not expose an unauthenticated model API payload for this repository to cache.

## Official evidence

- [Kimi K3 quickstart](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart): model ID, direct chat endpoint, 1M context, image/video input, max-only reasoning, fixed sampling parameters, structured output, and 1,048,576 maximum completion tokens
- [Chat Completions API](https://platform.kimi.ai/docs/api/chat): `/v1/chat/completions`, `kimi-k3`, `max_completion_tokens`, JSON modes, tool calling, and `reasoning_effort=max`
- [Moonshot model list](https://platform.kimi.ai/docs/models): Kimi K3 inventory and Kimi K2.5's August 31, 2026 platform sunset
- [Kimi K3 pricing](https://platform.kimi.ai/docs/pricing/chat-k3): cache-hit input, cache-miss input, and output pricing

## Validation

- `mix llm_db.build --install`
- `mix test test/llm_db/packaged_test.exs` — 15 passed
- `mix test` — 870 passed (41 doctests, 829 tests)
- pre-push `mix quality` — Credo and Dialyzer passed
