### PR TITLE
feat: filter models by architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ LLMDB.providers()
 LLMDB.allowed?("openai:gpt-4o-mini") #=> true
 ```
 
+Architecture classification uses optional llmfit metadata. Models without
+usable architecture metadata have the `:unknown` classification.
+
 ## API Cheatsheet
 
 - **`model/1`** — `"provider:model"`, `"model@provider"`, `{:provider, id}`, or `{"provider", id}` → `{:ok, %Model{}}` | `{:error, _}`

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ model.id  #=> "claude-haiku-4-5-20251001" (canonical ID)
 )
 {:ok, model} = LLMDB.model({provider, id})
 
+# Filter by model architecture
+moe_models = LLMDB.candidates(architecture: :moe)
+dense_models = LLMDB.candidates(architecture: :dense)
+unclassified_models = LLMDB.candidates(architecture: :unknown)
+
 # List providers
 LLMDB.providers()
 #=> [%LLMDB.Provider{id: :anthropic, ...}, %LLMDB.Provider{id: :openai, ...}]

--- a/lib/llm_db.ex
+++ b/lib/llm_db.ex
@@ -321,7 +321,8 @@ defmodule LLMDB do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order
   - `:scope` - Either `:all` (default) or a specific provider atom
-  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`)
+  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`).
+    Models without usable llmfit architecture metadata are `:unknown`.
 
   ## Returns
 
@@ -350,7 +351,8 @@ defmodule LLMDB do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order
   - `:scope` - Either `:all` (default) or a specific provider atom
-  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`)
+  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`).
+    Models without usable llmfit architecture metadata are `:unknown`.
 
   ## Returns
 

--- a/lib/llm_db.ex
+++ b/lib/llm_db.ex
@@ -321,6 +321,7 @@ defmodule LLMDB do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order
   - `:scope` - Either `:all` (default) or a specific provider atom
+  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`)
 
   ## Returns
 
@@ -349,6 +350,7 @@ defmodule LLMDB do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order
   - `:scope` - Either `:all` (default) or a specific provider atom
+  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`)
 
   ## Returns
 

--- a/lib/llm_db/query.ex
+++ b/lib/llm_db/query.ex
@@ -47,7 +47,8 @@ defmodule LLMDB.Query do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order (e.g., `[:openai, :anthropic]`)
   - `:scope` - Either `:all` (default) or a specific provider atom
-  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`)
+  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`).
+    Models without usable llmfit architecture metadata are `:unknown`.
 
   ## Returns
 
@@ -101,7 +102,8 @@ defmodule LLMDB.Query do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order (e.g., `[:openai, :anthropic]`)
   - `:scope` - Either `:all` (default) or a specific provider atom
-  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`)
+  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`).
+    Models without usable llmfit architecture metadata are `:unknown`.
 
   ## Returns
 
@@ -240,11 +242,19 @@ defmodule LLMDB.Query do
       llmfit when is_map(llmfit) ->
         case metadata_value(metadata_value(llmfit, :moe), :is_moe) do
           true -> :moe
-          _ -> :dense
+          false -> :dense
+          _ -> if usable_architecture?(llmfit), do: :dense, else: :unknown
         end
 
       _ ->
         :unknown
+    end
+  end
+
+  defp usable_architecture?(llmfit) do
+    case metadata_value(llmfit, :architecture) do
+      architecture when is_binary(architecture) -> String.trim(architecture) != ""
+      _ -> false
     end
   end
 

--- a/lib/llm_db/query.ex
+++ b/lib/llm_db/query.ex
@@ -33,6 +33,8 @@ defmodule LLMDB.Query do
     streaming_tool_calls: [:streaming, :tool_calls]
   }
 
+  @architecture_types [:dense, :moe, :unknown]
+
   @doc """
   Selects the first model matching capability requirements.
 
@@ -45,6 +47,7 @@ defmodule LLMDB.Query do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order (e.g., `[:openai, :anthropic]`)
   - `:scope` - Either `:all` (default) or a specific provider atom
+  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`)
 
   ## Returns
 
@@ -62,12 +65,15 @@ defmodule LLMDB.Query do
         require: [json_native: true],
         scope: :openai
       )
+
+      {:ok, {provider, model_id}} = Query.select(architecture: :moe)
   """
   @spec select(keyword()) :: {:ok, {provider(), model_id()}} | {:error, :no_match}
   def select(opts \\ []) do
     require_kw = Keyword.get(opts, :require, [])
     forbid_kw = Keyword.get(opts, :forbid, [])
     scope = Keyword.get(opts, :scope, :all)
+    architecture = opts |> Keyword.get(:architecture, :all) |> validate_architecture!()
 
     # Use snapshot.prefer as default if :prefer not explicitly provided
     prefer =
@@ -80,7 +86,7 @@ defmodule LLMDB.Query do
       end
 
     providers = build_provider_list(scope, prefer)
-    find_first_match(providers, require_kw, forbid_kw)
+    find_first_match(providers, require_kw, forbid_kw, architecture)
   end
 
   @doc """
@@ -95,6 +101,7 @@ defmodule LLMDB.Query do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order (e.g., `[:openai, :anthropic]`)
   - `:scope` - Either `:all` (default) or a specific provider atom
+  - `:architecture` - One of `:dense`, `:moe`, or `:unknown` (default: `:all`)
 
   ## Returns
 
@@ -113,12 +120,15 @@ defmodule LLMDB.Query do
         scope: :openai
       )
       #=> [{:openai, "gpt-4o"}, {:openai, "gpt-4o-mini"}, ...]
+
+      moe_candidates = Query.candidates(architecture: :moe)
   """
   @spec candidates(keyword()) :: [{provider(), model_id()}]
   def candidates(opts \\ []) do
     require_kw = Keyword.get(opts, :require, [])
     forbid_kw = Keyword.get(opts, :forbid, [])
     scope = Keyword.get(opts, :scope, :all)
+    architecture = opts |> Keyword.get(:architecture, :all) |> validate_architecture!()
 
     prefer =
       case Keyword.fetch(opts, :prefer) do
@@ -130,7 +140,7 @@ defmodule LLMDB.Query do
       end
 
     providers = build_provider_list(scope, prefer)
-    find_all_matches(providers, require_kw, forbid_kw)
+    find_all_matches(providers, require_kw, forbid_kw, architecture)
   end
 
   @doc """
@@ -187,28 +197,65 @@ defmodule LLMDB.Query do
     [provider]
   end
 
-  defp find_first_match([], _require_kw, _forbid_kw), do: {:error, :no_match}
+  defp find_first_match([], _require_kw, _forbid_kw, _architecture), do: {:error, :no_match}
 
-  defp find_first_match([provider | rest], require_kw, forbid_kw) do
+  defp find_first_match([provider | rest], require_kw, forbid_kw, architecture) do
     models_list =
       Catalog.models(provider)
       |> Enum.filter(&matches_require?(&1, require_kw))
       |> Enum.reject(&matches_forbid?(&1, forbid_kw))
+      |> Enum.filter(&matches_architecture?(&1, architecture))
 
     case models_list do
-      [] -> find_first_match(rest, require_kw, forbid_kw)
+      [] -> find_first_match(rest, require_kw, forbid_kw, architecture)
       [model | _] -> {:ok, {provider, model.id}}
     end
   end
 
-  defp find_all_matches(providers, require_kw, forbid_kw) do
+  defp find_all_matches(providers, require_kw, forbid_kw, architecture) do
     Enum.flat_map(providers, fn provider ->
       Catalog.models(provider)
       |> Enum.filter(&matches_require?(&1, require_kw))
       |> Enum.reject(&matches_forbid?(&1, forbid_kw))
+      |> Enum.filter(&matches_architecture?(&1, architecture))
       |> Enum.map(&{provider, &1.id})
     end)
   end
+
+  defp validate_architecture!(:all), do: :all
+
+  defp validate_architecture!(architecture) when architecture in @architecture_types,
+    do: architecture
+
+  defp validate_architecture!(architecture) do
+    raise ArgumentError,
+          "architecture must be :dense, :moe, :unknown, or :all, got: #{inspect(architecture)}"
+  end
+
+  defp matches_architecture?(_model, :all), do: true
+  defp matches_architecture?(model, architecture), do: architecture_type(model) == architecture
+
+  defp architecture_type(model) do
+    case metadata_value(Map.get(model, :extra), :llmfit) do
+      llmfit when is_map(llmfit) ->
+        case metadata_value(metadata_value(llmfit, :moe), :is_moe) do
+          true -> :moe
+          _ -> :dense
+        end
+
+      _ ->
+        :unknown
+    end
+  end
+
+  defp metadata_value(map, key) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
+  end
+
+  defp metadata_value(_map, _key), do: nil
 
   defp matches_require?(_model, []), do: true
 

--- a/test/llm_db/api_test.exs
+++ b/test/llm_db/api_test.exs
@@ -22,6 +22,7 @@ defmodule LLMDB.APITest do
       %{
         id: "gpt-4o",
         provider: :openai,
+        extra: %{llmfit: %{architecture: "dense-transformer"}},
         capabilities: %{chat: true, tools: %{enabled: true}, json: %{native: true}}
       },
       %{
@@ -32,6 +33,7 @@ defmodule LLMDB.APITest do
       %{
         id: "claude-3-5-sonnet-20241022",
         provider: :anthropic,
+        extra: %{"llmfit" => %{"moe" => %{"is_moe" => true}}},
         capabilities: %{chat: true, tools: %{enabled: true}, json: %{native: false}}
       },
       %{
@@ -176,6 +178,39 @@ defmodule LLMDB.APITest do
       candidates = LLMDB.candidates(require: [rerank: true])
 
       assert candidates == [{:cohere, "rerank-v3.5"}]
+    end
+
+    test "filters by dense architecture" do
+      assert LLMDB.candidates(architecture: :dense) == [{:openai, "gpt-4o"}]
+    end
+
+    test "filters by MoE architecture with snapshot string keys" do
+      assert LLMDB.candidates(architecture: :moe) == [
+               {:anthropic, "claude-3-5-sonnet-20241022"}
+             ]
+    end
+
+    test "filters models without architecture metadata as unknown" do
+      assert LLMDB.candidates(architecture: :unknown) |> MapSet.new() ==
+               MapSet.new([
+                 {:openai, "gpt-4o-mini"},
+                 {:cohere, "rerank-v3.5"}
+               ])
+    end
+
+    test "combines architecture and capability filters" do
+      assert LLMDB.candidates(require: [chat: true], architecture: :moe) == [
+               {:anthropic, "claude-3-5-sonnet-20241022"}
+             ]
+
+      assert {:ok, {:anthropic, "claude-3-5-sonnet-20241022"}} =
+               LLMDB.select(require: [chat: true], architecture: :moe)
+    end
+
+    test "rejects an invalid architecture filter" do
+      assert_raise ArgumentError, ~r/architecture must be/, fn ->
+        LLMDB.candidates(architecture: :sparse)
+      end
     end
   end
 

--- a/test/llm_db/api_test.exs
+++ b/test/llm_db/api_test.exs
@@ -28,6 +28,7 @@ defmodule LLMDB.APITest do
       %{
         id: "gpt-4o-mini",
         provider: :openai,
+        extra: %{llmfit: %{}},
         capabilities: %{chat: true, tools: %{enabled: true}, json: %{native: true}}
       },
       %{
@@ -190,7 +191,7 @@ defmodule LLMDB.APITest do
              ]
     end
 
-    test "filters models without architecture metadata as unknown" do
+    test "filters models with missing or unusable architecture metadata as unknown" do
       assert LLMDB.candidates(architecture: :unknown) |> MapSet.new() ==
                MapSet.new([
                  {:openai, "gpt-4o-mini"},


### PR DESCRIPTION
## Summary

- add `:architecture` filtering to `LLMDB.select/1` and `LLMDB.candidates/1`
- support `:dense`, `:moe`, and `:unknown` classifications
- support atom-keyed build metadata and string-keyed snapshot metadata
- document the new option and add API tests

## Impact

Consumers can limit model selection to dense, MoE, or unclassified models. Existing queries keep the current behavior because the default is `:all`.

## Validation

- `mix test` (883 passed)
- `mix quality`

Closes #292