### PR TITLE
chore: update GitHub repository URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@ LLM DB is a model metadata catalog with fast, capability-aware lookups. We value
 
 ```bash
 # Clone the repository
-git clone https://github.com/agentjido/llm_db.git
-cd llm_db
+git clone https://github.com/agentjido/llmdb.git
+cd llmdb
 
 # Install dependencies
 mix deps.get

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Hex.pm](https://img.shields.io/hexpm/v/llm_db.svg)](https://hex.pm/packages/llm_db)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/llm_db/)
-[![CI](https://github.com/agentjido/llm_db/actions/workflows/ci.yml/badge.svg)](https://github.com/agentjido/llm_db/actions/workflows/ci.yml)
-[![License](https://img.shields.io/hexpm/l/llm_db.svg)](https://github.com/agentjido/llm_db/blob/main/LICENSE)
+[![CI](https://github.com/agentjido/llmdb/actions/workflows/ci.yml/badge.svg)](https://github.com/agentjido/llmdb/actions/workflows/ci.yml)
+[![License](https://img.shields.io/hexpm/l/llm_db.svg)](https://github.com/agentjido/llmdb/blob/main/LICENSE)
 [![Website](https://img.shields.io/badge/website-jido.run-0f172a.svg)](https://jido.run)
 [![Ecosystem](https://img.shields.io/badge/ecosystem-jido.run-0ea5e9.svg)](https://jido.run/ecosystem)
 [![Discord](https://img.shields.io/badge/discord-join-5865F2.svg?logo=discord&logoColor=white)](https://jido.run/discord)

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,7 @@ if Mix.env() == :dev do
   config :git_ops,
     mix_project: LLMDB.MixProject,
     changelog_file: "CHANGELOG.md",
-    repository_url: "https://github.com/agentjido/llm_db",
+    repository_url: "https://github.com/agentjido/llmdb",
     manage_mix_version?: false,
     manage_readme_version: false,
     version_tag_prefix: ""

--- a/lib/llm_db/snapshot/release_store.ex
+++ b/lib/llm_db/snapshot/release_store.ex
@@ -15,7 +15,7 @@ defmodule LLMDB.Snapshot.ReleaseStore do
 
   alias LLMDB.Snapshot
 
-  @default_repo "agentjido/llm_db"
+  @default_repo "agentjido/llmdb"
   @default_index_tag "catalog-index"
   @default_cache_dir Path.join(["tmp", "llm_db", "snapshot_cache"])
   @github_api_version "2022-11-28"

--- a/lib/mix/tasks/llm_db.history.check.ex
+++ b/lib/mix/tasks/llm_db.history.check.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.LlmDb.History.Check do
   - `--allow-missing` - Treat missing history output as success (default: `false`)
   - `--allow-outdated` - Treat an older local history bundle as success (default: `false`)
   - `--output-dir` - History directory (default: `priv/llm_db/history`)
-  - `--repo` - GitHub repository slug (default: `agentjido/llm_db`)
+  - `--repo` - GitHub repository slug (default: `agentjido/llmdb`)
   - `--index-tag` - Deprecated compatibility option; ignored for immutable release lookup
   - `--cache-dir` - Local snapshot cache directory
   """

--- a/lib/mix/tasks/llm_db.history.sync.ex
+++ b/lib/mix/tasks/llm_db.history.sync.ex
@@ -13,12 +13,12 @@ defmodule Mix.Tasks.LlmDb.History.Sync do
 
       mix llm_db.history.sync
       mix llm_db.history.sync --output-dir priv/llm_db/history
-      mix llm_db.history.sync --repo agentjido/llm_db
+      mix llm_db.history.sync --repo agentjido/llmdb
 
   ## Options
 
   - `--output-dir` - Directory for generated history files (default: `priv/llm_db/history`)
-  - `--repo` - GitHub repository slug (default: `agentjido/llm_db`)
+  - `--repo` - GitHub repository slug (default: `agentjido/llmdb`)
   - `--index-tag` - Deprecated compatibility option; ignored for immutable release lookup
   - `--cache-dir` - Local snapshot cache directory
   """

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule LLMDB.MixProject do
   use Mix.Project
 
   @version "2026.8.0"
-  @source_url "https://github.com/agentjido/llm_db"
+  @source_url "https://github.com/agentjido/llmdb"
   @description "LLM model metadata catalog with fast, capability-aware lookups."
 
   def project do

--- a/priv/llm_db/history/meta.json
+++ b/priv/llm_db/history/meta.json
@@ -5,7 +5,7 @@
   "schema_version": 1,
   "snapshot_index_path": "/Users/mhostetler/Source/ReqLLM/llm_db/priv/llm_db/history/snapshot-index.json",
   "snapshots_written": 47,
-  "source": "git@github.com:agentjido/llm_db.git",
+  "source": "git@github.com:agentjido/llmdb.git",
   "to_snapshot_id": "2a3e431e61036f06f4147801cd3ffdf7f322ffdff3f3d850dd212fe5cc7abd75",
   "unique_snapshots_written": 47
 }

--- a/test/llm_db/snapshot/release_store_test.exs
+++ b/test/llm_db/snapshot/release_store_test.exs
@@ -161,7 +161,7 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     printf '%s\\n' "$*" >> "#{log_path}"
 
     if [ "$1" = "release" ] && [ "$2" = "create" ]; then
-      echo "https://github.com/agentjido/llm_db/releases/tag/$3"
+      echo "https://github.com/agentjido/llmdb/releases/tag/$3"
       exit 0
     fi
 


### PR DESCRIPTION
## Summary

- update active GitHub repository URLs from `agentjido/llm_db` to `agentjido/llmdb`
- update release-store defaults and maintainer task documentation
- keep historical changelog links unchanged so GitHub redirects continue to support them

## Impact

Package and application names remain `llm_db`. Documentation, repository metadata, badges, and release operations now use the renamed GitHub repository.

## Validation

- `mix format --check-formatted`
- `mix llm_db.build --check --install`
- `mix test` — 890 passed
- `mix quality`
