### PR TITLE
feat: sort models by size

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ model.id  #=> "claude-haiku-4-5-20251001" (canonical ID)
 )
 {:ok, model} = LLMDB.model({provider, id})
 
-# Sort model candidates by hardware-relevant model size
+# Sort by optional extra.llmfit size metadata; models without values are last
 smallest_models = LLMDB.candidates(
   sort_by: :total_parameters,
   sort_order: :asc

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ model.id  #=> "claude-haiku-4-5-20251001" (canonical ID)
 )
 {:ok, model} = LLMDB.model({provider, id})
 
+# Sort model candidates by hardware-relevant model size
+smallest_models = LLMDB.candidates(
+  sort_by: :total_parameters,
+  sort_order: :asc
+)
+
 # List providers
 LLMDB.providers()
 #=> [%LLMDB.Provider{id: :anthropic, ...}, %LLMDB.Provider{id: :openai, ...}]

--- a/lib/llm_db.ex
+++ b/lib/llm_db.ex
@@ -322,8 +322,8 @@ defmodule LLMDB do
   - `:prefer` - List of provider atoms in preference order
   - `:scope` - Either `:all` (default) or a specific provider atom
   - `:sort_by` - `:total_parameters`, `:active_parameters`, `:minimum_ram_gb`, or
-    `:minimum_vram_gb` (optional)
-  - `:sort_order` - `:asc` (default) or `:desc`; missing values are always last
+    `:minimum_vram_gb` from optional `extra.llmfit` metadata
+  - `:sort_order` - `:asc` (default) or `:desc`; models without a numeric value are last
 
   ## Returns
 
@@ -353,8 +353,8 @@ defmodule LLMDB do
   - `:prefer` - List of provider atoms in preference order
   - `:scope` - Either `:all` (default) or a specific provider atom
   - `:sort_by` - `:total_parameters`, `:active_parameters`, `:minimum_ram_gb`, or
-    `:minimum_vram_gb` (optional)
-  - `:sort_order` - `:asc` (default) or `:desc`; missing values are always last
+    `:minimum_vram_gb` from optional `extra.llmfit` metadata
+  - `:sort_order` - `:asc` (default) or `:desc`; models without a numeric value are last
 
   ## Returns
 

--- a/lib/llm_db.ex
+++ b/lib/llm_db.ex
@@ -311,7 +311,7 @@ defmodule LLMDB do
   # Selection (delegated to Query)
 
   @doc """
-  Selects the first model matching capability requirements.
+  Selects the first model matching capability and sort requirements.
 
   Delegates to `LLMDB.Query.select/1`.
 
@@ -321,6 +321,9 @@ defmodule LLMDB do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order
   - `:scope` - Either `:all` (default) or a specific provider atom
+  - `:sort_by` - `:total_parameters`, `:active_parameters`, `:minimum_ram_gb`, or
+    `:minimum_vram_gb` (optional)
+  - `:sort_order` - `:asc` (default) or `:desc`; missing values are always last
 
   ## Returns
 
@@ -339,7 +342,7 @@ defmodule LLMDB do
   defdelegate select(opts), to: Query
 
   @doc """
-  Returns all models matching capability requirements.
+  Returns all models matching capability and sort requirements.
 
   Delegates to `LLMDB.Query.candidates/1`.
 
@@ -349,6 +352,9 @@ defmodule LLMDB do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order
   - `:scope` - Either `:all` (default) or a specific provider atom
+  - `:sort_by` - `:total_parameters`, `:active_parameters`, `:minimum_ram_gb`, or
+    `:minimum_vram_gb` (optional)
+  - `:sort_order` - `:asc` (default) or `:desc`; missing values are always last
 
   ## Returns
 

--- a/lib/llm_db/query.ex
+++ b/lib/llm_db/query.ex
@@ -1,8 +1,9 @@
 defmodule LLMDB.Query do
   @moduledoc """
-  Query functions for selecting models based on capabilities and requirements.
+  Query functions for selecting models based on capabilities and model size.
 
-  Provides capability-based model selection with provider preferences.
+  Provides capability-based model selection with provider preferences and
+  optional hardware-related sorting.
   All queries operate on the filtered catalog loaded into the Store.
   """
 
@@ -33,11 +34,13 @@ defmodule LLMDB.Query do
     streaming_tool_calls: [:streaming, :tool_calls]
   }
 
+  @sort_fields [:total_parameters, :active_parameters, :minimum_ram_gb, :minimum_vram_gb]
+
   @doc """
   Selects the first model matching capability requirements.
 
-  Returns the first allowed model that matches the required capabilities,
-  in provider preference order.
+  Returns the first allowed model that matches the required capabilities.
+  Provider preference controls the order unless `:sort_by` is set.
 
   ## Options
 
@@ -45,6 +48,9 @@ defmodule LLMDB.Query do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order (e.g., `[:openai, :anthropic]`)
   - `:scope` - Either `:all` (default) or a specific provider atom
+  - `:sort_by` - `:total_parameters`, `:active_parameters`, `:minimum_ram_gb`, or
+    `:minimum_vram_gb` (optional)
+  - `:sort_order` - `:asc` (default) or `:desc`; missing values are always last
 
   ## Returns
 
@@ -62,12 +68,18 @@ defmodule LLMDB.Query do
         require: [json_native: true],
         scope: :openai
       )
+
+      {:ok, {provider, model_id}} = Query.select(
+        sort_by: :total_parameters
+      )
   """
   @spec select(keyword()) :: {:ok, {provider(), model_id()}} | {:error, :no_match}
   def select(opts \\ []) do
     require_kw = Keyword.get(opts, :require, [])
     forbid_kw = Keyword.get(opts, :forbid, [])
     scope = Keyword.get(opts, :scope, :all)
+    sort_by = opts |> Keyword.get(:sort_by) |> validate_sort_by!()
+    sort_order = opts |> Keyword.get(:sort_order, :asc) |> validate_sort_order!()
 
     # Use snapshot.prefer as default if :prefer not explicitly provided
     prefer =
@@ -80,14 +92,28 @@ defmodule LLMDB.Query do
       end
 
     providers = build_provider_list(scope, prefer)
-    find_first_match(providers, require_kw, forbid_kw)
+
+    case sort_by do
+      nil ->
+        find_first_match(providers, require_kw, forbid_kw)
+
+      _ ->
+        providers
+        |> find_all_matching_models(require_kw, forbid_kw)
+        |> sort_models(sort_by, sort_order)
+        |> case do
+          [] -> {:error, :no_match}
+          [model | _] -> {:ok, {model.provider, model.id}}
+        end
+    end
   end
 
   @doc """
   Gets all allowed models matching capability requirements.
 
-  Returns all models that match the capability filters in preference order.
-  Similar to `select/1` but returns all matches instead of just the first.
+  Returns all models that match the capability filters. Provider preference
+  controls the order unless `:sort_by` is set. Similar to `select/1` but
+  returns all matches instead of only the first.
 
   ## Options
 
@@ -95,10 +121,13 @@ defmodule LLMDB.Query do
   - `:forbid` - Keyword list of forbidden capabilities
   - `:prefer` - List of provider atoms in preference order (e.g., `[:openai, :anthropic]`)
   - `:scope` - Either `:all` (default) or a specific provider atom
+  - `:sort_by` - `:total_parameters`, `:active_parameters`, `:minimum_ram_gb`, or
+    `:minimum_vram_gb` (optional)
+  - `:sort_order` - `:asc` (default) or `:desc`; missing values are always last
 
   ## Returns
 
-  List of `{provider, model_id}` tuples matching the criteria, in preference order.
+  List of `{provider, model_id}` tuples matching the criteria.
 
   ## Examples
 
@@ -113,12 +142,18 @@ defmodule LLMDB.Query do
         scope: :openai
       )
       #=> [{:openai, "gpt-4o"}, {:openai, "gpt-4o-mini"}, ...]
+
+      local_candidates = Query.candidates(
+        sort_by: :minimum_ram_gb
+      )
   """
   @spec candidates(keyword()) :: [{provider(), model_id()}]
   def candidates(opts \\ []) do
     require_kw = Keyword.get(opts, :require, [])
     forbid_kw = Keyword.get(opts, :forbid, [])
     scope = Keyword.get(opts, :scope, :all)
+    sort_by = opts |> Keyword.get(:sort_by) |> validate_sort_by!()
+    sort_order = opts |> Keyword.get(:sort_order, :asc) |> validate_sort_order!()
 
     prefer =
       case Keyword.fetch(opts, :prefer) do
@@ -130,7 +165,11 @@ defmodule LLMDB.Query do
       end
 
     providers = build_provider_list(scope, prefer)
-    find_all_matches(providers, require_kw, forbid_kw)
+
+    providers
+    |> find_all_matching_models(require_kw, forbid_kw)
+    |> sort_models(sort_by, sort_order)
+    |> Enum.map(&{&1.provider, &1.id})
   end
 
   @doc """
@@ -187,6 +226,14 @@ defmodule LLMDB.Query do
     [provider]
   end
 
+  defp find_all_matching_models(providers, require_kw, forbid_kw) do
+    Enum.flat_map(providers, fn provider ->
+      Catalog.models(provider)
+      |> Enum.filter(&matches_require?(&1, require_kw))
+      |> Enum.reject(&matches_forbid?(&1, forbid_kw))
+    end)
+  end
+
   defp find_first_match([], _require_kw, _forbid_kw), do: {:error, :no_match}
 
   defp find_first_match([provider | rest], require_kw, forbid_kw) do
@@ -201,14 +248,73 @@ defmodule LLMDB.Query do
     end
   end
 
-  defp find_all_matches(providers, require_kw, forbid_kw) do
-    Enum.flat_map(providers, fn provider ->
-      Catalog.models(provider)
-      |> Enum.filter(&matches_require?(&1, require_kw))
-      |> Enum.reject(&matches_forbid?(&1, forbid_kw))
-      |> Enum.map(&{provider, &1.id})
-    end)
+  defp validate_sort_by!(nil), do: nil
+  defp validate_sort_by!(sort_by) when sort_by in @sort_fields, do: sort_by
+
+  defp validate_sort_by!(sort_by) do
+    raise ArgumentError,
+          "sort_by must be one of #{inspect(@sort_fields)}, got: #{inspect(sort_by)}"
   end
+
+  defp validate_sort_order!(sort_order) when sort_order in [:asc, :desc], do: sort_order
+
+  defp validate_sort_order!(sort_order) do
+    raise ArgumentError, "sort_order must be :asc or :desc, got: #{inspect(sort_order)}"
+  end
+
+  defp sort_models(models, nil, _sort_order), do: models
+
+  defp sort_models(models, sort_by, sort_order) do
+    models
+    |> Enum.with_index()
+    |> Enum.sort_by(fn {model, index} ->
+      case model_sort_value(model, sort_by) do
+        value when is_number(value) ->
+          ordered_value = if sort_order == :asc, do: value, else: -value
+          {0, ordered_value, index}
+
+        _ ->
+          {1, 0, index}
+      end
+    end)
+    |> Enum.map(&elem(&1, 0))
+  end
+
+  defp model_sort_value(model, :total_parameters) do
+    model |> llmfit_metadata() |> metadata_value(:parameters_raw)
+  end
+
+  defp model_sort_value(model, :active_parameters) do
+    model
+    |> llmfit_metadata()
+    |> metadata_value(:moe)
+    |> metadata_value(:active_parameters)
+  end
+
+  defp model_sort_value(model, :minimum_ram_gb) do
+    model
+    |> llmfit_metadata()
+    |> metadata_value(:memory)
+    |> metadata_value(:min_ram_gb)
+  end
+
+  defp model_sort_value(model, :minimum_vram_gb) do
+    model
+    |> llmfit_metadata()
+    |> metadata_value(:memory)
+    |> metadata_value(:min_vram_gb)
+  end
+
+  defp llmfit_metadata(model), do: metadata_value(Map.get(model, :extra), :llmfit)
+
+  defp metadata_value(map, key) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
+  end
+
+  defp metadata_value(_map, _key), do: nil
 
   defp matches_require?(_model, []), do: true
 

--- a/lib/llm_db/query.ex
+++ b/lib/llm_db/query.ex
@@ -49,8 +49,8 @@ defmodule LLMDB.Query do
   - `:prefer` - List of provider atoms in preference order (e.g., `[:openai, :anthropic]`)
   - `:scope` - Either `:all` (default) or a specific provider atom
   - `:sort_by` - `:total_parameters`, `:active_parameters`, `:minimum_ram_gb`, or
-    `:minimum_vram_gb` (optional)
-  - `:sort_order` - `:asc` (default) or `:desc`; missing values are always last
+    `:minimum_vram_gb` from optional `extra.llmfit` metadata
+  - `:sort_order` - `:asc` (default) or `:desc`; models without a numeric value are last
 
   ## Returns
 
@@ -100,10 +100,10 @@ defmodule LLMDB.Query do
       _ ->
         providers
         |> find_all_matching_models(require_kw, forbid_kw)
-        |> sort_models(sort_by, sort_order)
+        |> sort_candidates(sort_by, sort_order)
         |> case do
           [] -> {:error, :no_match}
-          [model | _] -> {:ok, {model.provider, model.id}}
+          [{provider, model} | _] -> {:ok, {provider, model.id}}
         end
     end
   end
@@ -122,8 +122,8 @@ defmodule LLMDB.Query do
   - `:prefer` - List of provider atoms in preference order (e.g., `[:openai, :anthropic]`)
   - `:scope` - Either `:all` (default) or a specific provider atom
   - `:sort_by` - `:total_parameters`, `:active_parameters`, `:minimum_ram_gb`, or
-    `:minimum_vram_gb` (optional)
-  - `:sort_order` - `:asc` (default) or `:desc`; missing values are always last
+    `:minimum_vram_gb` from optional `extra.llmfit` metadata
+  - `:sort_order` - `:asc` (default) or `:desc`; models without a numeric value are last
 
   ## Returns
 
@@ -168,8 +168,8 @@ defmodule LLMDB.Query do
 
     providers
     |> find_all_matching_models(require_kw, forbid_kw)
-    |> sort_models(sort_by, sort_order)
-    |> Enum.map(&{&1.provider, &1.id})
+    |> sort_candidates(sort_by, sort_order)
+    |> Enum.map(fn {provider, model} -> {provider, model.id} end)
   end
 
   @doc """
@@ -231,6 +231,7 @@ defmodule LLMDB.Query do
       Catalog.models(provider)
       |> Enum.filter(&matches_require?(&1, require_kw))
       |> Enum.reject(&matches_forbid?(&1, forbid_kw))
+      |> Enum.map(&{provider, &1})
     end)
   end
 
@@ -262,12 +263,12 @@ defmodule LLMDB.Query do
     raise ArgumentError, "sort_order must be :asc or :desc, got: #{inspect(sort_order)}"
   end
 
-  defp sort_models(models, nil, _sort_order), do: models
+  defp sort_candidates(candidates, nil, _sort_order), do: candidates
 
-  defp sort_models(models, sort_by, sort_order) do
-    models
+  defp sort_candidates(candidates, sort_by, sort_order) do
+    candidates
     |> Enum.with_index()
-    |> Enum.sort_by(fn {model, index} ->
+    |> Enum.sort_by(fn {{_provider, model}, index} ->
       case model_sort_value(model, sort_by) do
         value when is_number(value) ->
           ordered_value = if sort_order == :asc, do: value, else: -value

--- a/test/llm_db/api_test.exs
+++ b/test/llm_db/api_test.exs
@@ -22,16 +22,35 @@ defmodule LLMDB.APITest do
       %{
         id: "gpt-4o",
         provider: :openai,
+        extra: %{
+          llmfit: %{
+            parameters_raw: 100_000_000_000,
+            memory: %{min_ram_gb: 60.0, min_vram_gb: 50.0}
+          }
+        },
         capabilities: %{chat: true, tools: %{enabled: true}, json: %{native: true}}
       },
       %{
         id: "gpt-4o-mini",
         provider: :openai,
+        extra: %{
+          llmfit: %{
+            parameters_raw: 10_000_000_000,
+            memory: %{min_ram_gb: 6.0, min_vram_gb: 5.0}
+          }
+        },
         capabilities: %{chat: true, tools: %{enabled: true}, json: %{native: true}}
       },
       %{
         id: "claude-3-5-sonnet-20241022",
         provider: :anthropic,
+        extra: %{
+          "llmfit" => %{
+            "parameters_raw" => 200_000_000_000,
+            "memory" => %{"min_ram_gb" => 120.0, "min_vram_gb" => 100.0},
+            "moe" => %{"active_parameters" => 20_000_000_000}
+          }
+        },
         capabilities: %{chat: true, tools: %{enabled: true}, json: %{native: false}}
       },
       %{
@@ -176,6 +195,56 @@ defmodule LLMDB.APITest do
       candidates = LLMDB.candidates(require: [rerank: true])
 
       assert candidates == [{:cohere, "rerank-v3.5"}]
+    end
+
+    test "sorts by total parameters and places missing values last" do
+      assert LLMDB.candidates(sort_by: :total_parameters) == [
+               {:openai, "gpt-4o-mini"},
+               {:openai, "gpt-4o"},
+               {:anthropic, "claude-3-5-sonnet-20241022"},
+               {:cohere, "rerank-v3.5"}
+             ]
+
+      assert LLMDB.candidates(sort_by: :total_parameters, sort_order: :desc) == [
+               {:anthropic, "claude-3-5-sonnet-20241022"},
+               {:openai, "gpt-4o"},
+               {:openai, "gpt-4o-mini"},
+               {:cohere, "rerank-v3.5"}
+             ]
+    end
+
+    test "sorts by active parameters with snapshot string keys" do
+      assert hd(LLMDB.candidates(sort_by: :active_parameters)) ==
+               {:anthropic, "claude-3-5-sonnet-20241022"}
+    end
+
+    test "sorts by minimum RAM and VRAM" do
+      assert Enum.take(LLMDB.candidates(sort_by: :minimum_ram_gb), 3) == [
+               {:openai, "gpt-4o-mini"},
+               {:openai, "gpt-4o"},
+               {:anthropic, "claude-3-5-sonnet-20241022"}
+             ]
+
+      assert Enum.take(LLMDB.candidates(sort_by: :minimum_vram_gb), 3) == [
+               {:openai, "gpt-4o-mini"},
+               {:openai, "gpt-4o"},
+               {:anthropic, "claude-3-5-sonnet-20241022"}
+             ]
+    end
+
+    test "selects the first sorted model" do
+      assert {:ok, {:openai, "gpt-4o-mini"}} =
+               LLMDB.select(sort_by: :total_parameters)
+    end
+
+    test "rejects invalid sort options" do
+      assert_raise ArgumentError, ~r/sort_by must be/, fn ->
+        LLMDB.candidates(sort_by: :unknown_size)
+      end
+
+      assert_raise ArgumentError, ~r/sort_order must be/, fn ->
+        LLMDB.candidates(sort_order: :sideways)
+      end
     end
   end
 

--- a/test/llm_db/query_sort_test.exs
+++ b/test/llm_db/query_sort_test.exs
@@ -1,0 +1,49 @@
+defmodule LLMDB.QuerySortTest do
+  use ExUnit.Case, async: false
+
+  alias LLMDB.{Catalog, Model, Provider}
+
+  setup do
+    Catalog.clear!()
+    on_exit(&Catalog.clear!/0)
+
+    providers = [
+      Provider.new!(%{id: :google_vertex, name: "Google Vertex"}),
+      Provider.new!(%{id: :google_vertex_anthropic, name: "Vertex Anthropic"})
+    ]
+
+    model =
+      Model.new!(%{
+        id: "claude-model",
+        provider: :google_vertex_anthropic,
+        extra: %{llmfit: %{parameters_raw: 10_000_000_000}}
+      })
+
+    catalog =
+      Catalog.build(providers, [model], [model],
+        filters: %{allow: :all, deny: %{}},
+        prefer: [:google_vertex],
+        loaded_at: "2026-08-11T00:00:00Z",
+        digest: "query-sort-test"
+      )
+
+    Catalog.put!(catalog, source: :test)
+    :ok
+  end
+
+  test "sorted candidates preserve the requested provider route" do
+    assert LLMDB.candidates(scope: :google_vertex, sort_by: :total_parameters) == [
+             {:google_vertex, "claude-model"}
+           ]
+
+    assert LLMDB.candidates(sort_by: :total_parameters) == [
+             {:google_vertex, "claude-model"},
+             {:google_vertex_anthropic, "claude-model"}
+           ]
+  end
+
+  test "sorted selection preserves the requested provider route" do
+    assert LLMDB.select(scope: :google_vertex, sort_by: :total_parameters) ==
+             {:ok, {:google_vertex, "claude-model"}}
+  end
+end


### PR DESCRIPTION
## Summary

- add optional model-size sorting to `LLMDB.select/1` and `LLMDB.candidates/1`
- support total parameters, active parameters, minimum RAM, and minimum VRAM
- support ascending and descending order while keeping missing values last
- preserve provider preference when sorting is not requested
- support atom-keyed build metadata and string-keyed snapshot metadata

## Impact

Consumers can rank candidate models by parameter count or hardware requirements. Existing queries keep the current provider-preference order because sorting is opt-in.

## Validation

- `mix test` (883 passed)
- `mix quality`
- packaged snapshot smoke test for `:total_parameters`

Closes #293