### PR TITLE
test: use active Anthropic execution fixture

### DIFF
--- a/test/llm_db/packaged_test.exs
+++ b/test/llm_db/packaged_test.exs
@@ -136,8 +136,7 @@ defmodule LLMDB.PackagedTest do
         elevenlabs_model = snapshot["providers"]["elevenlabs"]["models"]["eleven_flash_v2_5"]
         claude_opus_4 = snapshot["providers"]["anthropic"]["models"]["claude-opus-4-20250514"]
 
-        claude_opus_4_1 =
-          snapshot["providers"]["anthropic"]["models"]["claude-opus-4-1-20250805"]
+        claude_opus_4_6 = snapshot["providers"]["anthropic"]["models"]["claude-opus-4-6"]
 
         assert responses_model["execution"]["text"]["family"] == "openai_responses_compatible"
         assert speech_model["execution"]["speech"]["family"] == "openai_speech"
@@ -145,7 +144,7 @@ defmodule LLMDB.PackagedTest do
         assert elevenlabs_model["execution"]["speech"]["family"] == "elevenlabs_speech"
         assert claude_opus_4["execution"]["text"]["family"] == "anthropic_messages"
         refute Map.has_key?(claude_opus_4["execution"], "object")
-        assert claude_opus_4_1["execution"]["object"]["family"] == "anthropic_messages"
+        assert claude_opus_4_6["execution"]["object"]["family"] == "anthropic_messages"
       end
     end
 


### PR DESCRIPTION
## Summary
- replace retired Claude Opus 4.1 in the representative object-execution assertion
- use active Claude Opus 4.6, which keeps the Anthropic Messages object-execution metadata after a source refresh

## Validation
- `mix llm_db.pull`
- `mix llm_db.build --install`
- `mix llm_db.build --check --install`
- `mix test test/llm_db/packaged_test.exs` against the refreshed catalog: 16 passed
- `mix test`: 897 passed
- `mix quality`

This fixes the validation failure in snapshot workflow run 32025046805.