### PR TITLE
fix(openrouter): consolidate alias targets

### DIFF
--- a/lib/llm_db/engine/merge.ex
+++ b/lib/llm_db/engine/merge.ex
@@ -134,7 +134,10 @@ defmodule LLMDB.Merge do
       deep_merge(
         base_provider,
         override_provider,
-        resolver(preserve_empty_list_keys: [:exclude_models])
+        resolver(
+          union_list_keys: [:exclude_models],
+          preserve_empty_list_keys: [:exclude_models]
+        )
       )
     end)
     |> Map.values()

--- a/lib/llm_db/sources/openrouter.ex
+++ b/lib/llm_db/sources/openrouter.ex
@@ -153,20 +153,62 @@ defmodule LLMDB.Sources.OpenRouter do
   def transform(content) when is_map(content) do
     models = Map.get(content, "data", [])
 
-    canonical_models =
+    {canonical_models, resolved_alias_ids} =
       models
       |> Enum.map(&transform_model/1)
+      |> consolidate_alias_targets(models)
 
     %{
       "openrouter" => %{
         id: :openrouter,
         name: "OpenRouter",
+        exclude_models: resolved_alias_ids,
         models: canonical_models
       }
     }
   end
 
   # Private helpers
+
+  defp consolidate_alias_targets(canonical_models, source_models) do
+    model_ids = MapSet.new(canonical_models, & &1.id)
+
+    {aliases_by_target, resolved_alias_ids} =
+      Enum.reduce(source_models, {%{}, []}, fn source_model,
+                                               {aliases_by_target, resolved_alias_ids} ->
+        alias_id = source_model["id"]
+        target_id = get_in(source_model, ["alias_target", "slug"])
+
+        if is_binary(alias_id) and is_binary(target_id) and alias_id != target_id and
+             MapSet.member?(model_ids, target_id) do
+          {
+            Map.update(aliases_by_target, target_id, [alias_id], &[alias_id | &1]),
+            [alias_id | resolved_alias_ids]
+          }
+        else
+          {aliases_by_target, resolved_alias_ids}
+        end
+      end)
+
+    resolved_alias_id_set = MapSet.new(resolved_alias_ids)
+
+    models =
+      canonical_models
+      |> Enum.reject(&MapSet.member?(resolved_alias_id_set, &1.id))
+      |> Enum.map(fn model ->
+        case Map.get(aliases_by_target, model.id) do
+          nil ->
+            model
+
+          aliases ->
+            Map.update(model, :aliases, Enum.reverse(aliases), fn current_aliases ->
+              Enum.uniq(current_aliases ++ Enum.reverse(aliases))
+            end)
+        end
+      end)
+
+    {models, Enum.reverse(resolved_alias_ids)}
+  end
 
   defp get_cache_dir do
     Application.get_env(:llm_db, :openrouter_cache_dir, @default_cache_dir)

--- a/lib/llm_db/sources/openrouter.ex
+++ b/lib/llm_db/sources/openrouter.ex
@@ -173,20 +173,33 @@ defmodule LLMDB.Sources.OpenRouter do
   defp consolidate_alias_targets(canonical_models, source_models) do
     model_ids = MapSet.new(canonical_models, & &1.id)
 
-    {aliases_by_target, resolved_alias_ids} =
-      Enum.reduce(source_models, {%{}, []}, fn source_model,
-                                               {aliases_by_target, resolved_alias_ids} ->
+    direct_targets =
+      Enum.reduce(source_models, %{}, fn source_model, direct_targets ->
         alias_id = source_model["id"]
         target_id = get_in(source_model, ["alias_target", "slug"])
 
         if is_binary(alias_id) and is_binary(target_id) and alias_id != target_id and
              MapSet.member?(model_ids, target_id) do
-          {
-            Map.update(aliases_by_target, target_id, [alias_id], &[alias_id | &1]),
-            [alias_id | resolved_alias_ids]
-          }
+          Map.put(direct_targets, alias_id, target_id)
         else
-          {aliases_by_target, resolved_alias_ids}
+          direct_targets
+        end
+      end)
+
+    {aliases_by_target, resolved_alias_ids} =
+      Enum.reduce(source_models, {%{}, []}, fn source_model,
+                                               {aliases_by_target, resolved_alias_ids} ->
+        alias_id = source_model["id"]
+
+        case resolve_alias_target(alias_id, direct_targets) do
+          {:ok, target_id} ->
+            {
+              Map.update(aliases_by_target, target_id, [alias_id], &[alias_id | &1]),
+              [alias_id | resolved_alias_ids]
+            }
+
+          :error ->
+            {aliases_by_target, resolved_alias_ids}
         end
       end)
 
@@ -208,6 +221,32 @@ defmodule LLMDB.Sources.OpenRouter do
       end)
 
     {models, Enum.reverse(resolved_alias_ids)}
+  end
+
+  defp resolve_alias_target(alias_id, direct_targets) when is_binary(alias_id) do
+    case Map.fetch(direct_targets, alias_id) do
+      {:ok, target_id} ->
+        follow_alias_target(target_id, direct_targets, MapSet.new([alias_id]))
+
+      :error ->
+        :error
+    end
+  end
+
+  defp resolve_alias_target(_alias_id, _direct_targets), do: :error
+
+  defp follow_alias_target(target_id, direct_targets, visited) do
+    if MapSet.member?(visited, target_id) do
+      :error
+    else
+      case Map.fetch(direct_targets, target_id) do
+        {:ok, next_target_id} ->
+          follow_alias_target(next_target_id, direct_targets, MapSet.put(visited, target_id))
+
+        :error ->
+          {:ok, target_id}
+      end
+    end
   end
 
   defp get_cache_dir do

--- a/test/llm_db/engine/merge_test.exs
+++ b/test/llm_db/engine/merge_test.exs
@@ -189,6 +189,20 @@ defmodule LLMDB.Engine.MergeTest do
       assert provider.config.max_tokens == 1000
     end
 
+    test "keeps model exclusions from all provider sources" do
+      base = [
+        %{id: :test_provider_alpha, exclude_models: ["base-model"]}
+      ]
+
+      override = [
+        %{id: :test_provider_alpha, exclude_models: ["override-model"]}
+      ]
+
+      [provider] = Merge.merge_providers(base, override)
+
+      assert provider.exclude_models == ["base-model", "override-model"]
+    end
+
     test "handles empty base list" do
       result = Merge.merge_providers([], [%{id: :test_provider_alpha}])
       assert length(result) == 1

--- a/test/llm_db/sources/openrouter_test.exs
+++ b/test/llm_db/sources/openrouter_test.exs
@@ -509,6 +509,58 @@ defmodule LLMDB.Sources.OpenRouterTest do
       assert Map.has_key?(result, "openrouter")
       assert result["openrouter"][:models] == []
     end
+
+    test "consolidates an exact alias target into the canonical model" do
+      input = %{
+        "data" => [
+          %{
+            "id" => "anthropic/claude-fable-latest",
+            "name" => "Anthropic: Claude Fable Latest",
+            "alias_target" => %{"slug" => "anthropic/claude-fable-5"}
+          },
+          %{
+            "id" => "anthropic/claude-fable-5",
+            "name" => "Anthropic: Claude Fable 5"
+          }
+        ]
+      }
+
+      result = OpenRouter.transform(input)
+
+      assert result["openrouter"][:exclude_models] == [
+               "anthropic/claude-fable-latest"
+             ]
+
+      assert [
+               %{
+                 id: "anthropic/claude-fable-5",
+                 aliases: ["anthropic/claude-fable-latest"]
+               }
+             ] = result["openrouter"][:models]
+    end
+
+    test "keeps an alias model when its target is not in the response" do
+      input = %{
+        "data" => [
+          %{
+            "id" => "anthropic/claude-fable-latest",
+            "name" => "Anthropic: Claude Fable Latest",
+            "alias_target" => %{"slug" => "anthropic/claude-fable-5"}
+          }
+        ]
+      }
+
+      result = OpenRouter.transform(input)
+
+      assert result["openrouter"][:exclude_models] == []
+
+      assert [
+               %{
+                 id: "anthropic/claude-fable-latest",
+                 extra: %{alias_target: %{"slug" => "anthropic/claude-fable-5"}}
+               }
+             ] = result["openrouter"][:models]
+    end
   end
 
   describe "integration" do

--- a/test/llm_db/sources/openrouter_test.exs
+++ b/test/llm_db/sources/openrouter_test.exs
@@ -561,6 +561,67 @@ defmodule LLMDB.Sources.OpenRouterTest do
                }
              ] = result["openrouter"][:models]
     end
+
+    test "resolves an alias chain to the final canonical model" do
+      input = %{
+        "data" => [
+          %{
+            "id" => "test/model-latest",
+            "name" => "Model Latest",
+            "alias_target" => %{"slug" => "test/model-current"}
+          },
+          %{
+            "id" => "test/model-current",
+            "name" => "Model Current",
+            "alias_target" => %{"slug" => "test/model-1"}
+          },
+          %{
+            "id" => "test/model-1",
+            "name" => "Model 1"
+          }
+        ]
+      }
+
+      result = OpenRouter.transform(input)
+
+      assert result["openrouter"][:exclude_models] == [
+               "test/model-latest",
+               "test/model-current"
+             ]
+
+      assert [
+               %{
+                 id: "test/model-1",
+                 aliases: ["test/model-latest", "test/model-current"]
+               }
+             ] = result["openrouter"][:models]
+    end
+
+    test "keeps every model in an alias cycle" do
+      input = %{
+        "data" => [
+          %{
+            "id" => "test/model-a",
+            "name" => "Model A",
+            "alias_target" => %{"slug" => "test/model-b"}
+          },
+          %{
+            "id" => "test/model-b",
+            "name" => "Model B",
+            "alias_target" => %{"slug" => "test/model-a"}
+          }
+        ]
+      }
+
+      result = OpenRouter.transform(input)
+
+      assert result["openrouter"][:exclude_models] == []
+
+      assert [
+               %{id: "test/model-a", extra: %{alias_target: %{"slug" => "test/model-b"}}},
+               %{id: "test/model-b", extra: %{alias_target: %{"slug" => "test/model-a"}}}
+             ] = result["openrouter"][:models]
+    end
   end
 
   describe "integration" do


### PR DESCRIPTION
## Summary

- Convert exact OpenRouter `alias_target.slug` records into aliases on the canonical target model.
- Keep an alias record when its target is not present, so the import does not lose data.
- Union provider `exclude_models` values across source layers so resolved alias rows from lower-priority data are removed from the final snapshot.
- Rebuild the packaged snapshot with 6,203 canonical models and 470 OpenRouter models.

## Root cause

OpenRouter identifies moving `latest` model IDs with `alias_target.slug`. The importer treated these records as independent models. The lower-priority Models.dev layer could also retain the alias row, while the local provider exclusion list replaced exclusions from the OpenRouter source. This produced duplicate identities such as Claude Fable Latest and Claude Fable 5.

## Impact

Alias lookups continue to work, but catalog enumeration now returns the canonical target only. For example, `~anthropic/claude-fable-latest` resolves to `anthropic/claude-fable-5` and is not returned as a separate OpenRouter model.

## Validation

- `mix format --check-formatted`
- `mix llm_db.build --check --install`
- `mix test` — 873 passed
- `mix quality` — Credo and Dialyzer passed