### PR TITLE
fix: make snapshot history incremental

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,12 +39,13 @@ store.
 3. Validate the packaged snapshot with `mix llm_db.build --check --install`, `mix test`, and `mix quality`
 4. Commit refreshed metadata inputs back to `main` when they changed
 5. Publish the current canonical snapshot using `mix llm_db.snapshot.publish`
-6. Rebuild and publish `history.tar.gz` from the published snapshot chain using `mix llm_db.history.rebuild --publish`
+6. Incrementally update and publish `history.tar.gz` using `mix llm_db.history.rebuild --publish`
 7. Validate the published history bundle
 
 **Output:**
 - Updated immutable `snapshot-<snapshot_id>` release assets
-- Updated immutable `history-<snapshot_id>` release assets for the latest published snapshot
+- Updated mutable `catalog-index` assets
+- Updated mutable `history-latest` checkpoint assets when history changed
 
 ### 3. Release to Hex and NPM (`release.yml`)
 

--- a/.github/workflows/build-metadata.yml
+++ b/.github/workflows/build-metadata.yml
@@ -116,4 +116,4 @@ jobs:
         run: |
           echo "### Snapshot Publish Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "- Refreshed catalog validated before publishing" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Snapshot and history releases updated" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Snapshot, compact index, and latest history checkpoint updated" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # The published history bundle carries this large generated checkpoint.
 /priv/llm_db/history/state.json
+/priv/llm_db/history/.incremental-transaction/
 
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # Temporary files, for example, from tests.
 /tmp/
 
+# The published history bundle carries this large generated checkpoint.
+/priv/llm_db/history/state.json
+
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
 

--- a/README.md
+++ b/README.md
@@ -408,13 +408,15 @@ mix llm_db.history.check --allow-outdated
 The normal rebuild installs the latest published checkpoint and processes only
 new snapshot observations. Use `mix llm_db.history.rebuild --full` for an audit
 or repair. A full rebuild also creates the checkpoint state that is required by
-later incremental runs.
+later incremental runs. An incremental update writes a recovery journal before
+it appends data. The next run rolls back an interrupted append before it starts.
 
 The release storage has these growth rules:
 
 - Immutable full snapshot releases grow linearly with changed catalog states.
-- The compact `catalog-index` asset grows linearly with snapshot observations.
-- `history-latest` is one mutable full checkpoint. New runs replace its assets.
+- `catalog-index` keeps the two latest complete, versioned index asset pairs.
+- `history-latest` keeps the two latest complete, versioned checkpoint pairs.
+- A publisher uploads a complete new pair before it removes an old pair.
 - Legacy immutable `history-*` releases remain readable for migration, but new
   rebuilds do not create more of them.
 - Local history event files grow linearly with recorded model changes.

--- a/README.md
+++ b/README.md
@@ -391,7 +391,8 @@ mix llm_db.history.migrate_git --publish
 This writes snapshot-based history artifacts under `priv/llm_db/history/` and
 materializes immutable historical snapshots under
 `_build/llm_db/snapshot_store/snapshots/`. With `--publish`, it also seeds the
-immutable snapshot releases and publishes the rebuilt history bundle.
+immutable snapshot releases, the compact catalog index, and the latest history
+checkpoint.
 
 After that one-time migration, publish each current snapshot and rebuild history
 from the published snapshot observation chain:
@@ -403,6 +404,24 @@ mix llm_db.history.sync
 mix llm_db.history.check
 mix llm_db.history.check --allow-outdated
 ```
+
+The normal rebuild installs the latest published checkpoint and processes only
+new snapshot observations. Use `mix llm_db.history.rebuild --full` for an audit
+or repair. A full rebuild also creates the checkpoint state that is required by
+later incremental runs.
+
+The release storage has these growth rules:
+
+- Immutable full snapshot releases grow linearly with changed catalog states.
+- The compact `catalog-index` asset grows linearly with snapshot observations.
+- `history-latest` is one mutable full checkpoint. New runs replace its assets.
+- Legacy immutable `history-*` releases remain readable for migration, but new
+  rebuilds do not create more of them.
+- Local history event files grow linearly with recorded model changes.
+
+This design keeps content-addressed snapshots for audit use. It prevents the
+previous faster-than-linear growth from one new full history release per
+snapshot.
 
 `mix llm_db.history.backfill` and `LLMDB.History.Backfill` remain functional for
 compatibility but are deprecated. They may be removed no earlier than

--- a/lib/llm_db/history/bundle.ex
+++ b/lib/llm_db/history/bundle.ex
@@ -54,15 +54,43 @@ defmodule LLMDB.History.Bundle do
   @spec install_archive(String.t(), String.t() | nil) :: :ok | {:error, term()}
   def install_archive(archive_path, destination \\ nil) when is_binary(archive_path) do
     output_dir = history_dir(destination)
-    File.mkdir_p!(output_dir)
+    install_dir = "#{output_dir}.install-#{System.unique_integer([:positive])}"
+    File.rm_rf!(install_dir)
+    File.mkdir_p!(install_dir)
 
     case :erl_tar.extract(String.to_charlist(archive_path), [
            :compressed,
-           {:cwd, String.to_charlist(output_dir)}
+           {:cwd, String.to_charlist(install_dir)}
          ]) do
-      :ok -> :ok
-      {:error, reason} -> {:error, reason}
+      :ok ->
+        File.mkdir_p!(output_dir)
+        clean_generated_output(output_dir)
+
+        install_dir
+        |> File.ls!()
+        |> Enum.each(fn name ->
+          File.cp_r!(Path.join(install_dir, name), Path.join(output_dir, name))
+        end)
+
+        File.rm_rf!(install_dir)
+        :ok
+
+      {:error, reason} ->
+        File.rm_rf!(install_dir)
+        {:error, reason}
     end
+  end
+
+  defp clean_generated_output(output_dir) do
+    [
+      "events",
+      "snapshots.ndjson",
+      "meta.json",
+      Snapshot.snapshot_index_filename(),
+      Snapshot.latest_filename(),
+      Snapshot.history_state_filename()
+    ]
+    |> Enum.each(fn name -> File.rm_rf!(Path.join(output_dir, name)) end)
   end
 
   defp build_metadata(history_dir, opts) do

--- a/lib/llm_db/history/bundle.ex
+++ b/lib/llm_db/history/bundle.ex
@@ -88,7 +88,8 @@ defmodule LLMDB.History.Bundle do
       "meta.json",
       Snapshot.snapshot_index_filename(),
       Snapshot.latest_filename(),
-      Snapshot.history_state_filename()
+      Snapshot.history_state_filename(),
+      ".incremental-transaction"
     ]
     |> Enum.each(fn name -> File.rm_rf!(Path.join(output_dir, name)) end)
   end

--- a/lib/llm_db/history/rebuilder.ex
+++ b/lib/llm_db/history/rebuilder.ex
@@ -13,12 +13,16 @@ defmodule LLMDB.History.Rebuilder do
   alias LLMDB.{History.Diff, History.Lineage, Snapshot}
 
   @lineage_overrides_file "lineage_overrides.json"
+  @checkpoint_schema_version 1
   @type observation :: map()
 
   @type summary :: %{
+          mode: :full | :incremental,
           snapshots_written: non_neg_integer(),
           unique_snapshots_written: non_neg_integer(),
+          snapshots_processed: non_neg_integer(),
           events_written: non_neg_integer(),
+          events_added: non_neg_integer(),
           output_dir: String.t(),
           snapshot_index_path: String.t(),
           latest_path: String.t(),
@@ -38,55 +42,186 @@ defmodule LLMDB.History.Rebuilder do
     snapshot_index_path = snapshot_index_path(opts, output_dir)
     latest_path = latest_path(opts, output_dir)
     source = Keyword.get(opts, :source)
+    mode = Keyword.get(opts, :mode, :auto)
 
     with :ok <- validate_observations(observations),
-         :ok <- prepare_output_dir(output_dir),
          {:ok, lineage_overrides} <- load_lineage_overrides(output_dir),
-         {:ok, result} <- rebuild_records(observations, snapshot_loader, lineage_overrides),
+         {:ok, checkpoint} <-
+           load_checkpoint(
+             mode,
+             output_dir,
+             snapshot_index_path,
+             observations,
+             lineage_overrides
+           ) do
+      case checkpoint do
+        :full ->
+          rebuild_full(
+            observations,
+            snapshot_loader,
+            lineage_overrides,
+            output_dir,
+            snapshot_index_path,
+            latest_path,
+            source
+          )
+
+        checkpoint ->
+          rebuild_incremental(
+            observations,
+            snapshot_loader,
+            lineage_overrides,
+            output_dir,
+            snapshot_index_path,
+            latest_path,
+            source,
+            checkpoint
+          )
+      end
+    end
+  end
+
+  defp rebuild_full(
+         observations,
+         snapshot_loader,
+         lineage_overrides,
+         output_dir,
+         snapshot_index_path,
+         latest_path,
+         source
+       ) do
+    with :ok <- prepare_output_dir(output_dir),
+         {:ok, result} <-
+           rebuild_records(
+             observations,
+             snapshot_loader,
+             lineage_overrides,
+             initial_state(),
+             0
+           ),
          :ok <-
-           write_outputs(
+           write_full_outputs(
              output_dir,
              snapshot_index_path,
              latest_path,
              observations,
              result,
-             source
+             source,
+             lineage_overrides
            ) do
       {:ok,
-       %{
-         snapshots_written: length(observations),
-         unique_snapshots_written:
-           observations |> Enum.map(& &1["snapshot_id"]) |> MapSet.new() |> MapSet.size(),
-         events_written: result.events_written,
-         output_dir: output_dir,
-         snapshot_index_path: snapshot_index_path,
-         latest_path: latest_path,
-         from_snapshot_id: observations |> List.first() |> snapshot_id_from_observation(),
-         to_snapshot_id: observations |> List.last() |> snapshot_id_from_observation()
-       }}
+       summary(
+         :full,
+         observations,
+         length(observations),
+         result.events_written,
+         result.events_written,
+         output_dir,
+         snapshot_index_path,
+         latest_path
+       )}
     end
   end
 
-  defp rebuild_records(observations, snapshot_loader, lineage_overrides) do
-    initial = %{
+  defp rebuild_incremental(
+         observations,
+         snapshot_loader,
+         lineage_overrides,
+         output_dir,
+         snapshot_index_path,
+         latest_path,
+         source,
+         checkpoint
+       ) do
+    pending_observations = Enum.drop(observations, checkpoint.observation_count)
+
+    if pending_observations == [] do
+      {:ok,
+       summary(
+         :incremental,
+         observations,
+         0,
+         checkpoint.events_written,
+         0,
+         output_dir,
+         snapshot_index_path,
+         latest_path
+       )}
+    else
+      initial = %{
+        previous_models: checkpoint.previous_models,
+        previous_lineage_by_key: checkpoint.previous_lineage_by_key,
+        snapshot_records: [],
+        events_by_year: %{},
+        events_written: 0,
+        has_previous: true
+      }
+
+      with {:ok, result} <-
+             rebuild_records(
+               pending_observations,
+               snapshot_loader,
+               lineage_overrides,
+               initial,
+               checkpoint.observation_count
+             ),
+           :ok <-
+             append_outputs(
+               output_dir,
+               snapshot_index_path,
+               latest_path,
+               observations,
+               result,
+               source,
+               lineage_overrides,
+               checkpoint.events_written
+             ) do
+        total_events = checkpoint.events_written + result.events_written
+
+        {:ok,
+         summary(
+           :incremental,
+           observations,
+           length(pending_observations),
+           total_events,
+           result.events_written,
+           output_dir,
+           snapshot_index_path,
+           latest_path
+         )}
+      end
+    end
+  end
+
+  defp initial_state do
+    %{
       previous_models: %{},
       previous_lineage_by_key: %{},
       snapshot_records: [],
       events_by_year: %{},
-      events_written: 0
+      events_written: 0,
+      has_previous: false
     }
+  end
 
+  defp rebuild_records(
+         observations,
+         snapshot_loader,
+         lineage_overrides,
+         initial,
+         observation_offset
+       ) do
     result =
       observations
-      |> Enum.with_index(1)
+      |> Enum.with_index(observation_offset + 1)
       |> Enum.reduce_while(initial, fn {observation, observation_idx}, acc ->
         case snapshot_loader.(observation["snapshot_id"]) do
           {:ok, snapshot} ->
             current_models = flatten_snapshot_models(snapshot)
 
             {events, current_lineage_by_key} =
-              case acc.snapshot_records do
-                [] ->
+              case acc.has_previous do
+                false ->
                   current_lineage_by_key = Lineage.initialize(current_models, lineage_overrides)
 
                   events =
@@ -95,7 +230,7 @@ defmodule LLMDB.History.Rebuilder do
 
                   {events, current_lineage_by_key}
 
-                _ ->
+                true ->
                   current_lineage_by_key =
                     Lineage.resolve(
                       acc.previous_models,
@@ -159,7 +294,8 @@ defmodule LLMDB.History.Rebuilder do
                previous_lineage_by_key: current_lineage_by_key,
                snapshot_records: [snapshot_record | acc.snapshot_records],
                events_by_year: events_by_year,
-               events_written: acc.events_written + length(events)
+               events_written: acc.events_written + length(events),
+               has_previous: true
              }}
 
           {:error, reason} ->
@@ -179,18 +315,64 @@ defmodule LLMDB.History.Rebuilder do
              Map.new(state.events_by_year, fn {year, records} ->
                {year, Enum.reverse(records)}
              end),
-           events_written: state.events_written
+           events_written: state.events_written,
+           previous_models: state.previous_models,
+           previous_lineage_by_key: state.previous_lineage_by_key
          }}
     end
   end
 
-  defp write_outputs(output_dir, snapshot_index_path, latest_path, observations, result, source) do
+  defp write_full_outputs(
+         output_dir,
+         snapshot_index_path,
+         latest_path,
+         observations,
+         result,
+         source,
+         lineage_overrides
+       ) do
     write_ndjson(Path.join(output_dir, "snapshots.ndjson"), result.snapshot_records)
 
     Enum.each(result.events_by_year, fn {year, records} ->
       write_ndjson(Path.join([output_dir, "events", "#{year}.ndjson"]), records)
     end)
 
+    write_index_and_latest(snapshot_index_path, latest_path, observations)
+
+    write_meta(output_dir, snapshot_index_path, observations, result.events_written, source)
+    write_checkpoint(output_dir, observations, result, lineage_overrides)
+  end
+
+  defp append_outputs(
+         output_dir,
+         snapshot_index_path,
+         latest_path,
+         observations,
+         result,
+         source,
+         lineage_overrides,
+         previous_event_count
+       ) do
+    append_ndjson(Path.join(output_dir, "snapshots.ndjson"), result.snapshot_records)
+
+    Enum.each(result.events_by_year, fn {year, records} ->
+      append_ndjson(Path.join([output_dir, "events", "#{year}.ndjson"]), records)
+    end)
+
+    write_index_and_latest(snapshot_index_path, latest_path, observations)
+
+    write_meta(
+      output_dir,
+      snapshot_index_path,
+      observations,
+      previous_event_count + result.events_written,
+      source
+    )
+
+    write_checkpoint(output_dir, observations, result, lineage_overrides)
+  end
+
+  defp write_index_and_latest(snapshot_index_path, latest_path, observations) do
     Snapshot.write!(snapshot_index_path, %{
       "schema_version" => Snapshot.schema_version(),
       "snapshots" => observations
@@ -201,6 +383,10 @@ defmodule LLMDB.History.Rebuilder do
       latest -> Snapshot.write!(latest_path, latest)
     end
 
+    :ok
+  end
+
+  defp write_meta(output_dir, snapshot_index_path, observations, event_count, source) do
     Snapshot.write!(Path.join(output_dir, "meta.json"), %{
       "schema_version" => Snapshot.schema_version(),
       "generated_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
@@ -208,11 +394,22 @@ defmodule LLMDB.History.Rebuilder do
       "snapshots_written" => length(observations),
       "unique_snapshots_written" =>
         observations |> Enum.map(& &1["snapshot_id"]) |> MapSet.new() |> MapSet.size(),
-      "events_written" => result.events_written,
-      "event_count" => result.events_written,
+      "events_written" => event_count,
+      "event_count" => event_count,
       "from_snapshot_id" => observations |> List.first() |> snapshot_id_from_observation(),
       "to_snapshot_id" => observations |> List.last() |> snapshot_id_from_observation(),
       "snapshot_index_path" => snapshot_index_path
+    })
+  end
+
+  defp write_checkpoint(output_dir, observations, result, lineage_overrides) do
+    Snapshot.write!(Path.join(output_dir, Snapshot.history_state_filename()), %{
+      "checkpoint_schema_version" => @checkpoint_schema_version,
+      "observation_count" => length(observations),
+      "to_snapshot_id" => observations |> List.last() |> snapshot_id_from_observation(),
+      "previous_models" => result.previous_models,
+      "previous_lineage_by_key" => result.previous_lineage_by_key,
+      "lineage_overrides_digest" => term_digest(lineage_overrides)
     })
   end
 
@@ -275,6 +472,94 @@ defmodule LLMDB.History.Rebuilder do
     end)
   end
 
+  defp load_checkpoint(:full, _output_dir, _index_path, _observations, _lineage_overrides),
+    do: {:ok, :full}
+
+  defp load_checkpoint(:auto, output_dir, index_path, observations, lineage_overrides) do
+    state_path = Path.join(output_dir, Snapshot.history_state_filename())
+    meta_path = Path.join(output_dir, "meta.json")
+    snapshots_path = Path.join(output_dir, "snapshots.ndjson")
+
+    checkpoint =
+      with {:ok, state} <- read_json(state_path),
+           @checkpoint_schema_version <- state["checkpoint_schema_version"],
+           observation_count when is_integer(observation_count) and observation_count > 0 <-
+             state["observation_count"],
+           true <- observation_count <= length(observations),
+           previous_models when is_map(previous_models) <- state["previous_models"],
+           previous_lineage_by_key when is_map(previous_lineage_by_key) <-
+             state["previous_lineage_by_key"],
+           true <- state["lineage_overrides_digest"] == term_digest(lineage_overrides),
+           {:ok, %{"snapshots" => existing_observations}} when is_list(existing_observations) <-
+             read_json(index_path),
+           existing_observations <- Enum.map(existing_observations, &stringify_observation/1),
+           true <- length(existing_observations) == observation_count,
+           true <- Enum.take(observations, observation_count) == existing_observations,
+           to_snapshot_id <-
+             existing_observations |> List.last() |> snapshot_id_from_observation(),
+           true <- state["to_snapshot_id"] == to_snapshot_id,
+           {:ok, meta} <- read_json(meta_path),
+           true <- meta["to_snapshot_id"] == to_snapshot_id,
+           events_written when is_integer(events_written) and events_written >= 0 <-
+             meta["event_count"] || meta["events_written"],
+           true <- File.exists?(snapshots_path),
+           true <- File.dir?(Path.join(output_dir, "events")) do
+        %{
+          observation_count: observation_count,
+          events_written: events_written,
+          previous_models: previous_models,
+          previous_lineage_by_key: previous_lineage_by_key
+        }
+      else
+        _reason -> :full
+      end
+
+    {:ok, checkpoint}
+  end
+
+  defp load_checkpoint(mode, _output_dir, _index_path, _observations, _lineage_overrides),
+    do: {:error, {:invalid_rebuild_mode, mode}}
+
+  defp read_json(path) do
+    with {:ok, content} <- File.read(path),
+         {:ok, decoded} <- Jason.decode(content) do
+      {:ok, decoded}
+    end
+  end
+
+  defp term_digest(term) do
+    term
+    |> Snapshot.encode()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  defp summary(
+         mode,
+         observations,
+         snapshots_processed,
+         events_written,
+         events_added,
+         output_dir,
+         snapshot_index_path,
+         latest_path
+       ) do
+    %{
+      mode: mode,
+      snapshots_written: length(observations),
+      unique_snapshots_written:
+        observations |> Enum.map(& &1["snapshot_id"]) |> MapSet.new() |> MapSet.size(),
+      snapshots_processed: snapshots_processed,
+      events_written: events_written,
+      events_added: events_added,
+      output_dir: output_dir,
+      snapshot_index_path: snapshot_index_path,
+      latest_path: latest_path,
+      from_snapshot_id: observations |> List.first() |> snapshot_id_from_observation(),
+      to_snapshot_id: observations |> List.last() |> snapshot_id_from_observation()
+    }
+  end
+
   defp provider_from_model_key(model_key) do
     model_key
     |> String.split(":", parts: 2)
@@ -332,6 +617,7 @@ defmodule LLMDB.History.Rebuilder do
     File.rm_rf!(Path.join(output_dir, "meta.json"))
     File.rm_rf!(Path.join(output_dir, Snapshot.snapshot_index_filename()))
     File.rm_rf!(Path.join(output_dir, Snapshot.latest_filename()))
+    File.rm_rf!(Path.join(output_dir, Snapshot.history_state_filename()))
     File.mkdir_p!(Path.join(output_dir, "events"))
     :ok
   end
@@ -347,6 +633,17 @@ defmodule LLMDB.History.Rebuilder do
       |> Enum.join("\n")
 
     File.write!(path, lines <> if(lines == "", do: "", else: "\n"))
+  end
+
+  defp append_ndjson(_path, []), do: :ok
+
+  defp append_ndjson(path, records) do
+    path
+    |> Path.dirname()
+    |> File.mkdir_p!()
+
+    lines = records |> Enum.map(&Jason.encode!/1) |> Enum.join("\n")
+    File.write!(path, lines <> "\n", [:append])
   end
 
   defp compact_nils(map) do

--- a/lib/llm_db/history/rebuilder.ex
+++ b/lib/llm_db/history/rebuilder.ex
@@ -13,6 +13,8 @@ defmodule LLMDB.History.Rebuilder do
   alias LLMDB.{History.Diff, History.Lineage, Snapshot}
 
   @lineage_overrides_file "lineage_overrides.json"
+  @transaction_dir ".incremental-transaction"
+  @transaction_manifest "manifest.json"
   @checkpoint_schema_version 1
   @type observation :: map()
 
@@ -43,14 +45,17 @@ defmodule LLMDB.History.Rebuilder do
     latest_path = latest_path(opts, output_dir)
     source = Keyword.get(opts, :source)
     mode = Keyword.get(opts, :mode, :auto)
+    incremental_commit_hook = Keyword.get(opts, :incremental_commit_hook, fn -> :ok end)
 
-    with :ok <- validate_observations(observations),
+    with :ok <- recover_interrupted_update(output_dir),
+         :ok <- validate_observations(observations),
          {:ok, lineage_overrides} <- load_lineage_overrides(output_dir),
          {:ok, checkpoint} <-
            load_checkpoint(
              mode,
              output_dir,
              snapshot_index_path,
+             latest_path,
              observations,
              lineage_overrides
            ) do
@@ -75,7 +80,8 @@ defmodule LLMDB.History.Rebuilder do
             snapshot_index_path,
             latest_path,
             source,
-            checkpoint
+            checkpoint,
+            incremental_commit_hook
           )
       end
     end
@@ -131,7 +137,8 @@ defmodule LLMDB.History.Rebuilder do
          snapshot_index_path,
          latest_path,
          source,
-         checkpoint
+         checkpoint,
+         incremental_commit_hook
        ) do
     pending_observations = Enum.drop(observations, checkpoint.observation_count)
 
@@ -174,7 +181,8 @@ defmodule LLMDB.History.Rebuilder do
                result,
                source,
                lineage_overrides,
-               checkpoint.events_written
+               checkpoint.events_written,
+               incremental_commit_hook
              ) do
         total_events = checkpoint.events_written + result.events_written
 
@@ -351,8 +359,18 @@ defmodule LLMDB.History.Rebuilder do
          result,
          source,
          lineage_overrides,
-         previous_event_count
+         previous_event_count,
+         incremental_commit_hook
        ) do
+    transaction =
+      begin_incremental_transaction(
+        output_dir,
+        snapshot_index_path,
+        latest_path,
+        observations,
+        result
+      )
+
     append_ndjson(Path.join(output_dir, "snapshots.ndjson"), result.snapshot_records)
 
     Enum.each(result.events_by_year, fn {year, records} ->
@@ -369,7 +387,9 @@ defmodule LLMDB.History.Rebuilder do
       source
     )
 
+    incremental_commit_hook.()
     write_checkpoint(output_dir, observations, result, lineage_overrides)
+    finish_incremental_transaction(transaction)
   end
 
   defp write_index_and_latest(snapshot_index_path, latest_path, observations) do
@@ -472,10 +492,24 @@ defmodule LLMDB.History.Rebuilder do
     end)
   end
 
-  defp load_checkpoint(:full, _output_dir, _index_path, _observations, _lineage_overrides),
-    do: {:ok, :full}
+  defp load_checkpoint(
+         :full,
+         _output_dir,
+         _index_path,
+         _latest_path,
+         _observations,
+         _lineage_overrides
+       ),
+       do: {:ok, :full}
 
-  defp load_checkpoint(:auto, output_dir, index_path, observations, lineage_overrides) do
+  defp load_checkpoint(
+         :auto,
+         output_dir,
+         index_path,
+         latest_path,
+         observations,
+         lineage_overrides
+       ) do
     state_path = Path.join(output_dir, Snapshot.history_state_filename())
     meta_path = Path.join(output_dir, "meta.json")
     snapshots_path = Path.join(output_dir, "snapshots.ndjson")
@@ -490,6 +524,8 @@ defmodule LLMDB.History.Rebuilder do
            previous_lineage_by_key when is_map(previous_lineage_by_key) <-
              state["previous_lineage_by_key"],
            true <- state["lineage_overrides_digest"] == term_digest(lineage_overrides),
+           true <- managed_path?(index_path, output_dir),
+           true <- managed_path?(latest_path, output_dir),
            {:ok, %{"snapshots" => existing_observations}} when is_list(existing_observations) <-
              read_json(index_path),
            existing_observations <- Enum.map(existing_observations, &stringify_observation/1),
@@ -517,8 +553,170 @@ defmodule LLMDB.History.Rebuilder do
     {:ok, checkpoint}
   end
 
-  defp load_checkpoint(mode, _output_dir, _index_path, _observations, _lineage_overrides),
-    do: {:error, {:invalid_rebuild_mode, mode}}
+  defp load_checkpoint(
+         mode,
+         _output_dir,
+         _index_path,
+         _latest_path,
+         _observations,
+         _lineage_overrides
+       ),
+       do: {:error, {:invalid_rebuild_mode, mode}}
+
+  defp begin_incremental_transaction(
+         output_dir,
+         snapshot_index_path,
+         latest_path,
+         observations,
+         result
+       ) do
+    transaction_dir = Path.join(output_dir, @transaction_dir)
+    backup_dir = Path.join(transaction_dir, "control")
+
+    data_paths =
+      [Path.join(output_dir, "snapshots.ndjson")] ++
+        Enum.map(Map.keys(result.events_by_year), fn year ->
+          Path.join([output_dir, "events", "#{year}.ndjson"])
+        end)
+
+    control_paths = [
+      snapshot_index_path,
+      latest_path,
+      Path.join(output_dir, "meta.json"),
+      Path.join(output_dir, Snapshot.history_state_filename())
+    ]
+
+    File.rm_rf!(transaction_dir)
+    File.mkdir_p!(backup_dir)
+
+    Enum.each(control_paths, fn path ->
+      if File.exists?(path) do
+        backup_path = transaction_backup_path(backup_dir, output_dir, path)
+        File.mkdir_p!(Path.dirname(backup_path))
+        File.cp!(path, backup_path)
+      end
+    end)
+
+    manifest = %{
+      "target_observation_count" => length(observations),
+      "target_snapshot_id" => observations |> List.last() |> snapshot_id_from_observation(),
+      "data_files" =>
+        Map.new(data_paths, fn path ->
+          {Path.relative_to(path, output_dir), file_size(path)}
+        end),
+      "control_files" => Enum.map(control_paths, &Path.relative_to(&1, output_dir))
+    }
+
+    Snapshot.write!(Path.join(transaction_dir, @transaction_manifest), manifest)
+    %{dir: transaction_dir}
+  end
+
+  defp finish_incremental_transaction(%{dir: transaction_dir}) do
+    File.rm_rf!(transaction_dir)
+    :ok
+  end
+
+  defp recover_interrupted_update(output_dir) do
+    transaction_dir = Path.join(output_dir, @transaction_dir)
+    manifest_path = Path.join(transaction_dir, @transaction_manifest)
+
+    cond do
+      not File.dir?(transaction_dir) ->
+        :ok
+
+      not File.exists?(manifest_path) ->
+        File.rm_rf!(transaction_dir)
+        :ok
+
+      true ->
+        with {:ok, manifest} <- read_json(manifest_path) do
+          if transaction_committed?(output_dir, manifest) do
+            File.rm_rf!(transaction_dir)
+          else
+            rollback_transaction(output_dir, transaction_dir, manifest)
+          end
+
+          :ok
+        else
+          _error ->
+            File.rm_rf!(transaction_dir)
+            :ok
+        end
+    end
+  end
+
+  defp transaction_committed?(output_dir, manifest) do
+    state_path = Path.join(output_dir, Snapshot.history_state_filename())
+
+    case read_json(state_path) do
+      {:ok, state} ->
+        state["observation_count"] == manifest["target_observation_count"] and
+          state["to_snapshot_id"] == manifest["target_snapshot_id"]
+
+      _error ->
+        false
+    end
+  end
+
+  defp rollback_transaction(output_dir, transaction_dir, manifest) do
+    Enum.each(manifest["data_files"] || %{}, fn {relative_path, original_size} ->
+      path = managed_transaction_path!(output_dir, relative_path)
+      restore_file_size(path, original_size)
+    end)
+
+    backup_dir = Path.join(transaction_dir, "control")
+
+    Enum.each(manifest["control_files"] || [], fn relative_path ->
+      path = managed_transaction_path!(output_dir, relative_path)
+      backup_path = managed_transaction_path!(backup_dir, relative_path)
+
+      if File.exists?(backup_path) do
+        File.mkdir_p!(Path.dirname(path))
+        File.cp!(backup_path, path)
+      else
+        File.rm_rf!(path)
+      end
+    end)
+
+    File.rm_rf!(transaction_dir)
+  end
+
+  defp restore_file_size(path, nil), do: File.rm_rf!(path)
+
+  defp restore_file_size(path, size) when is_integer(size) and size >= 0 do
+    File.open!(path, [:read, :write], fn file ->
+      {:ok, ^size} = :file.position(file, size)
+      :ok = :file.truncate(file)
+    end)
+  end
+
+  defp file_size(path) do
+    case File.stat(path) do
+      {:ok, stat} -> stat.size
+      {:error, :enoent} -> nil
+    end
+  end
+
+  defp transaction_backup_path(backup_dir, output_dir, path) do
+    relative_path = Path.relative_to(path, output_dir)
+    managed_transaction_path!(backup_dir, relative_path)
+  end
+
+  defp managed_transaction_path!(root, relative_path) do
+    path = Path.expand(relative_path, root)
+
+    if managed_path?(path, root) do
+      path
+    else
+      raise "invalid history transaction path: #{relative_path}"
+    end
+  end
+
+  defp managed_path?(path, root) do
+    expanded_path = Path.expand(path)
+    expanded_root = Path.expand(root)
+    expanded_path == expanded_root or String.starts_with?(expanded_path, expanded_root <> "/")
+  end
 
   defp read_json(path) do
     with {:ok, content} <- File.read(path),
@@ -618,6 +816,7 @@ defmodule LLMDB.History.Rebuilder do
     File.rm_rf!(Path.join(output_dir, Snapshot.snapshot_index_filename()))
     File.rm_rf!(Path.join(output_dir, Snapshot.latest_filename()))
     File.rm_rf!(Path.join(output_dir, Snapshot.history_state_filename()))
+    File.rm_rf!(Path.join(output_dir, @transaction_dir))
     File.mkdir_p!(Path.join(output_dir, "events"))
     :ok
   end

--- a/lib/llm_db/snapshot.ex
+++ b/lib/llm_db/snapshot.ex
@@ -19,6 +19,7 @@ defmodule LLMDB.Snapshot do
   @snapshot_index_filename "snapshot-index.json"
   @history_meta_filename "history-meta.json"
   @history_archive_filename "history.tar.gz"
+  @history_state_filename "state.json"
 
   @hash_excluded_keys MapSet.new([
                         "snapshot_id",
@@ -118,6 +119,9 @@ defmodule LLMDB.Snapshot do
 
   @spec history_archive_filename() :: String.t()
   def history_archive_filename, do: @history_archive_filename
+
+  @spec history_state_filename() :: String.t()
+  def history_state_filename, do: @history_state_filename
 
   @doc """
   Builds a canonical snapshot document from an engine snapshot.

--- a/lib/llm_db/snapshot/release_store.ex
+++ b/lib/llm_db/snapshot/release_store.ex
@@ -2,10 +2,11 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   @moduledoc """
   GitHub Releases-backed snapshot artifact store.
 
-  Runtime fetching resolves immutable snapshots through a compact mutable
-  catalog index and resolves the mutable latest history checkpoint. A release
-  scan supports migration when the compact assets do not exist. Publishing is
-  handled with the `gh` CLI for local maintainer workflows and GitHub Actions.
+  Runtime fetching resolves immutable snapshots through the latest complete
+  catalog asset generation. It resolves history through the latest complete
+  checkpoint generation. A release scan supports migration when these assets
+  do not exist. Publishing uses versioned asset pairs and keeps two complete
+  generations. It uses the `gh` CLI for maintainer workflows and GitHub Actions.
 
   This shared transport is internal. Runtime consumers configure snapshot
   sources through `LLMDB.load/1`; maintainers use the supported
@@ -21,6 +22,16 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   @default_cache_dir Path.join(["tmp", "llm_db", "snapshot_cache"])
   @github_api_version "2022-11-28"
   @release_page_size 100
+  @retained_generations 2
+
+  @catalog_asset_specs %{
+    "index" => {"snapshot-index-", ".json"},
+    "latest" => {"latest-", ".json"}
+  }
+  @history_asset_specs %{
+    "archive" => {"history-", ".tar.gz"},
+    "meta" => {"history-meta-", ".json"}
+  }
 
   @type config :: %{
           repo: String.t(),
@@ -126,22 +137,52 @@ defmodule LLMDB.Snapshot.ReleaseStore do
 
   defp fetch_published_snapshot_index(overrides) do
     cfg = config(overrides)
-    index_url = release_asset_url(cfg.repo, cfg.index_tag, Snapshot.snapshot_index_filename())
 
-    case fetch_json(index_url, overrides) do
-      {:ok, %{"snapshots" => snapshots}} when is_list(snapshots) ->
-        {:ok, snapshots}
+    with {:ok, assets} <-
+           latest_release_assets(cfg.repo, cfg.index_tag, @catalog_asset_specs, overrides),
+         {:ok, index} <- fetch_json(assets["index"], overrides) do
+      case index do
+        %{"snapshots" => snapshots} when is_list(snapshots) ->
+          {:ok, snapshots}
 
-      {:ok, other} ->
-        {:error, {:invalid_snapshot_index, other}}
-
-      {:error, :not_found} ->
-        fetch_snapshot_index_from_releases(overrides)
-
-      error ->
-        error
+        other ->
+          {:error, {:invalid_snapshot_index, other}}
+      end
+    else
+      {:error, :not_found} -> fetch_snapshot_index_from_releases(overrides)
+      error -> error
     end
   end
+
+  defp latest_release_assets(repo, tag, asset_specs, overrides) do
+    with {:ok, release} <- release_by_tag(repo, tag, overrides) do
+      complete_release_assets(release, asset_specs)
+    end
+  end
+
+  defp complete_release_assets(%{"assets" => assets}, asset_specs) when is_list(assets) do
+    assets_by_key =
+      Map.new(asset_specs, fn {key, {prefix, suffix}} ->
+        {key, versioned_assets(assets, prefix, suffix)}
+      end)
+
+    generations =
+      assets_by_key
+      |> Map.values()
+      |> Enum.map(&(&1 |> Map.keys() |> MapSet.new()))
+      |> intersect_sets()
+
+    case generations |> Enum.sort() |> List.last() do
+      nil ->
+        {:error, :not_found}
+
+      generation ->
+        urls = Map.new(assets_by_key, fn {key, values} -> {key, values[generation]} end)
+        {:ok, Map.put(urls, "generation", generation)}
+    end
+  end
+
+  defp complete_release_assets(_release, _asset_specs), do: {:error, :not_found}
 
   defp fetch_snapshot_index_from_releases(overrides) do
     with {:ok, releases} <- list_releases(config(overrides).repo, overrides) do
@@ -167,11 +208,15 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   @spec fetch_history_meta(keyword() | map()) :: {:ok, map()} | {:error, term()}
   def fetch_history_meta(overrides \\ %{}) do
     cfg = config(overrides)
-    meta_url = release_asset_url(cfg.repo, cfg.history_tag, Snapshot.history_meta_filename())
 
-    case fetch_json(meta_url, overrides) do
-      {:ok, %{} = meta} -> {:ok, meta}
-      {:ok, other} -> {:error, {:invalid_history_metadata, other}}
+    with {:ok, assets} <-
+           latest_release_assets(cfg.repo, cfg.history_tag, @history_asset_specs, overrides),
+         {:ok, meta} <- fetch_json(assets["meta"], overrides) do
+      case meta do
+        %{} -> {:ok, meta}
+        other -> {:error, {:invalid_history_metadata, other}}
+      end
+    else
       {:error, :not_found} -> fetch_legacy_history_meta(overrides)
       error -> error
     end
@@ -238,19 +283,30 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   def download_history_archive(destination, overrides \\ %{}) when is_binary(destination) do
     cfg = config(overrides)
 
-    history_url =
-      release_asset_url(cfg.repo, cfg.history_tag, Snapshot.history_archive_filename())
-
-    case download(history_url, overrides) do
-      {:ok, content} ->
-        write_download(destination, content)
-
+    with {:ok, assets} <-
+           latest_release_assets(cfg.repo, cfg.history_tag, @history_asset_specs, overrides),
+         {:ok, content} <- download(assets["archive"], overrides) do
+      write_download(destination, content)
+    else
       {:error, :not_found} ->
         download_legacy_history_archive(destination, overrides)
 
       error ->
         error
     end
+  end
+
+  defp write_download(destination, content) when is_binary(content) do
+    destination
+    |> Path.dirname()
+    |> File.mkdir_p!()
+
+    File.write!(destination, content)
+    :ok
+  end
+
+  defp write_download(_destination, content) do
+    {:error, {:invalid_download_body, content}}
   end
 
   defp download_legacy_history_archive(destination, overrides) do
@@ -264,23 +320,26 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     end
   end
 
-  defp write_download(destination, content) do
-    destination
-    |> Path.dirname()
-    |> File.mkdir_p!()
-
-    File.write!(destination, content)
-    :ok
-  end
-
   @spec publish_snapshot_index([String.t()], keyword() | map()) ::
           {:ok, String.t()} | {:error, term()}
   def publish_snapshot_index(asset_paths, overrides \\ %{}) when is_list(asset_paths) do
     cfg = config(overrides)
 
     with :ok <- ensure_gh_available(),
-         {:ok, asset_paths} <- validate_asset_paths(asset_paths) do
-      upsert_release(cfg.index_tag, cfg.repo, "Snapshot catalog index", asset_paths)
+         {:ok, asset_paths} <- validate_asset_paths(asset_paths),
+         {:ok, sources} <-
+           named_asset_sources(asset_paths, %{
+             "index" => Snapshot.snapshot_index_filename(),
+             "latest" => Snapshot.latest_filename()
+           }) do
+      publish_versioned_release(
+        cfg.index_tag,
+        cfg.repo,
+        "Snapshot catalog index",
+        generation_id(),
+        @catalog_asset_specs,
+        sources
+      )
     end
   end
 
@@ -314,8 +373,20 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     cfg = config(overrides)
 
     with :ok <- ensure_gh_available(),
-         {:ok, asset_paths} <- validate_asset_paths(asset_paths) do
-      upsert_release(cfg.history_tag, cfg.repo, "Latest model history", asset_paths)
+         {:ok, asset_paths} <- validate_asset_paths(asset_paths),
+         {:ok, sources} <-
+           named_asset_sources(asset_paths, %{
+             "archive" => Snapshot.history_archive_filename(),
+             "meta" => Snapshot.history_meta_filename()
+           }) do
+      publish_versioned_release(
+        cfg.history_tag,
+        cfg.repo,
+        "Latest model history",
+        generation_id(snapshot_id),
+        @history_asset_specs,
+        sources
+      )
     end
   end
 
@@ -524,6 +595,55 @@ defmodule LLMDB.Snapshot.ReleaseStore do
 
   defp release_asset_download_url(_release, _filename), do: nil
 
+  defp versioned_assets(assets, prefix, suffix) do
+    Enum.reduce(assets, %{}, fn asset, acc ->
+      name = asset["name"]
+      url = asset["browser_download_url"] || asset["url"]
+
+      case versioned_generation(name, prefix, suffix) do
+        generation when is_binary(generation) and is_binary(url) ->
+          Map.put(acc, generation, url)
+
+        _other ->
+          acc
+      end
+    end)
+  end
+
+  defp complete_generations(asset_names, asset_specs) do
+    asset_specs
+    |> Map.values()
+    |> Enum.map(fn {prefix, suffix} ->
+      asset_names
+      |> Enum.map(&versioned_generation(&1, prefix, suffix))
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+    end)
+    |> intersect_sets()
+    |> MapSet.to_list()
+  end
+
+  defp asset_generation(name, asset_specs) do
+    Enum.find_value(asset_specs, fn {_key, {prefix, suffix}} ->
+      versioned_generation(name, prefix, suffix)
+    end)
+  end
+
+  defp versioned_generation(name, prefix, suffix) when is_binary(name) do
+    if String.starts_with?(name, prefix) and String.ends_with?(name, suffix) do
+      generation_size = byte_size(name) - byte_size(prefix) - byte_size(suffix)
+
+      if generation_size > 0 do
+        binary_part(name, byte_size(prefix), generation_size)
+      end
+    end
+  end
+
+  defp versioned_generation(_name, _prefix, _suffix), do: nil
+
+  defp intersect_sets([]), do: MapSet.new()
+  defp intersect_sets([first | rest]), do: Enum.reduce(rest, first, &MapSet.intersection/2)
+
   defp release_tag_name(%{"tag_name" => tag}), do: tag
   defp release_tag_name(%{tag_name: tag}), do: tag
 
@@ -570,9 +690,24 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   end
 
   defp validate_asset_paths(paths) do
-    case Enum.filter(paths, &File.exists?/1) do
-      [] -> {:error, :no_release_assets}
-      existing_paths -> {:ok, existing_paths}
+    missing_paths = Enum.reject(paths, &File.exists?/1)
+
+    cond do
+      paths == [] -> {:error, :no_release_assets}
+      missing_paths == [] -> {:ok, paths}
+      true -> {:error, {:missing_release_assets, missing_paths}}
+    end
+  end
+
+  defp named_asset_sources(asset_paths, expected_names) do
+    sources =
+      Map.new(expected_names, fn {key, filename} ->
+        {key, Enum.find(asset_paths, &(Path.basename(&1) == filename))}
+      end)
+
+    case Enum.find(sources, fn {_key, path} -> is_nil(path) end) do
+      nil -> {:ok, sources}
+      {key, nil} -> {:error, {:missing_named_release_asset, key}}
     end
   end
 
@@ -588,23 +723,106 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     end
   end
 
-  defp upsert_release(tag, repo, title, asset_paths) do
+  defp publish_versioned_release(tag, repo, title, generation, asset_specs, sources) do
+    staging_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "llm_db-release-assets-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(staging_dir)
+
+    staged_paths =
+      Map.new(asset_specs, fn {key, {prefix, suffix}} ->
+        staged_path = Path.join(staging_dir, "#{prefix}#{generation}#{suffix}")
+        File.cp!(Map.fetch!(sources, key), staged_path)
+        {key, staged_path}
+      end)
+
+    try do
+      with :ok <- ensure_mutable_release(tag, repo, title),
+           :ok <- upload_release_assets(tag, repo, Map.values(staged_paths)),
+           :ok <- prune_release_assets(tag, repo, asset_specs, generation) do
+        {:ok, tag}
+      end
+    after
+      File.rm_rf!(staging_dir)
+    end
+  end
+
+  defp ensure_mutable_release(tag, repo, title) do
     case run_gh(["release", "view", tag, "--repo", repo]) do
       {:ok, _output} ->
-        args = ["release", "upload", tag] ++ asset_paths ++ ["--repo", repo, "--clobber"]
-
-        case run_gh(args) do
-          {:ok, _output} -> {:ok, tag}
-          {:error, reason} -> {:error, reason}
-        end
+        :ok
 
       {:error, _reason} ->
-        create_release(tag, repo, title, asset_paths)
+        case create_release(tag, repo, title, []) do
+          {:ok, ^tag} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp upload_release_assets(tag, repo, asset_paths) do
+    args = ["release", "upload", tag] ++ asset_paths ++ ["--repo", repo]
+
+    case run_gh(args) do
+      {:ok, _output} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp prune_release_assets(tag, repo, asset_specs, published_generation) do
+    with {:ok, asset_names} <- release_asset_names(tag, repo) do
+      retained_generations =
+        asset_names
+        |> complete_generations(asset_specs)
+        |> Enum.sort(:desc)
+        |> Enum.take(@retained_generations)
+        |> MapSet.new()
+
+      asset_names
+      |> Enum.filter(fn name ->
+        case asset_generation(name, asset_specs) do
+          nil ->
+            false
+
+          generation ->
+            generation < published_generation and
+              not MapSet.member?(retained_generations, generation)
+        end
+      end)
+      |> Enum.reduce_while(:ok, fn name, :ok ->
+        case run_gh(["release", "delete-asset", tag, name, "--repo", repo, "--yes"]) do
+          {:ok, _output} -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+      end)
+    end
+  end
+
+  defp release_asset_names(tag, repo) do
+    case run_gh(["release", "view", tag, "--repo", repo, "--json", "assets"]) do
+      {:ok, output} ->
+        with {:ok, %{"assets" => assets}} when is_list(assets) <- Jason.decode(output) do
+          {:ok, Enum.map(assets, & &1["name"])}
+        else
+          _error -> {:error, :invalid_release_assets}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
   defp list_releases(repo, overrides) do
     do_list_releases(repo, overrides, 1, [])
+  end
+
+  defp release_by_tag(repo, tag, overrides) do
+    encoded_tag = URI.encode_www_form(tag)
+    url = "https://api.github.com/repos/#{repo}/releases/tags/#{encoded_tag}"
+    api_get_json(url, [], overrides)
   end
 
   defp do_list_releases(repo, overrides, page, acc) do
@@ -707,6 +925,22 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     short_id = snapshot_id |> String.slice(0, 12)
     suffix = "#{System.system_time(:millisecond)}-#{System.unique_integer([:positive])}"
     "#{kind}-#{short_id}-#{suffix}"
+  end
+
+  defp generation_id(snapshot_id \\ nil) do
+    timestamp =
+      System.system_time(:millisecond)
+      |> Integer.to_string()
+      |> String.pad_leading(16, "0")
+
+    unique =
+      System.unique_integer([:positive, :monotonic])
+      |> Integer.to_string()
+      |> String.pad_leading(20, "0")
+
+    [timestamp, unique, snapshot_id && String.slice(snapshot_id, 0, 12)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("-")
   end
 
   defp expand_path(path) when is_binary(path) do

--- a/lib/llm_db/snapshot/release_store.ex
+++ b/lib/llm_db/snapshot/release_store.ex
@@ -2,10 +2,10 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   @moduledoc """
   GitHub Releases-backed snapshot artifact store.
 
-  Runtime fetching resolves immutable snapshot and history releases via the
-  GitHub Releases API and downloads public assets via Req. Publishing is
-  handled with the `gh` CLI, intended for local maintainer workflows and
-  GitHub Actions.
+  Runtime fetching resolves immutable snapshots through a compact mutable
+  catalog index and resolves the mutable latest history checkpoint. A release
+  scan supports migration when the compact assets do not exist. Publishing is
+  handled with the `gh` CLI for local maintainer workflows and GitHub Actions.
 
   This shared transport is internal. Runtime consumers configure snapshot
   sources through `LLMDB.load/1`; maintainers use the supported
@@ -17,14 +17,15 @@ defmodule LLMDB.Snapshot.ReleaseStore do
 
   @default_repo "agentjido/llmdb"
   @default_index_tag "catalog-index"
+  @default_history_tag "history-latest"
   @default_cache_dir Path.join(["tmp", "llm_db", "snapshot_cache"])
   @github_api_version "2022-11-28"
   @release_page_size 100
-  @max_release_pages 10
 
   @type config :: %{
           repo: String.t(),
           index_tag: String.t(),
+          history_tag: String.t(),
           cache_dir: String.t()
         }
 
@@ -46,6 +47,8 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     %{
       repo: Map.get(merged, :repo, Map.get(merged, "repo", @default_repo)),
       index_tag: Map.get(merged, :index_tag, Map.get(merged, "index_tag", @default_index_tag)),
+      history_tag:
+        Map.get(merged, :history_tag, Map.get(merged, "history_tag", @default_history_tag)),
       cache_dir:
         Map.get(merged, :cache_dir, Map.get(merged, "cache_dir", @default_cache_dir))
         |> expand_path()
@@ -109,10 +112,42 @@ defmodule LLMDB.Snapshot.ReleaseStore do
 
   @spec fetch_snapshot_index(keyword() | map()) :: {:ok, [map()]} | {:error, term()}
   def fetch_snapshot_index(overrides \\ %{}) do
-    with {:ok, releases} <- list_releases(config(overrides).repo) do
+    case override_entries(overrides, :snapshot_index) do
+      {:ok, entries} ->
+        {:ok, entries}
+
+      :none ->
+        fetch_published_snapshot_index(overrides)
+
+      error ->
+        error
+    end
+  end
+
+  defp fetch_published_snapshot_index(overrides) do
+    cfg = config(overrides)
+    index_url = release_asset_url(cfg.repo, cfg.index_tag, Snapshot.snapshot_index_filename())
+
+    case fetch_json(index_url, overrides) do
+      {:ok, %{"snapshots" => snapshots}} when is_list(snapshots) ->
+        {:ok, snapshots}
+
+      {:ok, other} ->
+        {:error, {:invalid_snapshot_index, other}}
+
+      {:error, :not_found} ->
+        fetch_snapshot_index_from_releases(overrides)
+
+      error ->
+        error
+    end
+  end
+
+  defp fetch_snapshot_index_from_releases(overrides) do
+    with {:ok, releases} <- list_releases(config(overrides).repo, overrides) do
       releases
       |> Enum.filter(&snapshot_release?/1)
-      |> build_entries(&snapshot_entry_from_release/1)
+      |> build_entries(&snapshot_entry_from_release(&1, overrides))
       |> case do
         {:ok, entries} ->
           sorted =
@@ -131,11 +166,21 @@ defmodule LLMDB.Snapshot.ReleaseStore do
 
   @spec fetch_history_meta(keyword() | map()) :: {:ok, map()} | {:error, term()}
   def fetch_history_meta(overrides \\ %{}) do
-    with {:ok, latest} <- fetch_latest(overrides),
-         snapshot_id when is_binary(snapshot_id) <- latest["snapshot_id"],
-         {:ok, entry} <- find_history_entry(snapshot_id, overrides),
+    cfg = config(overrides)
+    meta_url = release_asset_url(cfg.repo, cfg.history_tag, Snapshot.history_meta_filename())
+
+    case fetch_json(meta_url, overrides) do
+      {:ok, %{} = meta} -> {:ok, meta}
+      {:ok, other} -> {:error, {:invalid_history_metadata, other}}
+      {:error, :not_found} -> fetch_legacy_history_meta(overrides)
+      error -> error
+    end
+  end
+
+  defp fetch_legacy_history_meta(overrides) do
+    with {:ok, entry} <- latest_history_entry(overrides),
          meta_url when is_binary(meta_url) <- entry["history_meta_url"] do
-      fetch_json(meta_url)
+      fetch_json(meta_url, overrides)
     else
       nil -> {:error, :not_found}
       error -> error
@@ -147,9 +192,10 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   def fetch_snapshot(ref, overrides \\ %{})
 
   def fetch_snapshot(:latest, overrides) do
-    with {:ok, latest} <- fetch_latest(overrides),
+    with {:ok, snapshots} <- fetch_snapshot_index(overrides),
+         latest when is_map(latest) <- List.last(snapshots),
          snapshot_id when is_binary(snapshot_id) <- latest["snapshot_id"] do
-      fetch_snapshot(snapshot_id, overrides)
+      fetch_snapshot(snapshot_id, put_override(overrides, :snapshot_index, snapshots))
     else
       {:error, _reason} = error -> error
       _ -> {:error, :invalid_latest_snapshot}
@@ -167,8 +213,8 @@ defmodule LLMDB.Snapshot.ReleaseStore do
       {:error, :cache_miss} ->
         with {:ok, entry} <- find_snapshot_entry(snapshot_id, overrides),
              snapshot_url when is_binary(snapshot_url) <- entry["snapshot_url"],
-             {:ok, content} <- download(snapshot_url),
-             {:ok, snapshot} <- Snapshot.decode(content),
+             {:ok, content} <- download(snapshot_url, overrides),
+             {:ok, snapshot} <- decode_snapshot(content),
              ^snapshot_id <- snapshot["snapshot_id"] do
           File.write!(path, Snapshot.encode(snapshot))
           {:ok, %{snapshot: snapshot, snapshot_id: snapshot_id, path: path}}
@@ -190,20 +236,51 @@ defmodule LLMDB.Snapshot.ReleaseStore do
 
   @spec download_history_archive(String.t(), keyword() | map()) :: :ok | {:error, term()}
   def download_history_archive(destination, overrides \\ %{}) when is_binary(destination) do
-    with {:ok, latest} <- fetch_latest(overrides),
-         snapshot_id when is_binary(snapshot_id) <- latest["snapshot_id"],
-         {:ok, entry} <- find_history_entry(snapshot_id, overrides),
-         history_url when is_binary(history_url) <- entry["history_url"],
-         {:ok, content} <- download(history_url) do
-      destination
-      |> Path.dirname()
-      |> File.mkdir_p!()
+    cfg = config(overrides)
 
-      File.write!(destination, content)
-      :ok
+    history_url =
+      release_asset_url(cfg.repo, cfg.history_tag, Snapshot.history_archive_filename())
+
+    case download(history_url, overrides) do
+      {:ok, content} ->
+        write_download(destination, content)
+
+      {:error, :not_found} ->
+        download_legacy_history_archive(destination, overrides)
+
+      error ->
+        error
+    end
+  end
+
+  defp download_legacy_history_archive(destination, overrides) do
+    with {:ok, entry} <- latest_history_entry(overrides),
+         history_url when is_binary(history_url) <- entry["history_url"],
+         {:ok, content} <- download(history_url, overrides) do
+      write_download(destination, content)
     else
       nil -> {:error, :not_found}
       error -> error
+    end
+  end
+
+  defp write_download(destination, content) do
+    destination
+    |> Path.dirname()
+    |> File.mkdir_p!()
+
+    File.write!(destination, content)
+    :ok
+  end
+
+  @spec publish_snapshot_index([String.t()], keyword() | map()) ::
+          {:ok, String.t()} | {:error, term()}
+  def publish_snapshot_index(asset_paths, overrides \\ %{}) when is_list(asset_paths) do
+    cfg = config(overrides)
+
+    with :ok <- ensure_gh_available(),
+         {:ok, asset_paths} <- validate_asset_paths(asset_paths) do
+      upsert_release(cfg.index_tag, cfg.repo, "Snapshot catalog index", asset_paths)
     end
   end
 
@@ -234,23 +311,11 @@ defmodule LLMDB.Snapshot.ReleaseStore do
           {:ok, String.t()} | {:error, term()}
   def publish_history_release(asset_paths, snapshot_id, overrides \\ %{})
       when is_list(asset_paths) and is_binary(snapshot_id) do
+    cfg = config(overrides)
+
     with :ok <- ensure_gh_available(),
          {:ok, asset_paths} <- validate_asset_paths(asset_paths) do
-      case find_history_entry(snapshot_id, overrides) do
-        {:ok, entry} ->
-          {:ok, entry["tag"]}
-
-        {:error, :not_found} ->
-          create_release(
-            history_tag(snapshot_id),
-            config(overrides).repo,
-            "History #{snapshot_id}",
-            asset_paths
-          )
-
-        {:error, reason} ->
-          {:error, reason}
-      end
+      upsert_release(cfg.history_tag, cfg.repo, "Latest model history", asset_paths)
     end
   end
 
@@ -298,10 +363,10 @@ defmodule LLMDB.Snapshot.ReleaseStore do
         {:ok, entries}
 
       :none ->
-        with {:ok, releases} <- list_releases(config(overrides).repo) do
+        with {:ok, releases} <- list_releases(config(overrides).repo, overrides) do
           releases
           |> Enum.filter(&history_release?/1)
-          |> build_entries(&history_entry_from_release/1)
+          |> build_entries(&history_entry_from_release(&1, overrides))
           |> case do
             {:ok, entries} ->
               sorted =
@@ -316,6 +381,16 @@ defmodule LLMDB.Snapshot.ReleaseStore do
               error
           end
         end
+    end
+  end
+
+  defp latest_history_entry(overrides) do
+    with {:ok, entries} <- history_entries(overrides),
+         %{} = entry <- List.last(entries) do
+      {:ok, entry}
+    else
+      nil -> {:error, :not_found}
+      error -> error
     end
   end
 
@@ -387,7 +462,7 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   defp history_release?(%{tag_name: "history-" <> _rest}), do: true
   defp history_release?(_release), do: false
 
-  defp snapshot_entry_from_release(release) do
+  defp snapshot_entry_from_release(release, overrides) do
     snapshot_url = release_asset_download_url(release, Snapshot.snapshot_filename())
     meta_url = release_asset_download_url(release, Snapshot.snapshot_meta_filename())
 
@@ -396,7 +471,7 @@ defmodule LLMDB.Snapshot.ReleaseStore do
         {:ok, nil}
 
       true ->
-        with {:ok, meta} <- fetch_json(meta_url),
+        with {:ok, meta} <- fetch_json(meta_url, overrides),
              snapshot_id when is_binary(snapshot_id) <- meta["snapshot_id"] do
           entry =
             meta
@@ -412,7 +487,7 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     end
   end
 
-  defp history_entry_from_release(release) do
+  defp history_entry_from_release(release, overrides) do
     archive_url = release_asset_download_url(release, Snapshot.history_archive_filename())
     meta_url = release_asset_download_url(release, Snapshot.history_meta_filename())
 
@@ -421,7 +496,7 @@ defmodule LLMDB.Snapshot.ReleaseStore do
         {:ok, nil}
 
       true ->
-        with {:ok, meta} <- fetch_json(meta_url),
+        with {:ok, meta} <- fetch_json(meta_url, overrides),
              snapshot_id when is_binary(snapshot_id) <- meta["to_snapshot_id"] do
           entry =
             meta
@@ -456,19 +531,30 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   defp release_published_at(%{published_at: published_at}), do: published_at
   defp release_published_at(_release), do: nil
 
-  @spec fetch_json(String.t()) :: {:ok, term()} | {:error, term()}
-  defp fetch_json(url) do
-    with {:ok, content} <- download(url),
-         {:ok, decoded} <- Jason.decode(content) do
-      {:ok, decoded}
+  @spec fetch_json(String.t(), keyword() | map()) :: {:ok, term()} | {:error, term()}
+  defp fetch_json(url, overrides) do
+    case download(url, overrides) do
+      {:ok, content} when is_binary(content) -> Jason.decode(content)
+      {:ok, decoded} when is_map(decoded) or is_list(decoded) -> {:ok, decoded}
+      {:ok, other} -> {:error, {:invalid_json_body, other}}
+      error -> error
     end
   end
 
-  @spec download(String.t()) :: {:ok, binary()} | {:error, term()}
-  defp download(url) do
+  defp decode_snapshot(content) when is_binary(content), do: Snapshot.decode(content)
+  defp decode_snapshot(content) when is_map(content), do: Snapshot.prepare(content)
+  defp decode_snapshot(content), do: {:error, {:invalid_snapshot_body, content}}
+
+  @spec download(String.t(), keyword() | map()) :: {:ok, term()} | {:error, term()}
+  defp download(url, overrides) do
     :ok = ensure_http_started()
 
-    case Req.get(url) do
+    req_opts =
+      overrides
+      |> request_options()
+      |> Keyword.put_new(:redirect_log_level, false)
+
+    case Req.get(url, req_opts) do
       {:ok, %{status: status, body: body}} when status in 200..299 -> {:ok, body}
       {:ok, %{status: 404}} -> {:error, :not_found}
       {:ok, %{status: status, body: body}} -> {:error, {:http_status, status, body}}
@@ -502,21 +588,36 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     end
   end
 
-  defp list_releases(repo) do
-    do_list_releases(repo, 1, [])
+  defp upsert_release(tag, repo, title, asset_paths) do
+    case run_gh(["release", "view", tag, "--repo", repo]) do
+      {:ok, _output} ->
+        args = ["release", "upload", tag] ++ asset_paths ++ ["--repo", repo, "--clobber"]
+
+        case run_gh(args) do
+          {:ok, _output} -> {:ok, tag}
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, _reason} ->
+        create_release(tag, repo, title, asset_paths)
+    end
   end
 
-  defp do_list_releases(repo, page, acc) when page <= @max_release_pages do
+  defp list_releases(repo, overrides) do
+    do_list_releases(repo, overrides, 1, [])
+  end
+
+  defp do_list_releases(repo, overrides, page, acc) do
     url = "https://api.github.com/repos/#{repo}/releases"
 
-    case api_get_json(url, params: [per_page: @release_page_size, page: page]) do
+    case api_get_json(url, [params: [per_page: @release_page_size, page: page]], overrides) do
       {:ok, releases} when is_list(releases) ->
         next_acc = acc ++ releases
 
         if length(releases) < @release_page_size do
           {:ok, next_acc}
         else
-          do_list_releases(repo, page + 1, next_acc)
+          do_list_releases(repo, overrides, page + 1, next_acc)
         end
 
       {:ok, other} ->
@@ -527,12 +628,10 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     end
   end
 
-  defp do_list_releases(_repo, _page, acc), do: {:ok, acc}
-
-  defp api_get_json(url, opts) do
+  defp api_get_json(url, opts, overrides) do
     :ok = ensure_http_started()
 
-    req_opts = api_request_options(opts)
+    req_opts = api_request_options(opts, overrides)
 
     case Req.get(url, req_opts) do
       {:ok, %{status: status, body: body}} when status in 200..299 -> {:ok, body}
@@ -542,7 +641,7 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     end
   end
 
-  defp api_request_options(opts) do
+  defp api_request_options(opts, overrides) do
     headers =
       [
         {"accept", "application/vnd.github+json"},
@@ -551,10 +650,31 @@ defmodule LLMDB.Snapshot.ReleaseStore do
       ]
       |> maybe_add_auth_header()
 
-    opts
+    overrides
+    |> request_options()
+    |> Keyword.merge(opts)
     |> Keyword.put(:headers, headers)
     |> Keyword.put_new(:decode_body, true)
+    |> Keyword.put_new(:redirect_log_level, false)
   end
+
+  defp request_options(overrides) do
+    override_map = override_map(overrides)
+
+    case Map.get(override_map, :req_opts, Map.get(override_map, "req_opts", [])) do
+      opts when is_list(opts) -> opts
+      _other -> []
+    end
+  end
+
+  defp put_override(overrides, key, value) do
+    overrides
+    |> override_map()
+    |> Map.put(key, value)
+  end
+
+  defp override_map(overrides) when is_map(overrides), do: overrides
+  defp override_map(overrides) when is_list(overrides), do: Enum.into(overrides, %{})
 
   defp maybe_add_auth_header(headers) do
     case System.get_env("GH_TOKEN") || System.get_env("GITHUB_TOKEN") do

--- a/lib/mix/tasks/llm_db.history.check.ex
+++ b/lib/mix/tasks/llm_db.history.check.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.LlmDb.History.Check do
   - `--allow-outdated` - Treat an older local history bundle as success (default: `false`)
   - `--output-dir` - History directory (default: `priv/llm_db/history`)
   - `--repo` - GitHub repository slug (default: `agentjido/llmdb`)
-  - `--index-tag` - Deprecated compatibility option; ignored for immutable release lookup
+  - `--index-tag` - Shared snapshot-store compatibility option
   - `--cache-dir` - Local snapshot cache directory
   """
 

--- a/lib/mix/tasks/llm_db.history.migrate_git.ex
+++ b/lib/mix/tasks/llm_db.history.migrate_git.ex
@@ -12,8 +12,7 @@ defmodule Mix.Tasks.LlmDb.History.MigrateGit do
 
   By default this writes local artifacts only. With `--publish`, it also seeds
   GitHub Releases with all discovered immutable snapshots and uploads a rebuilt
-  `history.tar.gz` bundle to the immutable history release for the latest
-  migrated snapshot.
+  compact catalog index and the mutable latest history bundle.
   """
 
   @impl Mix.Task
@@ -80,11 +79,14 @@ defmodule Mix.Tasks.LlmDb.History.MigrateGit do
 
       observations = read_snapshot_index!(summary.snapshot_index_path)
 
-      publish_snapshots!(observations, summary.snapshots_dir, store_overrides)
+      indexed_observations =
+        publish_snapshots!(observations, summary.snapshots_dir, store_overrides)
+
+      publish_snapshot_index!(summary, indexed_observations, store_overrides)
 
       publish_history_bundle!(
         summary.output_dir,
-        observations,
+        indexed_observations,
         opts[:bundle_output_dir],
         store_overrides
       )
@@ -92,26 +94,70 @@ defmodule Mix.Tasks.LlmDb.History.MigrateGit do
   end
 
   defp publish_snapshots!(observations, snapshots_dir, store_overrides) do
-    observations
-    |> Enum.map(& &1["snapshot_id"])
-    |> Enum.uniq()
-    |> Enum.each(fn snapshot_id ->
-      snapshot_path = Path.join([snapshots_dir, snapshot_id, Snapshot.snapshot_filename()])
-      meta_path = Path.join([snapshots_dir, snapshot_id, Snapshot.snapshot_meta_filename()])
-
-      case ReleaseStore.ensure_snapshot_release(
-             snapshot_path,
-             meta_path,
-             snapshot_id,
-             store_overrides
-           ) do
-        {:ok, _tag} ->
-          :ok
-
-        {:error, reason} ->
-          Mix.raise("Failed publishing snapshot #{snapshot_id}: #{inspect(reason)}")
+    existing_entries =
+      case ReleaseStore.fetch_snapshot_index(store_overrides) do
+        {:ok, entries} -> entries
+        {:error, :not_found} -> []
+        {:error, reason} -> Mix.raise("Failed fetching snapshot index: #{inspect(reason)}")
       end
+
+    entries_by_id = Map.new(existing_entries, &{&1["snapshot_id"], &1})
+
+    published_by_id =
+      observations
+      |> Enum.uniq_by(& &1["snapshot_id"])
+      |> Enum.reduce(entries_by_id, fn observation, acc ->
+        snapshot_id = observation["snapshot_id"]
+        snapshot_path = Path.join([snapshots_dir, snapshot_id, Snapshot.snapshot_filename()])
+        meta_path = Path.join([snapshots_dir, snapshot_id, Snapshot.snapshot_meta_filename()])
+
+        case ReleaseStore.ensure_snapshot_release(
+               snapshot_path,
+               meta_path,
+               snapshot_id,
+               Keyword.put(store_overrides, :snapshot_index, Map.values(acc))
+             ) do
+          {:ok, tag} ->
+            existing = Map.get(acc, snapshot_id, %{})
+
+            asset_entry = %{
+              "tag" => tag,
+              "published_at" =>
+                existing["published_at"] ||
+                  DateTime.utc_now() |> DateTime.to_iso8601(),
+              "snapshot_url" =>
+                ReleaseStore.asset_url(tag, Snapshot.snapshot_filename(), store_overrides),
+              "snapshot_meta_url" =>
+                ReleaseStore.asset_url(tag, Snapshot.snapshot_meta_filename(), store_overrides)
+            }
+
+            Map.put(acc, snapshot_id, asset_entry)
+
+          {:error, reason} ->
+            Mix.raise("Failed publishing snapshot #{snapshot_id}: #{inspect(reason)}")
+        end
+      end)
+
+    Enum.map(observations, fn observation ->
+      Map.merge(observation, Map.fetch!(published_by_id, observation["snapshot_id"]))
     end)
+  end
+
+  defp publish_snapshot_index!(summary, observations, store_overrides) do
+    Snapshot.write!(summary.snapshot_index_path, %{
+      "schema_version" => Snapshot.schema_version(),
+      "snapshots" => observations
+    })
+
+    Snapshot.write!(summary.latest_path, List.last(observations))
+
+    case ReleaseStore.publish_snapshot_index(
+           [summary.snapshot_index_path, summary.latest_path],
+           store_overrides
+         ) do
+      {:ok, _tag} -> :ok
+      {:error, reason} -> Mix.raise("Failed publishing snapshot index: #{inspect(reason)}")
+    end
   end
 
   defp publish_history_bundle!(history_dir, observations, bundle_output_dir, store_overrides) do

--- a/lib/mix/tasks/llm_db.history.rebuild.ex
+++ b/lib/mix/tasks/llm_db.history.rebuild.ex
@@ -8,9 +8,11 @@ defmodule Mix.Tasks.LlmDb.History.Rebuild do
 
   @moduledoc """
   Rebuilds local history artifacts from the published snapshot observation chain,
-  then bundles the result and optionally republishes `history.tar.gz` plus
-  `history-meta.json` to an immutable `history-<snapshot_id>` release for the
-  latest snapshot in the chain.
+  then bundles the result and optionally publishes `history.tar.gz` plus
+  `history-meta.json` to the mutable `history-latest` release.
+
+  By default, the task installs the latest published checkpoint and processes
+  only new snapshots. Use `--full` for an audit or repair rebuild.
   """
 
   @impl Mix.Task
@@ -23,6 +25,7 @@ defmodule Mix.Tasks.LlmDb.History.Rebuild do
           history_dir: :string,
           output_dir: :string,
           publish: :boolean,
+          full: :boolean,
           repo: :string,
           index_tag: :string,
           cache_dir: :string
@@ -40,6 +43,7 @@ defmodule Mix.Tasks.LlmDb.History.Rebuild do
       |> maybe_put(:cache_dir, opts[:cache_dir])
 
     history_dir = Bundle.history_dir(opts[:history_dir])
+    full? = opts[:full] == true
 
     observations =
       case ReleaseStore.fetch_snapshot_index(store_overrides) do
@@ -63,8 +67,21 @@ defmodule Mix.Tasks.LlmDb.History.Rebuild do
           Mix.raise("History rebuild failed: #{inspect(reason)}")
       end
 
+    unless full? do
+      install_published_checkpoint(history_dir, store_overrides)
+    end
+
+    indexed_store_overrides = Keyword.put(store_overrides, :snapshot_index, observations)
+    load_count = :atomics.new(1, signed: false)
+
     snapshot_loader = fn snapshot_id ->
-      case ReleaseStore.fetch_snapshot(snapshot_id, store_overrides) do
+      count = :atomics.add_get(load_count, 1, 1)
+
+      if count == 1 or rem(count, 10) == 0 do
+        Mix.shell().info("  processing snapshot #{count}: #{String.slice(snapshot_id, 0, 12)}")
+      end
+
+      case ReleaseStore.fetch_snapshot(snapshot_id, indexed_store_overrides) do
         {:ok, %{snapshot: snapshot}} -> {:ok, snapshot}
         {:error, reason} -> {:error, reason}
       end
@@ -75,45 +92,54 @@ defmodule Mix.Tasks.LlmDb.History.Rebuild do
              observations: observations,
              output_dir: history_dir,
              source: "github_releases",
+             mode: if(full?, do: :full, else: :auto),
              snapshot_loader: snapshot_loader
            ) do
-      bundle_opts =
-        []
-        |> Keyword.put(:history_dir, history_dir)
-        |> Keyword.put(:snapshot_index, observations)
-        |> maybe_put(:output_dir, opts[:output_dir])
+      if summary.snapshots_processed == 0 do
+        Mix.shell().info("✓ History is already current")
+        Mix.shell().info("  snapshots: #{summary.snapshots_written}")
+        Mix.shell().info("  events:    #{summary.events_written}")
+      else
+        bundle_opts =
+          []
+          |> Keyword.put(:history_dir, history_dir)
+          |> Keyword.put(:snapshot_index, observations)
+          |> maybe_put(:output_dir, opts[:output_dir])
 
-      case Bundle.bundle(bundle_opts) do
-        {:ok, bundle} ->
-          history_release_tag =
-            if opts[:publish] do
-              to_snapshot_id =
-                summary.to_snapshot_id ||
-                  raise "History rebuild failed: missing to_snapshot_id for publish"
+        case Bundle.bundle(bundle_opts) do
+          {:ok, bundle} ->
+            history_release_tag =
+              if opts[:publish] do
+                to_snapshot_id =
+                  summary.to_snapshot_id ||
+                    raise "History rebuild failed: missing to_snapshot_id for publish"
 
-              case ReleaseStore.publish_history_release(
-                     [bundle.archive_path, bundle.metadata_path],
-                     to_snapshot_id,
-                     store_overrides
-                   ) do
-                {:ok, tag} -> tag
-                {:error, reason} -> Mix.raise("History rebuild failed: #{inspect(reason)}")
+                case ReleaseStore.publish_history_release(
+                       [bundle.archive_path, bundle.metadata_path],
+                       to_snapshot_id,
+                       store_overrides
+                     ) do
+                  {:ok, tag} -> tag
+                  {:error, reason} -> Mix.raise("History rebuild failed: #{inspect(reason)}")
+                end
               end
+
+            Mix.shell().info("✓ History rebuilt")
+            Mix.shell().info("  history dir: #{summary.output_dir}")
+            Mix.shell().info("  archive:     #{bundle.archive_path}")
+            Mix.shell().info("  metadata:    #{bundle.metadata_path}")
+            Mix.shell().info("  snapshots:   #{summary.snapshots_written}")
+            Mix.shell().info("  processed:   #{summary.snapshots_processed} (#{summary.mode})")
+            Mix.shell().info("  events:      #{summary.events_written}")
+            Mix.shell().info("  events added: #{summary.events_added}")
+
+            if opts[:publish] do
+              Mix.shell().info("  published history release: #{history_release_tag}")
             end
 
-          Mix.shell().info("✓ History rebuilt")
-          Mix.shell().info("  history dir: #{summary.output_dir}")
-          Mix.shell().info("  archive:     #{bundle.archive_path}")
-          Mix.shell().info("  metadata:    #{bundle.metadata_path}")
-          Mix.shell().info("  snapshots:   #{summary.snapshots_written}")
-          Mix.shell().info("  events:      #{summary.events_written}")
-
-          if opts[:publish] do
-            Mix.shell().info("  published history release: #{history_release_tag}")
-          end
-
-        {:error, reason} ->
-          Mix.raise("History rebuild failed: #{inspect(reason)}")
+          {:error, reason} ->
+            Mix.raise("History rebuild failed: #{inspect(reason)}")
+        end
       end
     else
       {:error, reason} ->
@@ -123,6 +149,31 @@ defmodule Mix.Tasks.LlmDb.History.Rebuild do
 
   defp maybe_put(opts, _key, nil), do: opts
   defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp install_published_checkpoint(history_dir, store_overrides) do
+    archive_path =
+      Path.join(
+        System.tmp_dir!(),
+        "llm_db-history-checkpoint-#{System.unique_integer([:positive])}.tar.gz"
+      )
+
+    case ReleaseStore.download_history_archive(archive_path, store_overrides) do
+      :ok ->
+        case Bundle.install_archive(archive_path, history_dir) do
+          :ok -> Mix.shell().info("✓ Installed latest history checkpoint")
+          {:error, reason} -> Mix.raise("History checkpoint install failed: #{inspect(reason)}")
+        end
+
+      {:error, :not_found} ->
+        Mix.shell().info("No published history checkpoint found; using a full rebuild")
+
+      {:error, reason} ->
+        Mix.raise("History checkpoint download failed: #{inspect(reason)}")
+    end
+
+    File.rm(archive_path)
+    :ok
+  end
 
   defp ensure_llm_db_project! do
     app = Mix.Project.config()[:app]

--- a/lib/mix/tasks/llm_db.history.sync.ex
+++ b/lib/mix/tasks/llm_db.history.sync.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.LlmDb.History.Sync do
 
   - `--output-dir` - Directory for generated history files (default: `priv/llm_db/history`)
   - `--repo` - GitHub repository slug (default: `agentjido/llmdb`)
-  - `--index-tag` - Deprecated compatibility option; ignored for immutable release lookup
+  - `--index-tag` - Shared snapshot-store compatibility option
   - `--cache-dir` - Local snapshot cache directory
   """
 

--- a/lib/mix/tasks/llm_db.snapshot.publish.ex
+++ b/lib/mix/tasks/llm_db.snapshot.publish.ex
@@ -9,9 +9,8 @@ defmodule Mix.Tasks.LlmDb.Snapshot.Publish do
   Builds and publishes a canonical snapshot to GitHub Releases.
 
   This creates or repairs the immutable snapshot release for the current
-  `snapshot_id`. Local `latest.json` and `snapshot-index.json` outputs are still
-  written for inspection, but the canonical remote index is derived from the
-  published snapshot releases themselves.
+  `snapshot_id`. It also publishes `latest.json` and `snapshot-index.json` to
+  the mutable compact catalog-index release.
   """
 
   @impl Mix.Task
@@ -43,7 +42,8 @@ defmodule Mix.Tasks.LlmDb.Snapshot.Publish do
     existing_snapshots =
       case ReleaseStore.fetch_snapshot_index(store_overrides) do
         {:ok, snapshots} -> snapshots
-        _ -> []
+        {:error, :not_found} -> []
+        {:error, reason} -> Mix.raise("Snapshot index fetch failed: #{inspect(reason)}")
       end
 
     latest_entry = List.last(existing_snapshots)
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.LlmDb.Snapshot.Publish do
           artifact.snapshot_path,
           artifact.metadata_path,
           artifact.snapshot_id,
-          store_overrides
+          Keyword.put(store_overrides, :snapshot_index, existing_snapshots)
         )
 
       published_at = DateTime.utc_now() |> DateTime.to_iso8601()
@@ -109,8 +109,12 @@ defmodule Mix.Tasks.LlmDb.Snapshot.Publish do
         "snapshots" => snapshots
       })
 
+      {:ok, index_tag} =
+        ReleaseStore.publish_snapshot_index([index_path, latest_path], store_overrides)
+
       Mix.shell().info("✓ Snapshot #{artifact.snapshot_id} published")
       Mix.shell().info("  snapshot release: #{snapshot_tag}")
+      Mix.shell().info("  catalog index:    #{index_tag}")
       Mix.shell().info("  latest index:     #{latest_path}")
       Mix.shell().info("  snapshot index:   #{index_path}")
     else

--- a/test/llm_db/history/bundle_test.exs
+++ b/test/llm_db/history/bundle_test.exs
@@ -1,0 +1,57 @@
+defmodule LLMDB.History.BundleTest do
+  use ExUnit.Case, async: true
+
+  alias LLMDB.{History.Bundle, Snapshot}
+
+  test "installs a checkpoint without stale generated files" do
+    source_dir = temp_dir("llm_db_bundle_source")
+    destination_dir = temp_dir("llm_db_bundle_destination")
+    bundle_dir = temp_dir("llm_db_bundle_output")
+
+    write_file(source_dir, "events/2026.ndjson", ~s({"event_id":"new"}\n))
+    write_file(source_dir, "snapshots.ndjson", ~s({"snapshot_id":"new"}\n))
+    write_json(source_dir, "meta.json", %{"to_snapshot_id" => "new", "event_count" => 1})
+    write_json(source_dir, Snapshot.history_state_filename(), %{"to_snapshot_id" => "new"})
+    write_json(source_dir, Snapshot.snapshot_index_filename(), %{"snapshots" => []})
+    write_json(source_dir, Snapshot.latest_filename(), %{"snapshot_id" => "new"})
+
+    write_file(destination_dir, "events/2025.ndjson", ~s({"event_id":"stale"}\n))
+    write_json(destination_dir, Snapshot.history_state_filename(), %{"to_snapshot_id" => "old"})
+    write_json(destination_dir, "lineage_overrides.json", %{"lineage" => %{}})
+
+    assert {:ok, bundle} =
+             Bundle.bundle(history_dir: source_dir, output_dir: bundle_dir)
+
+    assert :ok = Bundle.install_archive(bundle.archive_path, destination_dir)
+
+    refute File.exists?(Path.join(destination_dir, "events/2025.ndjson"))
+    assert File.exists?(Path.join(destination_dir, "events/2026.ndjson"))
+
+    assert read_json(destination_dir, Snapshot.history_state_filename())["to_snapshot_id"] ==
+             "new"
+
+    assert File.exists?(Path.join(destination_dir, "lineage_overrides.json"))
+  end
+
+  defp write_json(dir, path, value), do: write_file(dir, path, Jason.encode!(value))
+
+  defp write_file(dir, path, value) do
+    full_path = Path.join(dir, path)
+    File.mkdir_p!(Path.dirname(full_path))
+    File.write!(full_path, value)
+  end
+
+  defp read_json(dir, path) do
+    dir
+    |> Path.join(path)
+    |> File.read!()
+    |> Jason.decode!()
+  end
+
+  defp temp_dir(prefix) do
+    path = Path.join(System.tmp_dir!(), "#{prefix}_#{System.unique_integer([:positive])}")
+    File.rm_rf!(path)
+    File.mkdir_p!(path)
+    path
+  end
+end

--- a/test/llm_db/history/bundle_test.exs
+++ b/test/llm_db/history/bundle_test.exs
@@ -16,6 +16,7 @@ defmodule LLMDB.History.BundleTest do
     write_json(source_dir, Snapshot.latest_filename(), %{"snapshot_id" => "new"})
 
     write_file(destination_dir, "events/2025.ndjson", ~s({"event_id":"stale"}\n))
+    write_file(destination_dir, ".incremental-transaction/manifest.json", "stale")
     write_json(destination_dir, Snapshot.history_state_filename(), %{"to_snapshot_id" => "old"})
     write_json(destination_dir, "lineage_overrides.json", %{"lineage" => %{}})
 
@@ -25,6 +26,7 @@ defmodule LLMDB.History.BundleTest do
     assert :ok = Bundle.install_archive(bundle.archive_path, destination_dir)
 
     refute File.exists?(Path.join(destination_dir, "events/2025.ndjson"))
+    refute File.exists?(Path.join(destination_dir, ".incremental-transaction"))
     assert File.exists?(Path.join(destination_dir, "events/2026.ndjson"))
 
     assert read_json(destination_dir, Snapshot.history_state_filename())["to_snapshot_id"] ==

--- a/test/llm_db/history/rebuilder_test.exs
+++ b/test/llm_db/history/rebuilder_test.exs
@@ -200,6 +200,65 @@ defmodule LLMDB.History.RebuilderTest do
     assert_receive {:loaded, _snapshot_id}
   end
 
+  test "rolls back an interrupted incremental append before retry" do
+    history_dir = temp_dir("llm_db_history_interrupted")
+    full_dir = temp_dir("llm_db_history_interrupted_full")
+    snapshot_a = model_snapshot("gpt-test", "First")
+    snapshot_b = model_snapshot("gpt-test", "Second")
+    snapshots = Map.new([snapshot_a, snapshot_b], &{&1["snapshot_id"], &1})
+
+    observations = [
+      observation(snapshot_a, "2026-01-01T00:00:00Z"),
+      observation(snapshot_b, "2026-01-02T00:00:00Z")
+    ]
+
+    assert {:ok, _summary} =
+             Rebuilder.rebuild(
+               observations: Enum.take(observations, 1),
+               output_dir: history_dir,
+               snapshot_loader: &Map.fetch(snapshots, &1)
+             )
+
+    assert_raise RuntimeError, "simulated interruption", fn ->
+      Rebuilder.rebuild(
+        observations: observations,
+        output_dir: history_dir,
+        incremental_commit_hook: fn -> raise "simulated interruption" end,
+        snapshot_loader: &Map.fetch(snapshots, &1)
+      )
+    end
+
+    assert {:ok, retry_summary} =
+             Rebuilder.rebuild(
+               observations: observations,
+               output_dir: history_dir,
+               snapshot_loader: &Map.fetch(snapshots, &1)
+             )
+
+    assert retry_summary.mode == :incremental
+    assert retry_summary.snapshots_processed == 1
+
+    assert {:ok, _summary} =
+             Rebuilder.rebuild(
+               observations: observations,
+               output_dir: full_dir,
+               mode: :full,
+               snapshot_loader: &Map.fetch(snapshots, &1)
+             )
+
+    for path <- [
+          "snapshots.ndjson",
+          "events/2026.ndjson",
+          Snapshot.snapshot_index_filename(),
+          Snapshot.latest_filename(),
+          Snapshot.history_state_filename()
+        ] do
+      assert File.read!(Path.join(history_dir, path)) == File.read!(Path.join(full_dir, path))
+    end
+
+    refute File.exists?(Path.join(history_dir, ".incremental-transaction"))
+  end
+
   defp snapshot(providers) do
     document = %{
       "schema_version" => Snapshot.schema_version(),

--- a/test/llm_db/history/rebuilder_test.exs
+++ b/test/llm_db/history/rebuilder_test.exs
@@ -82,6 +82,9 @@ defmodule LLMDB.History.RebuilderTest do
     assert summary.to_snapshot_id == snapshot_b["snapshot_id"]
     assert summary.snapshots_written == 2
     assert summary.events_written == 3
+    assert summary.mode == :full
+    assert summary.snapshots_processed == 2
+    assert File.exists?(Path.join(history_dir, Snapshot.history_state_filename()))
 
     Application.put_env(:llm_db, :history_dir, history_dir)
     clear_history_cache()
@@ -96,6 +99,107 @@ defmodule LLMDB.History.RebuilderTest do
            ]
   end
 
+  test "incremental rebuild loads only new snapshots and matches a full rebuild" do
+    history_dir = temp_dir("llm_db_history_incremental")
+    full_dir = temp_dir("llm_db_history_full")
+
+    snapshot_a = model_snapshot("gpt-test", "First")
+    snapshot_b = model_snapshot("gpt-test", "Second")
+    snapshot_c = model_snapshot("gpt-test", "Third")
+
+    observations = [
+      observation(snapshot_a, "2026-01-01T00:00:00Z"),
+      observation(snapshot_b, "2026-01-02T00:00:00Z"),
+      observation(snapshot_c, "2026-01-03T00:00:00Z")
+    ]
+
+    snapshots =
+      Map.new([snapshot_a, snapshot_b, snapshot_c], fn snapshot ->
+        {snapshot["snapshot_id"], snapshot}
+      end)
+
+    assert {:ok, initial_summary} =
+             Rebuilder.rebuild(
+               observations: Enum.take(observations, 2),
+               output_dir: history_dir,
+               source: "test",
+               snapshot_loader: &Map.fetch(snapshots, &1)
+             )
+
+    assert initial_summary.mode == :full
+
+    test_pid = self()
+
+    assert {:ok, incremental_summary} =
+             Rebuilder.rebuild(
+               observations: observations,
+               output_dir: history_dir,
+               source: "test",
+               snapshot_loader: fn snapshot_id ->
+                 send(test_pid, {:loaded, snapshot_id})
+                 Map.fetch(snapshots, snapshot_id)
+               end
+             )
+
+    assert incremental_summary.mode == :incremental
+    assert incremental_summary.snapshots_processed == 1
+    assert incremental_summary.events_added == 1
+    snapshot_c_id = snapshot_c["snapshot_id"]
+    assert_receive {:loaded, ^snapshot_c_id}
+    refute_receive {:loaded, _snapshot_id}
+
+    assert {:ok, full_summary} =
+             Rebuilder.rebuild(
+               observations: observations,
+               output_dir: full_dir,
+               source: "test",
+               mode: :full,
+               snapshot_loader: &Map.fetch(snapshots, &1)
+             )
+
+    assert full_summary.events_written == incremental_summary.events_written
+
+    for path <- [
+          "snapshots.ndjson",
+          "events/2026.ndjson",
+          Snapshot.snapshot_index_filename(),
+          Snapshot.latest_filename(),
+          Snapshot.history_state_filename()
+        ] do
+      assert File.read!(Path.join(history_dir, path)) == File.read!(Path.join(full_dir, path))
+    end
+  end
+
+  test "missing checkpoint state uses the full migration path" do
+    history_dir = temp_dir("llm_db_history_missing_state")
+    snapshot = model_snapshot("gpt-test", "First")
+    observations = [observation(snapshot, "2026-01-01T00:00:00Z")]
+
+    assert {:ok, _summary} =
+             Rebuilder.rebuild(
+               observations: observations,
+               output_dir: history_dir,
+               snapshot_loader: fn _snapshot_id -> {:ok, snapshot} end
+             )
+
+    File.rm!(Path.join(history_dir, Snapshot.history_state_filename()))
+    test_pid = self()
+
+    assert {:ok, summary} =
+             Rebuilder.rebuild(
+               observations: observations,
+               output_dir: history_dir,
+               snapshot_loader: fn snapshot_id ->
+                 send(test_pid, {:loaded, snapshot_id})
+                 {:ok, snapshot}
+               end
+             )
+
+    assert summary.mode == :full
+    assert summary.snapshots_processed == 1
+    assert_receive {:loaded, _snapshot_id}
+  end
+
   defp snapshot(providers) do
     document = %{
       "schema_version" => Snapshot.schema_version(),
@@ -105,6 +209,28 @@ defmodule LLMDB.History.RebuilderTest do
     }
 
     Map.put(document, "snapshot_id", Snapshot.snapshot_id(document))
+  end
+
+  defp model_snapshot(model_id, name) do
+    snapshot(%{
+      "openai" => %{
+        "id" => "openai",
+        "models" => %{
+          model_id => %{
+            "id" => model_id,
+            "provider" => "openai",
+            "name" => name
+          }
+        }
+      }
+    })
+  end
+
+  defp observation(snapshot, captured_at) do
+    %{
+      "snapshot_id" => snapshot["snapshot_id"],
+      "captured_at" => captured_at
+    }
   end
 
   defp write_snapshot(base_dir, snapshot) do

--- a/test/llm_db/snapshot/release_store_test.exs
+++ b/test/llm_db/snapshot/release_store_test.exs
@@ -46,7 +46,11 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     log = File.read!(log_path)
     assert log =~ "release create #{snapshot_tag} #{snapshot_path} #{snapshot_meta_path}"
     assert log =~ "release view history-latest"
-    assert log =~ "release create history-latest #{history_archive_path} #{history_meta_path}"
+    assert log =~ "release create history-latest --repo agentjido/llmdb"
+    assert log =~ "release upload history-latest"
+    assert log =~ "history-meta-"
+    assert log =~ ".tar.gz"
+    refute log =~ "--clobber"
   end
 
   test "reuses already indexed snapshot and history releases" do
@@ -102,7 +106,7 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     log = File.read!(log_path)
     assert log =~ "release view history-latest"
     assert log =~ "release upload history-latest"
-    assert log =~ "--clobber"
+    refute log =~ "--clobber"
     refute log =~ "release create"
   end
 
@@ -143,7 +147,7 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     refute log =~ "release upload"
   end
 
-  test "loads more than one thousand snapshots from the compact index in one request" do
+  test "loads more than one thousand snapshots from one compact index asset" do
     snapshots =
       Enum.map(1..1_001, fn index ->
         %{
@@ -157,20 +161,26 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     plug = fn conn ->
       send(test_pid, {:request, conn.request_path})
 
-      conn
-      |> Plug.Conn.put_resp_content_type("application/octet-stream")
-      |> Plug.Conn.send_resp(
-        200,
-        Jason.encode!(%{"schema_version" => 1, "snapshots" => snapshots})
-      )
+      case conn.request_path do
+        "/repos/agentjido/llmdb/releases/tags/catalog-index" ->
+          Req.Test.json(conn, versioned_release("catalog-index", "0001"))
+
+        "/catalog/snapshot-index-0001.json" ->
+          conn
+          |> Plug.Conn.put_resp_content_type("application/octet-stream")
+          |> Plug.Conn.send_resp(
+            200,
+            Jason.encode!(%{"schema_version" => 1, "snapshots" => snapshots})
+          )
+      end
     end
 
     assert {:ok, loaded} = ReleaseStore.fetch_snapshot_index(req_opts: [plug: plug])
     assert length(loaded) == 1_001
     assert List.last(loaded)["snapshot_id"] == "snapshot-1001"
 
-    assert_receive {:request,
-                    "/agentjido/llmdb/releases/download/catalog-index/snapshot-index.json"}
+    assert_receive {:request, "/repos/agentjido/llmdb/releases/tags/catalog-index"}
+    assert_receive {:request, "/catalog/snapshot-index-0001.json"}
 
     refute_receive {:request, _path}
   end
@@ -184,7 +194,10 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
       send(test_pid, {:request, conn.request_path})
 
       case conn.request_path do
-        "/agentjido/llmdb/releases/download/catalog-index/snapshot-index.json" ->
+        "/repos/agentjido/llmdb/releases/tags/catalog-index" ->
+          Req.Test.json(conn, versioned_release("catalog-index", "0001"))
+
+        "/catalog/snapshot-index-0001.json" ->
           conn
           |> Plug.Conn.put_resp_content_type("application/octet-stream")
           |> Plug.Conn.send_resp(
@@ -212,11 +225,118 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     assert {:ok, %{snapshot_id: ^snapshot_id}} =
              ReleaseStore.fetch_snapshot(:latest, cache_dir: cache_dir, req_opts: [plug: plug])
 
-    assert_receive {:request,
-                    "/agentjido/llmdb/releases/download/catalog-index/snapshot-index.json"}
+    assert_receive {:request, "/repos/agentjido/llmdb/releases/tags/catalog-index"}
+    assert_receive {:request, "/catalog/snapshot-index-0001.json"}
 
     assert_receive {:request, "/snapshot.json"}
     refute_receive {:request, _path}
+  end
+
+  test "ignores a newer incomplete catalog asset generation" do
+    test_pid = self()
+
+    plug = fn conn ->
+      send(test_pid, {:request, conn.request_path})
+
+      case conn.request_path do
+        "/repos/agentjido/llmdb/releases/tags/catalog-index" ->
+          release =
+            versioned_release("catalog-index", "0001")
+            |> update_in(["assets"], fn assets ->
+              [
+                %{
+                  "name" => "snapshot-index-0002.json",
+                  "browser_download_url" =>
+                    "https://example.test/catalog/snapshot-index-0002.json"
+                }
+                | assets
+              ]
+            end)
+
+          Req.Test.json(conn, release)
+
+        "/catalog/snapshot-index-0001.json" ->
+          Req.Test.json(conn, %{"schema_version" => 1, "snapshots" => []})
+      end
+    end
+
+    assert {:ok, []} = ReleaseStore.fetch_snapshot_index(req_opts: [plug: plug])
+    assert_receive {:request, "/catalog/snapshot-index-0001.json"}
+    refute_receive {:request, "/catalog/snapshot-index-0002.json"}
+  end
+
+  test "keeps existing release assets when a replacement upload fails" do
+    tmp_dir = tmp_dir("release_store_upload_failure")
+    bin_dir = Path.join(tmp_dir, "bin")
+    assets_dir = Path.join(tmp_dir, "assets")
+    log_path = Path.join(tmp_dir, "gh.log")
+    script_path = Path.join(bin_dir, "gh")
+    original_path = System.get_env("PATH")
+
+    {_snapshot_path, _snapshot_meta_path, history_archive_path, history_meta_path} =
+      write_assets!(assets_dir)
+
+    File.mkdir_p!(bin_dir)
+    File.write!(script_path, gh_script(log_path, "history-latest", fail_upload: true))
+    File.chmod!(script_path, 0o755)
+    File.write!(log_path, "")
+    System.put_env("PATH", "#{bin_dir}:#{original_path}")
+
+    on_exit(fn -> System.put_env("PATH", original_path) end)
+
+    assert {:error, "upload failed"} =
+             ReleaseStore.publish_history_release(
+               [history_archive_path, history_meta_path],
+               "abc"
+             )
+
+    log = File.read!(log_path)
+    assert log =~ "release upload history-latest"
+    refute log =~ "--clobber"
+    refute log =~ "delete-asset"
+  end
+
+  test "retains the two latest complete release asset generations" do
+    tmp_dir = tmp_dir("release_store_retention")
+    bin_dir = Path.join(tmp_dir, "bin")
+    assets_dir = Path.join(tmp_dir, "assets")
+    log_path = Path.join(tmp_dir, "gh.log")
+    script_path = Path.join(bin_dir, "gh")
+    original_path = System.get_env("PATH")
+
+    {_snapshot_path, _snapshot_meta_path, history_archive_path, history_meta_path} =
+      write_assets!(assets_dir)
+
+    old_assets =
+      for generation <- ["0001", "0002", "0003"],
+          name <- ["history-#{generation}.tar.gz", "history-meta-#{generation}.json"] do
+        name
+      end
+
+    File.mkdir_p!(bin_dir)
+
+    File.write!(
+      script_path,
+      gh_script(log_path, "history-latest", release_assets: old_assets)
+    )
+
+    File.chmod!(script_path, 0o755)
+    File.write!(log_path, "")
+    System.put_env("PATH", "#{bin_dir}:#{original_path}")
+
+    on_exit(fn -> System.put_env("PATH", original_path) end)
+
+    assert {:ok, "history-latest"} =
+             ReleaseStore.publish_history_release(
+               [history_archive_path, history_meta_path],
+               "abc"
+             )
+
+    log = File.read!(log_path)
+    assert log =~ "delete-asset history-latest history-0001.tar.gz"
+    assert log =~ "delete-asset history-latest history-meta-0001.json"
+    refute log =~ "delete-asset history-latest history-0002"
+    refute log =~ "delete-asset history-latest history-0003"
   end
 
   defp write_assets!(assets_dir) do
@@ -235,11 +355,24 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     {snapshot_path, snapshot_meta_path, history_archive_path, history_meta_path}
   end
 
-  defp gh_script(log_path, existing_tag \\ nil) do
+  defp gh_script(log_path, existing_tag \\ nil, opts \\ []) do
+    fail_upload? = Keyword.get(opts, :fail_upload, false)
+
+    release_assets =
+      opts
+      |> Keyword.get(:release_assets, [])
+      |> Enum.map(&%{"name" => &1})
+      |> then(&Jason.encode!(%{"assets" => &1}))
+
     """
     #!/bin/sh
     set -eu
     printf '%s\\n' "$*" >> "#{log_path}"
+
+    if [ "$1" = "release" ] && [ "$2" = "view" ] && [ "${7:-}" = "assets" ]; then
+      printf '%s\\n' '#{release_assets}'
+      exit 0
+    fi
 
     if [ "$1" = "release" ] && [ "$2" = "view" ] && [ "$3" = "#{existing_tag}" ]; then
       exit 0
@@ -251,12 +384,37 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     fi
 
     if [ "$1" = "release" ] && [ "$2" = "upload" ]; then
+      if [ "#{fail_upload?}" = "true" ]; then
+        echo "upload failed" >&2
+        exit 1
+      fi
+      exit 0
+    fi
+
+    if [ "$1" = "release" ] && [ "$2" = "delete-asset" ]; then
       exit 0
     fi
 
     echo "unexpected command: $*" >&2
     exit 1
     """
+  end
+
+  defp versioned_release(tag, generation) do
+    %{
+      "tag_name" => tag,
+      "assets" => [
+        %{
+          "name" => "snapshot-index-#{generation}.json",
+          "browser_download_url" =>
+            "https://example.test/catalog/snapshot-index-#{generation}.json"
+        },
+        %{
+          "name" => "latest-#{generation}.json",
+          "browser_download_url" => "https://example.test/catalog/latest-#{generation}.json"
+        }
+      ]
+    }
   end
 
   defp valid_snapshot do

--- a/test/llm_db/snapshot/release_store_test.exs
+++ b/test/llm_db/snapshot/release_store_test.exs
@@ -41,11 +41,12 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
                history_entries: []
              )
 
-    assert history_tag =~ ~r/^history-abc-\d+-\d+$/
+    assert history_tag == "history-latest"
 
     log = File.read!(log_path)
     assert log =~ "release create #{snapshot_tag} #{snapshot_path} #{snapshot_meta_path}"
-    assert log =~ "release create #{history_tag} #{history_archive_path} #{history_meta_path}"
+    assert log =~ "release view history-latest"
+    assert log =~ "release create history-latest #{history_archive_path} #{history_meta_path}"
   end
 
   test "reuses already indexed snapshot and history releases" do
@@ -60,7 +61,7 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
       write_assets!(assets_dir)
 
     File.mkdir_p!(bin_dir)
-    File.write!(script_path, gh_script(log_path))
+    File.write!(script_path, gh_script(log_path, "history-latest"))
     File.chmod!(script_path, 0o755)
     File.write!(log_path, "")
     System.put_env("PATH", "#{bin_dir}:#{original_path}")
@@ -91,14 +92,18 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
                snapshot_index: [existing_snapshot_entry]
              )
 
-    assert {:ok, "history-abc-existing"} =
+    assert {:ok, "history-latest"} =
              ReleaseStore.publish_history_release(
                [history_archive_path, history_meta_path],
                "abc",
                history_entries: [existing_history_entry]
              )
 
-    assert File.read!(log_path) == ""
+    log = File.read!(log_path)
+    assert log =~ "release view history-latest"
+    assert log =~ "release upload history-latest"
+    assert log =~ "--clobber"
+    refute log =~ "release create"
   end
 
   test "creates a fresh unique snapshot release when only broken historical tags exist" do
@@ -138,6 +143,82 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     refute log =~ "release upload"
   end
 
+  test "loads more than one thousand snapshots from the compact index in one request" do
+    snapshots =
+      Enum.map(1..1_001, fn index ->
+        %{
+          "snapshot_id" => "snapshot-#{index}",
+          "snapshot_url" => "https://example.test/snapshot-#{index}.json"
+        }
+      end)
+
+    test_pid = self()
+
+    plug = fn conn ->
+      send(test_pid, {:request, conn.request_path})
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/octet-stream")
+      |> Plug.Conn.send_resp(
+        200,
+        Jason.encode!(%{"schema_version" => 1, "snapshots" => snapshots})
+      )
+    end
+
+    assert {:ok, loaded} = ReleaseStore.fetch_snapshot_index(req_opts: [plug: plug])
+    assert length(loaded) == 1_001
+    assert List.last(loaded)["snapshot_id"] == "snapshot-1001"
+
+    assert_receive {:request,
+                    "/agentjido/llmdb/releases/download/catalog-index/snapshot-index.json"}
+
+    refute_receive {:request, _path}
+  end
+
+  test "fetches the compact index once and the latest snapshot once" do
+    snapshot = valid_snapshot()
+    snapshot_id = snapshot["snapshot_id"]
+    test_pid = self()
+
+    plug = fn conn ->
+      send(test_pid, {:request, conn.request_path})
+
+      case conn.request_path do
+        "/agentjido/llmdb/releases/download/catalog-index/snapshot-index.json" ->
+          conn
+          |> Plug.Conn.put_resp_content_type("application/octet-stream")
+          |> Plug.Conn.send_resp(
+            200,
+            Jason.encode!(%{
+              "schema_version" => 1,
+              "snapshots" => [
+                %{
+                  "snapshot_id" => snapshot_id,
+                  "snapshot_url" => "https://example.test/snapshot.json"
+                }
+              ]
+            })
+          )
+
+        "/snapshot.json" ->
+          conn
+          |> Plug.Conn.put_resp_content_type("application/octet-stream")
+          |> Plug.Conn.send_resp(200, Jason.encode!(snapshot))
+      end
+    end
+
+    cache_dir = tmp_dir("release_store_fetch")
+
+    assert {:ok, %{snapshot_id: ^snapshot_id}} =
+             ReleaseStore.fetch_snapshot(:latest, cache_dir: cache_dir, req_opts: [plug: plug])
+
+    assert_receive {:request,
+                    "/agentjido/llmdb/releases/download/catalog-index/snapshot-index.json"}
+
+    assert_receive {:request, "/snapshot.json"}
+    refute_receive {:request, _path}
+  end
+
   defp write_assets!(assets_dir) do
     File.mkdir_p!(assets_dir)
 
@@ -154,20 +235,39 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     {snapshot_path, snapshot_meta_path, history_archive_path, history_meta_path}
   end
 
-  defp gh_script(log_path) do
+  defp gh_script(log_path, existing_tag \\ nil) do
     """
     #!/bin/sh
     set -eu
     printf '%s\\n' "$*" >> "#{log_path}"
+
+    if [ "$1" = "release" ] && [ "$2" = "view" ] && [ "$3" = "#{existing_tag}" ]; then
+      exit 0
+    fi
 
     if [ "$1" = "release" ] && [ "$2" = "create" ]; then
       echo "https://github.com/agentjido/llmdb/releases/tag/$3"
       exit 0
     fi
 
+    if [ "$1" = "release" ] && [ "$2" = "upload" ]; then
+      exit 0
+    fi
+
     echo "unexpected command: $*" >&2
     exit 1
     """
+  end
+
+  defp valid_snapshot do
+    snapshot = %{
+      "schema_version" => 1,
+      "version" => 2,
+      "generated_at" => "2026-08-17T00:00:00Z",
+      "providers" => %{}
+    }
+
+    Map.put(snapshot, "snapshot_id", LLMDB.Snapshot.snapshot_id(snapshot))
   end
 
   defp tmp_dir(prefix) do


### PR DESCRIPTION
## Description

- publish one compact `catalog-index` instead of scanning release pages on normal runs
- rebuild history from checkpoint state and only new snapshots, with `--full` for repair
- replace per-snapshot full history releases with one mutable `history-latest` checkpoint
- keep release-scan and legacy history bundle fallbacks for migration
- suppress signed redirect logs and add request-count, equivalence, and migration tests

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None. Existing immutable snapshot and history releases remain readable. The first run creates the compact index and checkpoint; later runs use the incremental path.

## Testing

- [x] Tests pass (`mix test`) — 902 passed
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md`
- [x] I have **NOT** directly edited generated snapshot/history artifacts

## Related Issues

Closes #305